### PR TITLE
fix(slots form): restore slot title placeholder hint

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/page.tsx
@@ -168,6 +168,7 @@ export default async function SignupDetailPage({ params }: PageParams) {
               type="text"
               name="title"
               required
+              placeholder="e.g., Week 1 snack"
               className="focus:border-brand focus:ring-brand w-full rounded-lg border border-surface-sunk px-3 py-2 focus:outline-none focus:ring-1"
             />
           </label>


### PR DESCRIPTION
## Summary
- Re-add the `placeholder="e.g., Week 1 snack"` hint to the slot title input on the signup detail page.
- This was lost when the form was reworked to use visible field labels; the hint is still useful as in-input prompt copy.

## Test plan
- [ ] `pnpm lint && pnpm typecheck && pnpm test` (run locally — all green)
- [ ] Visit `/app/signups/[id]`, confirm "Slot title" input shows the placeholder when empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)