### PR TITLE
docs(contributing): include env setup and worker step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,16 @@ OpenSignup is AGPL-3.0. Contributions retain your copyright and are licensed und
 
 ```bash
 pnpm install
-docker compose up -d
+cp .env.example .env.local
+docker compose up -d            # local Postgres on :5433
 pnpm db:migrate
-pnpm dev
+pnpm dev                         # http://localhost:3000
+```
+
+In a separate terminal, run the reminder worker if you're touching jobs or email:
+
+```bash
+pnpm worker
 ```
 
 Run `pnpm test` for unit tests, `pnpm test:db` for integration tests against the compose Postgres, and `pnpm test:e2e` for Playwright.


### PR DESCRIPTION
Setup instructions skipped `cp .env.example .env.local`, so following
CONTRIBUTING.md from a clean checkout failed at `pnpm db:migrate`
because env validation requires DATABASE_URL/AUTH_SECRET/AUTH_URL.
Also note `pnpm worker` for the reminder pipeline, matching README.

https://claude.ai/code/session_01VbuW7Vq3QhSbz2TMvrYoZN