### PR TITLE
fix(ids): make parseId reject non-base62 bodies, matching isId

### DIFF
--- a/src/lib/ids.test.ts
+++ b/src/lib/ids.test.ts
@@ -51,4 +51,16 @@ describe('parseId', () => {
   it('returns null for unknown prefixes', () => {
     expect(parseId('xxx_' + 'A'.repeat(22))).toBeNull();
   });
+
+  it('rejects bodies containing non-base62 characters', () => {
+    expect(parseId('sig_' + '!'.repeat(22))).toBeNull();
+    expect(parseId('sig_' + '-'.repeat(22))).toBeNull();
+    expect(parseId('sig_' + 'A'.repeat(21) + '!')).toBeNull();
+  });
+
+  it('rejects bodies of the wrong length', () => {
+    expect(parseId('sig_' + 'A'.repeat(21))).toBeNull();
+    expect(parseId('sig_' + 'A'.repeat(23))).toBeNull();
+    expect(parseId('sig_')).toBeNull();
+  });
 });

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -45,11 +45,7 @@ export function makeId<P extends IdPrefix>(prefix: P): `${P}_${string}` {
   return `${prefix}_${body}` as `${P}_${string}`;
 }
 
-export function isId<P extends IdPrefix>(prefix: P, value: unknown): value is `${P}_${string}` {
-  if (typeof value !== 'string') return false;
-  const marker = `${prefix}_`;
-  if (!value.startsWith(marker)) return false;
-  const body = value.slice(marker.length);
+function isBase62Body(body: string): boolean {
   if (body.length !== 22) return false;
   for (const c of body) {
     if (!BASE62_ALPHABET.includes(c)) return false;
@@ -63,6 +59,12 @@ export function parseId(value: string): { prefix: IdPrefix; body: string } | nul
   const prefix = value.slice(0, idx) as IdPrefix;
   if (!ID_PREFIXES.includes(prefix)) return null;
   const body = value.slice(idx + 1);
-  if (body.length !== 22) return null;
+  if (!isBase62Body(body)) return null;
   return { prefix, body };
+}
+
+export function isId<P extends IdPrefix>(prefix: P, value: unknown): value is `${P}_${string}` {
+  if (typeof value !== 'string') return false;
+  const parsed = parseId(value);
+  return parsed?.prefix === prefix;
 }


### PR DESCRIPTION
Previously parseId only checked body length, while isId also validated
that the body chars were in the base62 alphabet. The two could disagree
on the same string. Extract a shared isBase62Body helper and have isId
delegate to parseId so there's one definition of "valid ID".