### PR TITLE
refactor(services): replace unsafe actor casts with requireOrganizerId

### DIFF
--- a/src/lib/policy.test.ts
+++ b/src/lib/policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type Actor,
   isInWorkspace,
+  requireOrganizerId,
   requireWorkspaceAccess,
   requireWorkspaceWrite,
   workspaceRole,
@@ -52,5 +53,25 @@ describe('policy', () => {
   it('workspaceRole returns null for anon and unknown ws', () => {
     const a = organizer({ ws_one: 'owner' });
     expect(workspaceRole(a, 'ws_unknown')).toBeNull();
+  });
+
+  it('requireOrganizerId returns the organizer id', () => {
+    const a = organizer({ ws_one: 'owner' });
+    expect(requireOrganizerId(a)).toBe('org_123');
+  });
+
+  it('requireOrganizerId throws for anonymous actor', () => {
+    const anon: Actor = { kind: 'anonymous' };
+    expect(() => requireOrganizerId(anon)).toThrow(/organizer session/);
+  });
+
+  it('requireOrganizerId throws for participant actor', () => {
+    const participant: Actor = {
+      kind: 'participant',
+      signupId: 'sig_1',
+      participantId: 'par_1',
+      commitmentId: 'com_1',
+    };
+    expect(() => requireOrganizerId(participant)).toThrow(/organizer session/);
   });
 });

--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -41,6 +41,11 @@ export function requireOrganizer(actor: Actor): asserts actor is Extract<Actor, 
   }
 }
 
+export function requireOrganizerId(actor: Actor): string {
+  requireOrganizer(actor);
+  return actor.id;
+}
+
 export function requireWorkspaceAccess(actor: Actor, workspaceId: string | null): void {
   if (workspaceId === null) return; // guest-scope, only covered by ownership checks elsewhere
   requireOrganizer(actor);

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -7,7 +7,7 @@ import { recordActivity } from '@/lib/activity';
 import { serviceError, ServiceException, type ServiceError } from '@/lib/errors';
 import { makeId } from '@/lib/ids';
 import { parseInputSafe } from '@/lib/parse';
-import { requireWorkspaceAccess, requireWorkspaceWrite, type Actor } from '@/lib/policy';
+import { requireOrganizerId, requireWorkspaceAccess, requireWorkspaceWrite, type Actor } from '@/lib/policy';
 import { err, ok, type Result } from '@/lib/result';
 import { toSlug } from '@/lib/slug';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
@@ -65,7 +65,7 @@ export async function createSignup(
     await recordActivity(tx, {
       signupId: inserted.id,
       workspaceId,
-      actor: { actorId: actor.id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'signup.created',
       payload: { title: inserted.title },
     });
@@ -142,7 +142,7 @@ export async function updateSignup(
     await recordActivity(tx, {
       signupId,
       workspaceId: row.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'signup.updated',
       payload: { changed: Object.keys(data) },
     });
@@ -226,7 +226,7 @@ async function transitionStatus(
     await recordActivity(tx, {
       signupId,
       workspaceId: row.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType,
       payload: { from: row.status, to },
     });

--- a/src/services/slot-fields.ts
+++ b/src/services/slot-fields.ts
@@ -7,7 +7,7 @@ import { recordActivity } from '@/lib/activity';
 import { serviceError, type ServiceError } from '@/lib/errors';
 import { makeId } from '@/lib/ids';
 import { parseInputSafe } from '@/lib/parse';
-import { requireWorkspaceAccess, requireWorkspaceWrite, type Actor } from '@/lib/policy';
+import { requireOrganizerId, requireWorkspaceAccess, requireWorkspaceWrite, type Actor } from '@/lib/policy';
 import { err, ok, type Result } from '@/lib/result';
 import {
   type SlotFieldConfig,
@@ -176,7 +176,7 @@ export async function addField(
     await recordActivity(tx, {
       signupId,
       workspaceId: signupRow.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'field.created',
       payload: { fieldId: row.id, ref: row.ref, fieldType: row.fieldType },
     });
@@ -269,7 +269,7 @@ export async function updateField(
     await recordActivity(tx, {
       signupId: existing.signupId,
       workspaceId: existing.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'field.updated',
       payload: { fieldId: row.id, ref: row.ref, changes },
     });
@@ -344,7 +344,7 @@ export async function deleteField(
     await recordActivity(tx, {
       signupId: existing.signupId,
       workspaceId: existing.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'field.deleted',
       payload: {
         fieldId,

--- a/src/services/slots.ts
+++ b/src/services/slots.ts
@@ -7,7 +7,7 @@ import { recordActivity } from '@/lib/activity';
 import { serviceError, type ServiceError } from '@/lib/errors';
 import { makeId } from '@/lib/ids';
 import { parseInputSafe } from '@/lib/parse';
-import { requireWorkspaceWrite, type Actor } from '@/lib/policy';
+import { requireOrganizerId, requireWorkspaceWrite, type Actor } from '@/lib/policy';
 import { err, ok, type Result } from '@/lib/result';
 import { toSlug } from '@/lib/slug';
 import {
@@ -73,7 +73,7 @@ export async function addSlot(
     await recordActivity(tx, {
       signupId,
       workspaceId: signupRow.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'slot.created',
       payload: { slotId: inserted.id },
     });
@@ -134,7 +134,7 @@ export async function addSlotsBulk(
     await recordActivity(tx, {
       signupId,
       workspaceId: signupRow.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'slot.created',
       payload: { count: out.length, bulk: true },
     });
@@ -213,7 +213,7 @@ export async function updateSlot(
     await recordActivity(tx, {
       signupId: row.signupId,
       workspaceId: slotRow.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'slot.updated',
       payload: { slotId, changed: Object.keys(data) },
     });
@@ -242,7 +242,7 @@ export async function deleteSlot(
     await recordActivity(tx, {
       signupId: slotRow.signupId,
       workspaceId: slotRow.workspaceId,
-      actor: { actorId: (actor as { id: string }).id, actorType: 'organizer' },
+      actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'slot.deleted',
       payload: { slotId },
     });


### PR DESCRIPTION
Across signups, slots, and slot-fields services, recordActivity calls
used (actor as { id: string }).id to grab the organizer id, bypassing
the Actor discriminated union. The cast was needed only because
requireWorkspaceWrite returns void and TypeScript can't see through it
to narrow Actor to the organizer variant.

Add a small helper requireOrganizerId in lib/policy.ts that reuses the
existing requireOrganizer asserts function, then route the ten activity
call sites through it. No behavior change for organizer callers; a
non-organizer reaching these sites still throws unauthorized.

https://claude.ai/code/session_01BnT3JDqjkZfQvdYKbgxTns