### PR TITLE
Prevent commitment swaps across different signups

### DIFF
--- a/src/services/commitments.db.test.ts
+++ b/src/services/commitments.db.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { getDb, type Db } from '@/db/client';
+import { commitments } from '@/db/schema/commitments';
+import { workspaceMembers } from '@/db/schema/members';
+import { organizers } from '@/db/schema/organizers';
+import { workspaces } from '@/db/schema/workspaces';
+import { makeId } from '@/lib/ids';
+import type { Actor } from '@/lib/policy';
+import { commitToSlot, updateOwnCommitment } from '@/services/commitments';
+import { createSignup, publishSignup } from '@/services/signups';
+import { addSlot } from '@/services/slots';
+
+interface Fixture {
+  db: Db;
+  workspaceId: string;
+  organizerId: string;
+  actor: Actor;
+}
+
+async function setupWorkspace(): Promise<Fixture> {
+  const db = getDb();
+  const organizerId = makeId('org');
+  const workspaceId = makeId('ws');
+  const memberId = makeId('mem');
+  const slug = `test-${workspaceId.slice(-8).toLowerCase()}`;
+  const email = `${slug}@example.test`;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(organizers).values({ id: organizerId, email, name: 'Test Org' });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      slug,
+      name: 'Test Workspace',
+      type: 'personal',
+      plan: 'free',
+    });
+    await tx.insert(workspaceMembers).values({
+      id: memberId,
+      workspaceId,
+      organizerId,
+      role: 'owner',
+      status: 'active',
+    });
+  });
+
+  const actor: Actor = {
+    kind: 'organizer',
+    id: organizerId,
+    email,
+    workspaceIds: [workspaceId],
+    workspaceRoles: { [workspaceId]: 'owner' },
+  };
+
+  return { db, workspaceId, organizerId, actor };
+}
+
+async function teardownWorkspace(db: Db, workspaceId: string, organizerId: string): Promise<void> {
+  await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+  await db.delete(organizers).where(eq(organizers.id, organizerId));
+}
+
+async function makeOpenSignupWithSlot(fx: Fixture, title: string) {
+  const created = await createSignup(fx.db, fx.actor, fx.workspaceId, {
+    title,
+    description: '',
+    tags: [],
+    visibility: 'unlisted' as const,
+    settings: {},
+  });
+  if (!created.ok) throw new Error(`createSignup failed: ${created.error.message}`);
+
+  const slot = await addSlot(fx.db, fx.actor, created.value.id, {
+    values: {},
+    capacity: 5,
+  });
+  if (!slot.ok) throw new Error(`addSlot failed: ${slot.error.message}`);
+
+  const pub = await publishSignup(fx.db, fx.actor, created.value.id);
+  if (!pub.ok) throw new Error(`publishSignup failed: ${pub.error.message}`);
+
+  return { signupId: created.value.id, slotId: slot.value.id };
+}
+
+describe('updateOwnCommitment swap (db)', () => {
+  let fx: Fixture;
+
+  beforeAll(async () => {
+    fx = await setupWorkspace();
+  });
+
+  afterAll(async () => {
+    await teardownWorkspace(fx.db, fx.workspaceId, fx.organizerId);
+  });
+
+  it('rejects a swap whose target slot is in a different signup', async () => {
+    const a = await makeOpenSignupWithSlot(fx, 'Signup A');
+    const b = await makeOpenSignupWithSlot(fx, 'Signup B');
+
+    const committed = await commitToSlot(fx.db, a.slotId, {
+      name: 'Alice',
+      email: 'alice@example.test',
+      quantity: 1,
+    });
+    if (!committed.ok) throw new Error(`commitToSlot failed: ${committed.error.message}`);
+    const original = committed.value.commitment;
+    const editToken = committed.value.editToken;
+
+    const r = await updateOwnCommitment(fx.db, original.id, editToken, {
+      swapToSlotId: b.slotId,
+    });
+
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('forbidden');
+
+    // Original commitment in signup A is still confirmed (transaction rolled back).
+    const stillThere = await fx.db
+      .select()
+      .from(commitments)
+      .where(eq(commitments.id, original.id))
+      .limit(1);
+    expect(stillThere[0]?.status).toBe('confirmed');
+
+    // No commitment row was created in signup B.
+    const inB = await fx.db
+      .select()
+      .from(commitments)
+      .where(eq(commitments.signupId, b.signupId));
+    expect(inB.length).toBe(0);
+  });
+
+  it('allows a swap to another slot within the same signup', async () => {
+    const a = await makeOpenSignupWithSlot(fx, 'Signup C');
+    const second = await addSlot(fx.db, fx.actor, a.signupId, {
+      values: {},
+      capacity: 5,
+    });
+    if (!second.ok) throw new Error(`second addSlot failed: ${second.error.message}`);
+
+    const committed = await commitToSlot(fx.db, a.slotId, {
+      name: 'Bob',
+      email: 'bob@example.test',
+      quantity: 1,
+    });
+    if (!committed.ok) throw new Error(`commitToSlot failed: ${committed.error.message}`);
+    const original = committed.value.commitment;
+    const editToken = committed.value.editToken;
+
+    const r = await updateOwnCommitment(fx.db, original.id, editToken, {
+      swapToSlotId: second.value.id,
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.slotId).toBe(second.value.id);
+    expect(r.value.signupId).toBe(a.signupId);
+
+    // Original is now cancelled; new commitment is on the second slot.
+    const originalRow = await fx.db
+      .select()
+      .from(commitments)
+      .where(eq(commitments.id, original.id))
+      .limit(1);
+    expect(originalRow[0]?.status).toBe('cancelled');
+
+    const onSecond = await fx.db
+      .select()
+      .from(commitments)
+      .where(and(eq(commitments.slotId, second.value.id), eq(commitments.status, 'confirmed')));
+    expect(onSecond.length).toBe(1);
+  });
+});

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -243,6 +243,16 @@ export async function updateOwnCommitment(
   if (data.swapToSlotId && data.swapToSlotId !== current.slotId) {
     const swapToSlotId = data.swapToSlotId;
     return db.transaction(async (tx) => {
+      const target = await tx
+        .select({ signupId: slots.signupId })
+        .from(slots)
+        .where(eq(slots.id, swapToSlotId))
+        .limit(1);
+      if (!target[0]) return err(serviceError('not_found', 'target slot not found'));
+      if (target[0].signupId !== current.signupId) {
+        return err(serviceError('forbidden', 'cannot swap to a slot in a different signup'));
+      }
+
       const cancelled = await tx
         .update(commitments)
         .set({ status: 'cancelled', cancelledAt: new Date(), updatedAt: new Date() })

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -248,8 +248,9 @@ export async function updateOwnCommitment(
         .from(slots)
         .where(eq(slots.id, swapToSlotId))
         .limit(1);
-      if (!target[0]) return err(serviceError('not_found', 'target slot not found'));
-      if (target[0].signupId !== current.signupId) {
+      const targetRow = target[0];
+      if (!targetRow) return err(serviceError('not_found', 'target slot not found'));
+      if (targetRow.signupId !== current.signupId) {
         return err(serviceError('forbidden', 'cannot swap to a slot in a different signup'));
       }
 


### PR DESCRIPTION
## Summary
Add validation to prevent users from swapping their commitment to a slot in a different signup. This ensures that commitment swaps only occur within the same signup context.

## Key Changes
- Added validation in `updateOwnCommitment` to check that the target slot belongs to the same signup as the current commitment
- Returns a `forbidden` error if a user attempts to swap to a slot in a different signup
- The validation is performed within a database transaction to ensure atomicity
- Added comprehensive test coverage with two test cases:
  - Verifies that cross-signup swaps are rejected and the transaction is rolled back
  - Verifies that same-signup swaps continue to work correctly

## Implementation Details
- The validation queries the target slot to retrieve its `signupId` before proceeding with the swap
- If the target slot's signup differs from the current commitment's signup, the operation fails with a `forbidden` error code
- The transaction ensures that if validation fails, no database changes are committed
- Tests use a realistic fixture setup with workspace, organizer, and signup creation to validate the behavior end-to-end

https://claude.ai/code/session_012qSoRUMUzRHCeegKDokRSH