### PR TITLE
fix(capacity): treat capacity as sum(quantity) instead of row count

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/slots/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/slots/page.tsx
@@ -135,9 +135,11 @@ export default async function SlotsTab({ params }: PageParams) {
       ) : (
         <ul className="divide-y divide-surface-sunk overflow-hidden rounded-xl border border-surface-sunk bg-white">
           {sig.slots.map((slot) => {
-            const active = commitments.filter(
-              (c) => c.slotId === slot.id && (c.status === 'confirmed' || c.status === 'tentative'),
-            );
+            const activeQty = commitments
+              .filter(
+                (c) => c.slotId === slot.id && (c.status === 'confirmed' || c.status === 'tentative'),
+              )
+              .reduce((acc, c) => acc + c.quantity, 0);
             const summary = summarizeValues(fields, (slot.values as Record<string, unknown>) ?? {});
             return (
               <li key={slot.id} className="flex items-center justify-between gap-4 px-5 py-4">
@@ -145,7 +147,7 @@ export default async function SlotsTab({ params }: PageParams) {
                   <p className="truncate font-medium">{summary || slot.ref}</p>
                   <p className="text-ink-muted text-sm">
                     {slot.slotAt ? new Date(slot.slotAt).toLocaleDateString() : '—'} ·{' '}
-                    {active.length}
+                    {activeQty}
                     {slot.capacity ? `/${slot.capacity}` : ''} signed up
                   </p>
                 </div>

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -36,18 +36,15 @@ export default async function PublicSignupPage({ params }: PageParams) {
   }
   const sig = result.value;
 
-  const slots: SignupViewSlot[] = sig.slots.map((slot) => {
-    const committerIds = sig.committerByslot[slot.id] ?? [];
-    return {
-      id: slot.id,
-      ref: slot.ref,
-      values: (slot.values as Record<string, unknown>) ?? {},
-      slotAt: slot.slotAt ? slot.slotAt.toISOString() : null,
-      capacity: slot.capacity,
-      status: slot.status as SlotStatus,
-      committed: committerIds.length,
-    };
-  });
+  const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
+    id: slot.id,
+    ref: slot.ref,
+    values: (slot.values as Record<string, unknown>) ?? {},
+    slotAt: slot.slotAt ? slot.slotAt.toISOString() : null,
+    capacity: slot.capacity,
+    status: slot.status as SlotStatus,
+    committed: sig.committedByslot[slot.id] ?? 0,
+  }));
   const fields: SignupViewField[] = sig.fields.map((f) => ({
     ref: f.ref,
     label: f.label,

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -43,7 +43,7 @@ export default async function PublicSignupPage({ params }: PageParams) {
     slotAt: slot.slotAt ? slot.slotAt.toISOString() : null,
     capacity: slot.capacity,
     status: slot.status as SlotStatus,
-    committed: sig.committedByslot[slot.id] ?? 0,
+    committed: sig.committedBySlot[slot.id] ?? 0,
   }));
   const fields: SignupViewField[] = sig.fields.map((f) => ({
     ref: f.ref,

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -130,9 +130,10 @@ export async function commitToSlot(
       );
     }
 
-    // Count active commitments for capacity check
-    const countRows = await tx
-      .select({ count: sql<number>`count(*)::int` })
+    // Capacity is the cap on sum(quantity), not row count: a Qty=5 commit on a
+    // cap=4 slot is over capacity even with zero existing rows.
+    const sumRows = await tx
+      .select({ sum: sql<number>`coalesce(sum(${commitments.quantity}), 0)::int` })
       .from(commitments)
       .where(
         and(
@@ -140,9 +141,10 @@ export async function commitToSlot(
           or(eq(commitments.status, 'confirmed'), eq(commitments.status, 'tentative')),
         ),
       );
-    const count = countRows[0]?.count ?? 0;
+    const usedQty = sumRows[0]?.sum ?? 0;
 
-    if (slot.capacity !== null && count >= slot.capacity) {
+    if (slot.capacity !== null && usedQty + data.quantity > slot.capacity) {
+      const remaining = Math.max(0, slot.capacity - usedQty);
       const alts = await tx
         .select({ id: slots.id, ref: slots.ref, slotAt: slots.slotAt })
         .from(slots)
@@ -150,16 +152,28 @@ export async function commitToSlot(
         .orderBy(asc(slots.slotAt), asc(slots.sortOrder))
         .limit(3);
       return err(
-        serviceError('capacity_full', 'that slot just filled', {
-          details: {
-            alternatives: alts.map((a) => ({
-              id: a.id,
-              ref: a.ref,
-              slotAt: a.slotAt?.toISOString() ?? null,
-            })),
+        serviceError(
+          'capacity_full',
+          remaining === 0
+            ? 'that slot just filled'
+            : `only ${remaining} left — you asked for ${data.quantity}`,
+          {
+            details: {
+              remaining,
+              requested: data.quantity,
+              capacity: slot.capacity,
+              alternatives: alts.map((a) => ({
+                id: a.id,
+                ref: a.ref,
+                slotAt: a.slotAt?.toISOString() ?? null,
+              })),
+            },
+            suggestion:
+              remaining === 0
+                ? 'pick one of the suggested open slots'
+                : `lower the quantity to ${remaining} or fewer`,
           },
-          suggestion: 'pick one of the suggested open slots',
-        }),
+        ),
       );
     }
 
@@ -290,6 +304,47 @@ export async function updateOwnCommitment(
   }
 
   return db.transaction(async (tx) => {
+    if (data.quantity !== undefined && data.quantity > current.quantity) {
+      const slotRows = await tx
+        .select({ capacity: slots.capacity })
+        .from(slots)
+        .where(eq(slots.id, current.slotId))
+        .for('update')
+        .limit(1);
+      const cap = slotRows[0]?.capacity ?? null;
+      if (cap !== null) {
+        const sumRows = await tx
+          .select({ sum: sql<number>`coalesce(sum(${commitments.quantity}), 0)::int` })
+          .from(commitments)
+          .where(
+            and(
+              eq(commitments.slotId, current.slotId),
+              ne(commitments.id, commitmentId),
+              or(eq(commitments.status, 'confirmed'), eq(commitments.status, 'tentative')),
+            ),
+          );
+        const otherQty = sumRows[0]?.sum ?? 0;
+        if (otherQty + data.quantity > cap) {
+          const remaining = Math.max(0, cap - otherQty);
+          return err(
+            serviceError(
+              'capacity_full',
+              remaining === 0
+                ? 'no spots left for additional quantity'
+                : `only ${remaining} left — you asked for ${data.quantity}`,
+              {
+                details: { remaining, requested: data.quantity, capacity: cap },
+                suggestion:
+                  remaining === 0
+                    ? 'lower the quantity'
+                    : `lower the quantity to ${remaining} or fewer`,
+              },
+            ),
+          );
+        }
+      }
+    }
+
     const [updated] = await tx
       .update(commitments)
       .set({

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -304,6 +304,9 @@ export async function updateOwnCommitment(
   }
 
   return db.transaction(async (tx) => {
+    // Capacity guard: only fires when quantity *increases* on the same slot.
+    // The swap path (slotId change) returns earlier and re-runs the full
+    // capacity check via commitToSlot, so a slot move never reaches here.
     if (data.quantity !== undefined && data.quantity > current.quantity) {
       const slotRows = await tx
         .select({ capacity: slots.capacity })

--- a/src/services/signups.cached.ts
+++ b/src/services/signups.cached.ts
@@ -1,8 +1,12 @@
 import { cache } from 'react';
 import { getDb } from '@/db/client';
 import type { Actor } from '@/lib/policy';
-import { getSignupForOrganizer } from '@/services/signups';
+import { getPublicSignup, getSignupForOrganizer } from '@/services/signups';
 
 export const loadSignupForOrganizer = cache(async (actor: Actor, signupId: string) => {
   return getSignupForOrganizer(getDb(), actor, signupId);
+});
+
+export const loadPublicSignup = cache(async (slug: string) => {
+  return getPublicSignup(getDb(), slug);
 });

--- a/src/services/signups.db.test.ts
+++ b/src/services/signups.db.test.ts
@@ -340,7 +340,7 @@ describe('signups service (db)', () => {
       expect(r.ok).toBe(true);
       if (!r.ok) return;
       expect(r.value.id).toBe(created.value.id);
-      expect(r.value.committedByslot).toEqual({});
+      expect(r.value.committedBySlot).toEqual({});
     });
 
     it('returns ok for a closed signup', async () => {
@@ -414,10 +414,10 @@ describe('signups service (db)', () => {
 
       const pubR = await getPublicSignup(fx.db, created.value.slug);
       if (!pubR.ok) throw new Error('public read failed');
-      expect(pubR.value.committedByslot).toEqual({});
+      expect(pubR.value.committedBySlot).toEqual({});
     });
 
-    it('reports committedByslot as sum of quantities', async () => {
+    it('reports committedBySlot as sum of quantities', async () => {
       const created = await createSignup(fx.db, fx.actor, fx.workspaceId, validCreateInput('Qty sum'));
       if (!created.ok) throw new Error('setup failed');
       const slotR = await addSlot(fx.db, fx.actor, created.value.id, { values: {}, capacity: 10 });
@@ -440,7 +440,7 @@ describe('signups service (db)', () => {
 
       const pubR = await getPublicSignup(fx.db, created.value.slug);
       if (!pubR.ok) throw new Error('public read failed');
-      expect(pubR.value.committedByslot[slotR.value.id]).toBe(7);
+      expect(pubR.value.committedBySlot[slotR.value.id]).toBe(7);
 
       const c = await commitToSlot(fx.db, slotR.value.id, {
         name: 'C',

--- a/src/services/signups.db.test.ts
+++ b/src/services/signups.db.test.ts
@@ -9,6 +9,7 @@ import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
 import type { Actor, WorkspaceRole } from '@/lib/policy';
 import { addSlot } from '@/services/slots';
+import { commitToSlot } from '@/services/commitments';
 import {
   archiveSignup,
   closeSignup,
@@ -339,7 +340,7 @@ describe('signups service (db)', () => {
       expect(r.ok).toBe(true);
       if (!r.ok) return;
       expect(r.value.id).toBe(created.value.id);
-      expect(r.value.committerByslot).toEqual({});
+      expect(r.value.committedByslot).toEqual({});
     });
 
     it('returns ok for a closed signup', async () => {
@@ -392,6 +393,63 @@ describe('signups service (db)', () => {
       if (r.ok) return;
       expect(r.error.code).toBe('not_found');
       expect(r.error.received).toBeUndefined();
+    });
+
+    it('rejects a single commit whose quantity exceeds capacity', async () => {
+      const created = await createSignup(fx.db, fx.actor, fx.workspaceId, validCreateInput('Cap qty'));
+      if (!created.ok) throw new Error('setup failed');
+      const slotR = await addSlot(fx.db, fx.actor, created.value.id, { values: {}, capacity: 1 });
+      if (!slotR.ok) throw new Error('slot setup failed');
+      const pub = await publishSignup(fx.db, fx.actor, created.value.id);
+      if (!pub.ok) throw new Error('setup failed');
+
+      const r = await commitToSlot(fx.db, slotR.value.id, {
+        name: 'Sarah',
+        email: 'sarah@example.com',
+        quantity: 5,
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('capacity_full');
+
+      const pubR = await getPublicSignup(fx.db, created.value.slug);
+      if (!pubR.ok) throw new Error('public read failed');
+      expect(pubR.value.committedByslot).toEqual({});
+    });
+
+    it('reports committedByslot as sum of quantities', async () => {
+      const created = await createSignup(fx.db, fx.actor, fx.workspaceId, validCreateInput('Qty sum'));
+      if (!created.ok) throw new Error('setup failed');
+      const slotR = await addSlot(fx.db, fx.actor, created.value.id, { values: {}, capacity: 10 });
+      if (!slotR.ok) throw new Error('slot setup failed');
+      const pub = await publishSignup(fx.db, fx.actor, created.value.id);
+      if (!pub.ok) throw new Error('setup failed');
+
+      const a = await commitToSlot(fx.db, slotR.value.id, {
+        name: 'A',
+        email: 'a@example.com',
+        quantity: 3,
+      });
+      if (!a.ok) throw new Error('first commit failed');
+      const b = await commitToSlot(fx.db, slotR.value.id, {
+        name: 'B',
+        email: 'b@example.com',
+        quantity: 4,
+      });
+      if (!b.ok) throw new Error('second commit failed');
+
+      const pubR = await getPublicSignup(fx.db, created.value.slug);
+      if (!pubR.ok) throw new Error('public read failed');
+      expect(pubR.value.committedByslot[slotR.value.id]).toBe(7);
+
+      const c = await commitToSlot(fx.db, slotR.value.id, {
+        name: 'C',
+        email: 'c@example.com',
+        quantity: 4,
+      });
+      expect(c.ok).toBe(false);
+      if (c.ok) return;
+      expect(c.error.code).toBe('capacity_full');
     });
 
     it('returns not_found without `received` when soft-deleted', async () => {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -258,7 +258,7 @@ export async function listSignupsForWorkspace(
 export async function getPublicSignup(
   db: Db,
   slug: string,
-): Promise<Result<SignupWithSlots & { committedByslot: Record<string, number> }, ServiceError>> {
+): Promise<Result<SignupWithSlots & { committedBySlot: Record<string, number> }, ServiceError>> {
   const found = await db.select().from(signups).where(eq(signups.slug, slug)).limit(1);
   const row = found[0];
   if (!row || row.deletedAt) return err(serviceError('not_found', 'signup not found'));
@@ -292,12 +292,12 @@ export async function getPublicSignup(
     )
     .groupBy(commitments.slotId);
 
-  const committedByslot: Record<string, number> = {};
+  const committedBySlot: Record<string, number> = {};
   for (const c of committerRows) {
-    committedByslot[c.slotId] = c.sum;
+    committedBySlot[c.slotId] = c.sum;
   }
 
-  return ok({ ...row, slots: signupSlots, fields, committedByslot });
+  return ok({ ...row, slots: signupSlots, fields, committedBySlot });
 }
 
 async function pickAvailableSlug(db: Db, title: string): Promise<string> {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNull, or } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, or, sql } from 'drizzle-orm';
 import type { Db } from '@/db/client';
 import { commitments } from '@/db/schema/commitments';
 import { signups } from '@/db/schema/signups';
@@ -258,7 +258,7 @@ export async function listSignupsForWorkspace(
 export async function getPublicSignup(
   db: Db,
   slug: string,
-): Promise<Result<SignupWithSlots & { committerByslot: Record<string, string[]> }, ServiceError>> {
+): Promise<Result<SignupWithSlots & { committedByslot: Record<string, number> }, ServiceError>> {
   const found = await db.select().from(signups).where(eq(signups.slug, slug)).limit(1);
   const row = found[0];
   if (!row || row.deletedAt) return err(serviceError('not_found', 'signup not found'));
@@ -281,8 +281,7 @@ export async function getPublicSignup(
   const committerRows = await db
     .select({
       slotId: commitments.slotId,
-      participantId: commitments.participantId,
-      status: commitments.status,
+      sum: sql<number>`coalesce(sum(${commitments.quantity}), 0)::int`,
     })
     .from(commitments)
     .where(
@@ -290,16 +289,15 @@ export async function getPublicSignup(
         eq(commitments.signupId, row.id),
         or(eq(commitments.status, 'confirmed'), eq(commitments.status, 'tentative')),
       ),
-    );
+    )
+    .groupBy(commitments.slotId);
 
-  const committerByslot: Record<string, string[]> = {};
+  const committedByslot: Record<string, number> = {};
   for (const c of committerRows) {
-    const list = committerByslot[c.slotId] ?? [];
-    list.push(c.participantId);
-    committerByslot[c.slotId] = list;
+    committedByslot[c.slotId] = c.sum;
   }
 
-  return ok({ ...row, slots: signupSlots, fields, committerByslot });
+  return ok({ ...row, slots: signupSlots, fields, committedByslot });
 }
 
 async function pickAvailableSlug(db: Db, title: string): Promise<string> {


### PR DESCRIPTION
## Summary
- A single commit with `quantity=5` on a slot with `capacity=1` was being accepted because the capacity check counted commitment rows, not summed quantities.
- Both the public signup query (`getPublicSignup`) and the commit/update paths (`commitToSlot`, `updateOwnCommitment`) now aggregate `sum(quantity)` for `confirmed | tentative` rows.
- Over-capacity error now distinguishes "slot just filled" from "you asked for more than remaining" so the user knows whether to try again or pick a different slot.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test`
- [x] `pnpm test:db` (concurrent commit races + new regression tests for qty>capacity and committed-by-slot reporting)
- [x] Manual: try `qty=5` on a 0/1 slot → rejected with "only 1 left — you asked for 5"
- [x] Manual: fill the slot, try `qty=1` → rejected with "that slot just filled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)