### PR TITLE
feat(admin): use clipboard icon button for share URL copy

### DIFF
--- a/src/components/CopyLinkField.tsx
+++ b/src/components/CopyLinkField.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
 
 interface CopyLinkFieldProps {
   url: string;
@@ -45,10 +46,21 @@ export default function CopyLinkField({ url }: CopyLinkFieldProps) {
       <button
         type="button"
         onClick={handleCopy}
-        className="text-brand shrink-0 underline transition hover:no-underline"
+        aria-label={copied ? 'Link copied' : 'Copy link'}
+        title="Copy link"
+        className={`inline-flex size-8 shrink-0 items-center justify-center rounded-lg transition hover:text-ink ${
+          copied ? 'text-success' : 'text-ink-muted'
+        }`}
       >
-        {copied ? 'Copied!' : 'Copy'}
+        {copied ? (
+          <Check size={16} aria-hidden="true" />
+        ) : (
+          <Copy size={16} aria-hidden="true" />
+        )}
       </button>
+      <span className="sr-only" aria-live="polite">
+        {copied ? 'Link copied' : ''}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the inline "Copy" text link on the signup detail page with a small tertiary icon button (Lucide `Copy` -> `Check` on success), per the OpenSignup design system.
- Adds an `sr-only` `aria-live="polite"` region so the copied state is still announced to screen readers.
- Lets the global `:focus-visible` outline rule own the focus styling — no custom ring.

## Test plan
- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass.
- [ ] Open `/app/signups/<id>` and confirm a single icon button (no "Copy" text) sits next to the URL.
- [ ] Click the icon — clipboard receives the URL, icon flips to a green `Check` for ~1.5s, then back.
- [ ] Tab to the button — global blue focus outline shows.
- [ ] With a screen reader, activating the button announces "Link copied".
- [ ] On a narrow viewport, the URL truncates and the icon stays on the same row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)