### PR TITLE
feat(admin): restore close-signup button to detail header

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/layout.tsx
+++ b/src/app/app/(chrome)/signups/[id]/layout.tsx
@@ -7,7 +7,7 @@ import { countCommitmentsForSignup } from '@/services/commitments';
 import { publicSignupUrl } from '@/lib/links';
 import { SignupHeader } from '@/components/signup/SignupHeader';
 import { TabsNav } from '@/components/signup/TabsNav';
-import { publishAction } from './actions';
+import { closeAction, publishAction } from './actions';
 
 type LayoutProps = {
   children: React.ReactNode;
@@ -51,6 +51,7 @@ export default async function SignupDetailLayout({ children, params }: LayoutPro
         status={sig.status}
         publicUrl={publicSignupUrl(sig.slug)}
         publishAction={publishAction.bind(null, id)}
+        closeAction={closeAction.bind(null, id)}
       />
       <TabsNav
         signupId={id}

--- a/src/app/app/(chrome)/signups/[id]/settings/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/settings/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
-import { closeAction, updateBasicsAction } from '../actions';
+import { updateBasicsAction } from '../actions';
 
 type PageParams = {
   params: Promise<{ id: string }>;
@@ -57,25 +57,6 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
           </button>
         </div>
       </form>
-
-      {sig.status === 'open' ? (
-        <div className="border-danger/30 bg-danger/5 rounded-xl border p-6">
-          <h2 className="text-danger text-sm font-semibold">Danger zone</h2>
-          <p className="text-ink-muted mt-1 text-sm">
-            Closing stops new signups but keeps the page visible.
-          </p>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <form action={closeAction.bind(null, id)}>
-              <button
-                type="submit"
-                className="hover:bg-surface-raised rounded-lg border border-surface-sunk bg-white px-4 py-2 text-sm font-medium transition"
-              >
-                Close signup
-              </button>
-            </form>
-          </div>
-        </div>
-      ) : null}
     </section>
   );
 }

--- a/src/components/signup/SignupHeader.tsx
+++ b/src/components/signup/SignupHeader.tsx
@@ -10,6 +10,7 @@ interface SignupHeaderProps {
   status: string;
   publicUrl: string;
   publishAction: () => void | Promise<void>;
+  closeAction: () => void | Promise<void>;
 }
 
 export function SignupHeader({
@@ -19,6 +20,7 @@ export function SignupHeader({
   status,
   publicUrl,
   publishAction,
+  closeAction,
 }: SignupHeaderProps) {
   const previewHref = `/app/signups/${signupId}/preview`;
   const exportHref = `/api/signups/${signupId}/export.csv`;
@@ -59,6 +61,16 @@ export function SignupHeader({
                 className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
               >
                 Publish
+              </button>
+            </form>
+          ) : null}
+          {status === 'open' ? (
+            <form action={closeAction}>
+              <button
+                type="submit"
+                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
+              >
+                Close signup
               </button>
             </form>
           ) : null}


### PR DESCRIPTION
## Summary
- Restore **Close signup** to the signup detail header next to Preview/Export — it's now reachable from any tab instead of being buried in Settings.
- Style matches the existing Publish button (brand-fill); shown only when `status === 'open'` and mutually exclusive with Publish (which only shows for drafts).
- Drop the duplicate Close button from Settings → Danger zone now that the header owns the affordance.

The close API/service (`closeAction` → `closeSignup`) is unchanged; this is purely a UI placement fix for the regression introduced when the detail page was split into tabs (#17).

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test` — green (92/92)
- [x] Manual smoke: open signup detail page for a `draft`, confirm header shows Publish (not Close).
- [x] Manual smoke: open signup detail page for an `open` signup, confirm header shows brand-blue **Close signup**, click it, status flips to `closed`, button disappears.
- [x] Manual smoke: confirm Settings tab no longer renders the Danger zone for open signups.
- [x] Manual smoke: `closed` / `archived` signup → header shows neither Publish nor Close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)