### PR TITLE
a11y: announce dynamic form errors via role="alert"

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/settings/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/settings/page.tsx
@@ -20,7 +20,7 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
   return (
     <section className="max-w-2xl space-y-6">
       {error ? (
-        <p className="bg-danger/10 text-danger rounded-lg px-3 py-2 text-sm">{error}</p>
+        <p role="alert" className="bg-danger/10 text-danger rounded-lg px-3 py-2 text-sm">{error}</p>
       ) : null}
       <form
         action={updateBasicsAction.bind(null, id)}

--- a/src/app/s/[slug]/c/[id]/edit-form.tsx
+++ b/src/app/s/[slug]/c/[id]/edit-form.tsx
@@ -100,6 +100,7 @@ export default function EditForm({
       </div>
       {message ? (
         <p
+          role={message.kind === 'ok' ? 'status' : 'alert'}
           className={`rounded-lg px-3 py-2 text-sm ${
             message.kind === 'ok' ? 'bg-success/10 text-success' : 'bg-danger/10 text-danger'
           }`}

--- a/src/app/s/[slug]/commit-dialog.tsx
+++ b/src/app/s/[slug]/commit-dialog.tsx
@@ -155,7 +155,7 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
                 </label>
               </div>
               {error ? (
-                <div className="rounded-lg bg-danger/10 p-3 text-sm text-danger">
+                <div role="alert" className="rounded-lg bg-danger/10 p-3 text-sm text-danger">
                   <p className="font-medium">{error.message}</p>
                   {error.suggestion ? <p className="text-xs">{error.suggestion}</p> : null}
                   {error.details?.alternatives?.length ? (


### PR DESCRIPTION
Three error messages render after a user action (form submit, mutation
error, or ?error= redirect) but lacked an ARIA live-region role, so
screen readers stayed silent. The login page already used role="alert"
on its identical-looking error; this brings the other three call sites
in line with that convention.

The edit-form's combined success/error message uses role="status" on
success (polite) and role="alert" on error (assertive).

https://claude.ai/code/session_01KtTWRZgu6bPUCz1fW4wWvr