### PR TITLE
feat(participant): multi-commit returning-participant cookie

### DIFF
--- a/src/app/api/commitments/[id]/route.ts
+++ b/src/app/api/commitments/[id]/route.ts
@@ -3,6 +3,11 @@ import { getDb } from '@/db/client';
 import { fail, handle, respond } from '@/lib/api-response';
 import { serviceError } from '@/lib/errors';
 import {
+  COMMIT_COOKIE_NAME,
+  removeReturningCommit,
+  setReturningCommitCookie,
+} from '@/lib/returning-participant';
+import {
   cancelOwnCommitment,
   getOwnCommitment,
   updateOwnCommitment,
@@ -52,6 +57,11 @@ export async function DELETE(
     const token = readToken(req);
     if (!token) return fail(serviceError('forbidden', 'edit token required', { field: 'token' }));
     const result = await cancelOwnCommitment(getDb(), id, token);
-    return respond(result);
+    const response = respond(result);
+    if (result.ok) {
+      const next = removeReturningCommit(req.cookies.get(COMMIT_COOKIE_NAME)?.value, id);
+      setReturningCommitCookie(response, next);
+    }
+    return response;
   });
 }

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -47,6 +47,7 @@ export async function POST(
       req.cookies.get(COMMIT_COOKIE_NAME)?.value ?? null,
       result.value.commitment.id,
       result.value.editToken,
+      sig.id,
     );
     setReturningCommitCookie(response, nextCookie);
     return response;

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -4,6 +4,11 @@ import { getDb } from '@/db/client';
 import { signups } from '@/db/schema/signups';
 import { slots } from '@/db/schema/slots';
 import { fail, handle, respond } from '@/lib/api-response';
+import {
+  COMMIT_COOKIE_NAME,
+  appendReturningCommit,
+  setReturningCommitCookie,
+} from '@/lib/returning-participant';
 import { serviceError } from '@/lib/errors';
 import { commitmentEditUrl, link } from '@/lib/links';
 import { commitToSlot } from '@/services/commitments';
@@ -27,7 +32,7 @@ export async function POST(
     if (!sig) return fail(serviceError('not_found', 'signup missing'));
 
     const editUrl = commitmentEditUrl(sig.slug, result.value.commitment.id, result.value.editToken);
-    return respond(
+    const response = respond(
       { ok: true, value: { ...result.value, editUrl } },
       {
         edit: link(editUrl),
@@ -38,5 +43,12 @@ export async function POST(
         ),
       },
     );
+    const nextCookie = appendReturningCommit(
+      req.cookies.get(COMMIT_COOKIE_NAME)?.value ?? null,
+      result.value.commitment.id,
+      result.value.editToken,
+    );
+    setReturningCommitCookie(response, nextCookie);
+    return response;
   });
 }

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/lib/returning-participant';
 import type { SignupStatus } from '@/schemas/signups';
 import type { SlotStatus } from '@/schemas/slots';
-import { getOwnCommitment } from '@/services/commitments';
+import { getOwnCommitmentsForSignup } from '@/services/commitments';
 import { getPublicSignup } from '@/services/signups';
 import SignupView, { type SignupViewField, type SignupViewSlot } from './signup-view';
 
@@ -45,25 +45,18 @@ export default async function PublicSignupPage({ params }: PageParams) {
 
   const cookieStore = await cookies();
   const returningRaw = cookieStore.get(COMMIT_COOKIE_NAME)?.value ?? null;
-  const returning = parseReturningCommits(returningRaw);
-  const db = getDb();
-  const lookups = await Promise.all(
-    returning.map(async (r) => {
-      const found = await getOwnCommitment(db, r.commitmentId, r.token);
-      if (!found.ok) return null;
-      const c = found.value;
-      if (c.signupId !== sig.id) return null;
-      if (c.status !== 'confirmed' && c.status !== 'tentative') return null;
-      return {
-        slotId: c.slotId,
-        editUrl: commitmentEditUrl(slug, c.id, r.token),
-        participantName: c.participantName,
-      };
-    }),
+  // Drop entries the cookie says belong to a different signup; legacy entries
+  // (no signupId) fall through and are filtered by the signupId-scoped query.
+  const candidates = parseReturningCommits(returningRaw).filter(
+    (e) => !e.signupId || e.signupId === sig.id,
   );
-  const ownCommitments = lookups.filter(
-    (x): x is { slotId: string; editUrl: string; participantName: string } => x !== null,
-  );
+  const found = await getOwnCommitmentsForSignup(getDb(), sig.id, candidates);
+  const tokenById = new Map(candidates.map((c) => [c.commitmentId, c.token]));
+  const ownCommitments = found.map((c) => ({
+    slotId: c.slotId,
+    editUrl: commitmentEditUrl(slug, c.id, tokenById.get(c.id) ?? ''),
+    participantName: c.participantName,
+  }));
 
   const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
     id: slot.id,

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -1,7 +1,14 @@
+import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getDb } from '@/db/client';
+import { commitmentEditUrl } from '@/lib/links';
+import {
+  COMMIT_COOKIE_NAME,
+  parseReturningCommits,
+} from '@/lib/returning-participant';
 import type { SignupStatus } from '@/schemas/signups';
 import type { SlotStatus } from '@/schemas/slots';
+import { getOwnCommitment } from '@/services/commitments';
 import { getPublicSignup } from '@/services/signups';
 import SignupView, { type SignupViewField, type SignupViewSlot } from './signup-view';
 
@@ -36,6 +43,28 @@ export default async function PublicSignupPage({ params }: PageParams) {
   }
   const sig = result.value;
 
+  const cookieStore = await cookies();
+  const returningRaw = cookieStore.get(COMMIT_COOKIE_NAME)?.value ?? null;
+  const returning = parseReturningCommits(returningRaw);
+  const db = getDb();
+  const lookups = await Promise.all(
+    returning.map(async (r) => {
+      const found = await getOwnCommitment(db, r.commitmentId, r.token);
+      if (!found.ok) return null;
+      const c = found.value;
+      if (c.signupId !== sig.id) return null;
+      if (c.status !== 'confirmed' && c.status !== 'tentative') return null;
+      return {
+        slotId: c.slotId,
+        editUrl: commitmentEditUrl(slug, c.id, r.token),
+        participantName: c.participantName,
+      };
+    }),
+  );
+  const ownCommitments = lookups.filter(
+    (x): x is { slotId: string; editUrl: string; participantName: string } => x !== null,
+  );
+
   const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
     id: slot.id,
     ref: slot.ref,
@@ -66,6 +95,7 @@ export default async function PublicSignupPage({ params }: PageParams) {
         slots={slots}
         slug={slug}
         mode="live"
+        ownCommitments={ownCommitments}
       />
     </main>
   );

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -5,6 +5,12 @@ import type { SlotStatus } from '@/schemas/slots';
 import { Banner } from '@/components/banner';
 import CommitDialog from './commit-dialog';
 
+export interface OwnCommitment {
+  slotId: string;
+  editUrl: string;
+  participantName: string;
+}
+
 export interface SignupViewSlot {
   id: string;
   ref: string;
@@ -47,6 +53,7 @@ interface SignupViewProps {
   slots: SignupViewSlot[];
   slug: string;
   mode: 'live' | 'preview';
+  ownCommitments?: OwnCommitment[];
 }
 
 interface SlotGroup {
@@ -78,13 +85,24 @@ function groupSlots(
   return [...map.values()].sort((a, b) => a.label.localeCompare(b.label));
 }
 
-export default function SignupView({ signup, fields, groupByRef, slots, slug, mode }: SignupViewProps) {
+export default function SignupView({
+  signup,
+  fields,
+  groupByRef,
+  slots,
+  slug,
+  mode,
+  ownCommitments,
+}: SignupViewProps) {
   const isPreview = mode === 'preview';
   const effectiveStatus =
     isPreview && signup.status === 'draft' ? 'open' : signup.status;
   const groupField =
     groupByRef ? fields.find((f) => f.ref === groupByRef) ?? null : null;
   const groups = groupSlots(slots, groupField);
+  const ownBySlot = new Map((ownCommitments ?? []).map((c) => [c.slotId, c]));
+  const firstOwn = ownCommitments?.[0] ?? null;
+  const ownCount = ownCommitments?.length ?? 0;
 
   const previewCopy =
     signup.status === 'draft'
@@ -105,6 +123,24 @@ export default function SignupView({ signup, fields, groupByRef, slots, slug, mo
           title="Closed"
           body="This signup is no longer collecting responses."
         />
+      ) : firstOwn ? (
+        <div className="rounded-xl border border-surface-sunk bg-success/5 px-4 py-3 text-sm">
+          <span className="font-medium">You&apos;re signed up</span>
+          {ownCount === 1 ? (
+            <>
+              {' '}as <span className="text-ink">{firstOwn.participantName}</span>.{' '}
+              <Link href={firstOwn.editUrl} className="text-brand underline">
+                Edit or cancel
+              </Link>
+            </>
+          ) : (
+            <>
+              {' '}as <span className="text-ink">{firstOwn.participantName}</span> for{' '}
+              <span className="text-ink">{ownCount} slots</span>. Use the Edit button on
+              any of your slots below to change or cancel it.
+            </>
+          )}
+        </div>
       ) : null}
 
       <header className="space-y-2">
@@ -128,10 +164,14 @@ export default function SignupView({ signup, fields, groupByRef, slots, slug, mo
                 const closed = slot.status !== 'open' || effectiveStatus !== 'open' || full;
                 const summary =
                   summarizeSlotValues(fields, slot.values, groupField?.ref) || slot.ref;
+                const own = ownBySlot.get(slot.id) ?? null;
+                const isOwn = own !== null;
                 return (
                   <li
                     key={slot.id}
-                    className="flex items-center justify-between gap-4 px-5 py-4"
+                    className={`flex items-center justify-between gap-4 px-5 py-4 ${
+                      isOwn ? 'bg-success/5' : ''
+                    }`}
                   >
                     <div className="min-w-0">
                       <p className="truncate font-medium">{summary}</p>
@@ -151,8 +191,15 @@ export default function SignupView({ signup, fields, groupByRef, slots, slug, mo
                         {slot.capacity ? `/${slot.capacity}` : ''}
                       </span>
                       <div className="flex w-24 justify-center">
-                        {closed ? (
-                          <span className="text-ink-muted px-3 py-1.5 text-xs font-medium">
+                        {own ? (
+                          <Link
+                            href={own.editUrl}
+                            className="rounded-lg border border-surface-sunk bg-white px-4 py-2 text-sm font-medium transition hover:bg-surface-raised"
+                          >
+                            Edit
+                          </Link>
+                        ) : closed ? (
+                          <span className="text-ink-muted px-3 py-1.5 text-sm font-medium">
                             {full ? 'Full' : 'Closed'}
                           </span>
                         ) : isPreview ? (
@@ -165,7 +212,11 @@ export default function SignupView({ signup, fields, groupByRef, slots, slug, mo
                             Sign up
                           </button>
                         ) : (
-                          <CommitDialog slotId={slot.id} slotTitle={summary} slug={slug} />
+                          <CommitDialog
+                            slotId={slot.id}
+                            slotTitle={summary}
+                            slug={slug}
+                          />
                         )}
                       </div>
                     </div>

--- a/src/lib/returning-participant.test.ts
+++ b/src/lib/returning-participant.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMMIT_COOKIE_NAME,
+  appendReturningCommit,
+  parseReturningCommits,
+  removeReturningCommit,
+  serializeReturningCommits,
+} from './returning-participant';
+
+describe('returning-participant cookie', () => {
+  it('cookie name is stable across versions', () => {
+    expect(COMMIT_COOKIE_NAME).toBe('os_commit');
+  });
+
+  it('roundtrips a list of commits with special-char tokens', () => {
+    const value = serializeReturningCommits([
+      { commitmentId: 'com_abc', token: 'tok-1.with_special' },
+      { commitmentId: 'com_def', token: 'tok2' },
+    ]);
+    expect(parseReturningCommits(value)).toEqual([
+      { commitmentId: 'com_abc', token: 'tok-1.with_special' },
+      { commitmentId: 'com_def', token: 'tok2' },
+    ]);
+  });
+
+  it('parses legacy single-entry cookies (no comma)', () => {
+    expect(parseReturningCommits('com_abc.tok')).toEqual([
+      { commitmentId: 'com_abc', token: 'tok' },
+    ]);
+  });
+
+  it('returns empty list for unparseable values', () => {
+    expect(parseReturningCommits('')).toEqual([]);
+    expect(parseReturningCommits(null)).toEqual([]);
+    expect(parseReturningCommits('justone')).toEqual([]);
+  });
+
+  it('skips entries with invalid commitment id prefix', () => {
+    expect(parseReturningCommits('par_abc.tok,com_ok.tok2')).toEqual([
+      { commitmentId: 'com_ok', token: 'tok2' },
+    ]);
+  });
+
+  it('appends a new commit to the front and de-dupes the same id', () => {
+    const a = appendReturningCommit(null, 'com_a', 'ta');
+    const ab = appendReturningCommit(a, 'com_b', 'tb');
+    expect(parseReturningCommits(ab).map((c) => c.commitmentId)).toEqual(['com_b', 'com_a']);
+
+    // re-appending the same id replaces the prior token (e.g. token rotation)
+    const aab = appendReturningCommit(ab, 'com_a', 'ta2');
+    expect(parseReturningCommits(aab)).toEqual([
+      { commitmentId: 'com_a', token: 'ta2' },
+      { commitmentId: 'com_b', token: 'tb' },
+    ]);
+  });
+
+  it('removes a single commit, leaving the rest', () => {
+    const start = serializeReturningCommits([
+      { commitmentId: 'com_a', token: 'ta' },
+      { commitmentId: 'com_b', token: 'tb' },
+      { commitmentId: 'com_c', token: 'tc' },
+    ]);
+    const after = removeReturningCommit(start, 'com_b');
+    expect(parseReturningCommits(after).map((c) => c.commitmentId)).toEqual(['com_a', 'com_c']);
+  });
+});

--- a/src/lib/returning-participant.test.ts
+++ b/src/lib/returning-participant.test.ts
@@ -12,20 +12,27 @@ describe('returning-participant cookie', () => {
     expect(COMMIT_COOKIE_NAME).toBe('os_commit');
   });
 
-  it('roundtrips a list of commits with special-char tokens', () => {
+  it('roundtrips a list of commits with signupId', () => {
     const value = serializeReturningCommits([
-      { commitmentId: 'com_abc', token: 'tok-1.with_special' },
-      { commitmentId: 'com_def', token: 'tok2' },
+      { commitmentId: 'com_abc', token: 'tokOne_-A1', signupId: 'sig_one' },
+      { commitmentId: 'com_def', token: 'tok2', signupId: 'sig_two' },
     ]);
     expect(parseReturningCommits(value)).toEqual([
-      { commitmentId: 'com_abc', token: 'tok-1.with_special' },
-      { commitmentId: 'com_def', token: 'tok2' },
+      { commitmentId: 'com_abc', token: 'tokOne_-A1', signupId: 'sig_one' },
+      { commitmentId: 'com_def', token: 'tok2', signupId: 'sig_two' },
     ]);
   });
 
-  it('parses legacy single-entry cookies (no comma)', () => {
+  it('parses legacy single-entry cookies (no comma, no signupId)', () => {
     expect(parseReturningCommits('com_abc.tok')).toEqual([
       { commitmentId: 'com_abc', token: 'tok' },
+    ]);
+  });
+
+  it('parses legacy multi-entry cookies without signupId', () => {
+    expect(parseReturningCommits('com_a.ta,com_b.tb')).toEqual([
+      { commitmentId: 'com_a', token: 'ta' },
+      { commitmentId: 'com_b', token: 'tb' },
     ]);
   });
 
@@ -36,31 +43,44 @@ describe('returning-participant cookie', () => {
   });
 
   it('skips entries with invalid commitment id prefix', () => {
-    expect(parseReturningCommits('par_abc.tok,com_ok.tok2')).toEqual([
-      { commitmentId: 'com_ok', token: 'tok2' },
+    expect(parseReturningCommits('par_abc.tok,com_ok.tok2.sig_x')).toEqual([
+      { commitmentId: 'com_ok', token: 'tok2', signupId: 'sig_x' },
     ]);
   });
 
   it('appends a new commit to the front and de-dupes the same id', () => {
-    const a = appendReturningCommit(null, 'com_a', 'ta');
-    const ab = appendReturningCommit(a, 'com_b', 'tb');
+    const a = appendReturningCommit(null, 'com_a', 'ta', 'sig_x');
+    const ab = appendReturningCommit(a, 'com_b', 'tb', 'sig_x');
     expect(parseReturningCommits(ab).map((c) => c.commitmentId)).toEqual(['com_b', 'com_a']);
 
     // re-appending the same id replaces the prior token (e.g. token rotation)
-    const aab = appendReturningCommit(ab, 'com_a', 'ta2');
+    const aab = appendReturningCommit(ab, 'com_a', 'ta2', 'sig_x');
     expect(parseReturningCommits(aab)).toEqual([
-      { commitmentId: 'com_a', token: 'ta2' },
-      { commitmentId: 'com_b', token: 'tb' },
+      { commitmentId: 'com_a', token: 'ta2', signupId: 'sig_x' },
+      { commitmentId: 'com_b', token: 'tb', signupId: 'sig_x' },
     ]);
+  });
+
+  it('appends without signupId for callers that omit it', () => {
+    const next = appendReturningCommit(null, 'com_a', 'ta');
+    expect(parseReturningCommits(next)).toEqual([{ commitmentId: 'com_a', token: 'ta' }]);
   });
 
   it('removes a single commit, leaving the rest', () => {
     const start = serializeReturningCommits([
-      { commitmentId: 'com_a', token: 'ta' },
-      { commitmentId: 'com_b', token: 'tb' },
-      { commitmentId: 'com_c', token: 'tc' },
+      { commitmentId: 'com_a', token: 'ta', signupId: 'sig_x' },
+      { commitmentId: 'com_b', token: 'tb', signupId: 'sig_x' },
+      { commitmentId: 'com_c', token: 'tc', signupId: 'sig_y' },
     ]);
     const after = removeReturningCommit(start, 'com_b');
     expect(parseReturningCommits(after).map((c) => c.commitmentId)).toEqual(['com_a', 'com_c']);
+  });
+
+  it('mixes legacy and new entries in one cookie', () => {
+    const value = 'com_old.tokOld,com_new.tokNew.sig_z';
+    expect(parseReturningCommits(value)).toEqual([
+      { commitmentId: 'com_old', token: 'tokOld' },
+      { commitmentId: 'com_new', token: 'tokNew', signupId: 'sig_z' },
+    ]);
   });
 });

--- a/src/lib/returning-participant.ts
+++ b/src/lib/returning-participant.ts
@@ -7,25 +7,43 @@ const MAX_ENTRIES = 40;
 export interface ReturningCommit {
   commitmentId: string;
   token: string;
+  signupId?: string;
 }
 
 function serializeOne(c: ReturningCommit): string {
-  return `${c.commitmentId}.${encodeURIComponent(c.token)}`;
+  const base = `${c.commitmentId}.${encodeURIComponent(c.token)}`;
+  return c.signupId ? `${base}.${c.signupId}` : base;
 }
 
 function parseOne(raw: string): ReturningCommit | null {
-  const dot = raw.indexOf('.');
-  if (dot <= 0 || dot >= raw.length - 1) return null;
-  const commitmentId = raw.slice(0, dot);
+  const firstDot = raw.indexOf('.');
+  if (firstDot <= 0 || firstDot >= raw.length - 1) return null;
+  const commitmentId = raw.slice(0, firstDot);
   if (!commitmentId.startsWith('com_')) return null;
+
+  // Tail format: encodedToken[.sig_XYZ]. Use lastIndexOf so a token containing
+  // a literal `.` (unusual — real edit tokens are base64url) still parses as
+  // long as it isn't followed by something starting with `sig_`.
+  const rest = raw.slice(firstDot + 1);
+  const lastDot = rest.lastIndexOf('.');
+  let encodedToken: string;
+  let signupId: string | undefined;
+  if (lastDot > 0 && rest.slice(lastDot + 1).startsWith('sig_')) {
+    encodedToken = rest.slice(0, lastDot);
+    signupId = rest.slice(lastDot + 1);
+  } else {
+    encodedToken = rest;
+    signupId = undefined;
+  }
+
   let token: string;
   try {
-    token = decodeURIComponent(raw.slice(dot + 1));
+    token = decodeURIComponent(encodedToken);
   } catch {
     return null;
   }
   if (!token) return null;
-  return { commitmentId, token };
+  return signupId ? { commitmentId, token, signupId } : { commitmentId, token };
 }
 
 export function serializeReturningCommits(commits: ReturningCommit[]): string {
@@ -51,9 +69,13 @@ export function appendReturningCommit(
   raw: string | null | undefined,
   commitmentId: string,
   token: string,
+  signupId?: string,
 ): string {
   const existing = parseReturningCommits(raw).filter((c) => c.commitmentId !== commitmentId);
-  const next = [{ commitmentId, token }, ...existing].slice(0, MAX_ENTRIES);
+  const entry: ReturningCommit = signupId
+    ? { commitmentId, token, signupId }
+    : { commitmentId, token };
+  const next = [entry, ...existing].slice(0, MAX_ENTRIES);
   return serializeReturningCommits(next);
 }
 

--- a/src/lib/returning-participant.ts
+++ b/src/lib/returning-participant.ts
@@ -1,0 +1,81 @@
+import type { NextResponse } from 'next/server';
+
+export const COMMIT_COOKIE_NAME = 'os_commit';
+const MAX_AGE_DAYS = 60;
+const MAX_ENTRIES = 40;
+
+export interface ReturningCommit {
+  commitmentId: string;
+  token: string;
+}
+
+function serializeOne(c: ReturningCommit): string {
+  return `${c.commitmentId}.${encodeURIComponent(c.token)}`;
+}
+
+function parseOne(raw: string): ReturningCommit | null {
+  const dot = raw.indexOf('.');
+  if (dot <= 0 || dot >= raw.length - 1) return null;
+  const commitmentId = raw.slice(0, dot);
+  if (!commitmentId.startsWith('com_')) return null;
+  let token: string;
+  try {
+    token = decodeURIComponent(raw.slice(dot + 1));
+  } catch {
+    return null;
+  }
+  if (!token) return null;
+  return { commitmentId, token };
+}
+
+export function serializeReturningCommits(commits: ReturningCommit[]): string {
+  return commits.map(serializeOne).join(',');
+}
+
+export function parseReturningCommits(raw: string | null | undefined): ReturningCommit[] {
+  if (!raw) return [];
+  const out: ReturningCommit[] = [];
+  const seen = new Set<string>();
+  for (const part of raw.split(',')) {
+    if (!part) continue;
+    const parsed = parseOne(part);
+    if (!parsed) continue;
+    if (seen.has(parsed.commitmentId)) continue;
+    seen.add(parsed.commitmentId);
+    out.push(parsed);
+  }
+  return out;
+}
+
+export function appendReturningCommit(
+  raw: string | null | undefined,
+  commitmentId: string,
+  token: string,
+): string {
+  const existing = parseReturningCommits(raw).filter((c) => c.commitmentId !== commitmentId);
+  const next = [{ commitmentId, token }, ...existing].slice(0, MAX_ENTRIES);
+  return serializeReturningCommits(next);
+}
+
+export function removeReturningCommit(
+  raw: string | null | undefined,
+  commitmentId: string,
+): string {
+  return serializeReturningCommits(
+    parseReturningCommits(raw).filter((c) => c.commitmentId !== commitmentId),
+  );
+}
+
+export function setReturningCommitCookie(response: NextResponse, value: string): void {
+  // Path `/` — every API route mutating commits needs to read/write this cookie,
+  // and SSR filters by signup_id, so cross-signup leakage is impossible.
+  // httpOnly: cookie carries edit-token capabilities; no client code reads it.
+  response.cookies.set({
+    name: COMMIT_COOKIE_NAME,
+    value,
+    path: '/',
+    maxAge: MAX_AGE_DAYS * 24 * 60 * 60,
+    sameSite: 'lax',
+    httpOnly: true,
+  });
+}

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, ne, or, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, ne, or, sql } from 'drizzle-orm';
 import type { Db, Queryable } from '@/db/client';
 import { commitments } from '@/db/schema/commitments';
 import { participants } from '@/db/schema/participants';
@@ -238,6 +238,43 @@ export async function getOwnCommitment(
     return err(serviceError('forbidden', 'invalid edit token'));
   }
   return ok({ ...found.c, participantName: found.pname, participantEmail: found.pemail });
+}
+
+/**
+ * Batch lookup for the returning-participant cookie. Resolves a list of
+ * (commitmentId, token) pairs against a single signup in one DB query, dropping
+ * any rows that don't belong to the signup, are inactive, or fail token verify.
+ */
+export async function getOwnCommitmentsForSignup(
+  db: Db,
+  signupId: string,
+  items: { commitmentId: string; token: string }[],
+): Promise<Array<CommitmentRow & { participantName: string; participantEmail: string }>> {
+  if (items.length === 0) return [];
+  const tokenById = new Map(items.map((i) => [i.commitmentId, i.token]));
+  const rows = await db
+    .select({
+      c: commitments,
+      pname: participants.name,
+      pemail: participants.email,
+    })
+    .from(commitments)
+    .innerJoin(participants, eq(participants.id, commitments.participantId))
+    .where(
+      and(
+        eq(commitments.signupId, signupId),
+        inArray(commitments.id, [...tokenById.keys()]),
+        or(eq(commitments.status, 'confirmed'), eq(commitments.status, 'tentative')),
+      ),
+    );
+  const out: Array<CommitmentRow & { participantName: string; participantEmail: string }> = [];
+  for (const row of rows) {
+    const token = tokenById.get(row.c.id);
+    if (!token) continue;
+    if (!verifyHash(token, row.c.editTokenHash)) continue;
+    out.push({ ...row.c, participantName: row.pname, participantEmail: row.pemail });
+  }
+  return out;
 }
 
 export async function updateOwnCommitment(


### PR DESCRIPTION
> Stacked on top of #28. Review/merge that one first — diff here is just the cookie work.

## Summary
- Single edit-token cookie → list cookie (capped at 40 entries to stay under the 4KB cookie limit), so a participant who signs up for several slots in one signup sees all of their commitments highlighted with Edit links.
- Server now manages the cookie end-to-end (set on `POST`, scrub on `DELETE`), which lets the cookie be `httpOnly` — XSS can no longer exfiltrate edit tokens.
- Bumps the closed-slot \"Full\"/\"Closed\" label from `text-xs` to `text-sm` to match surrounding row text.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test` (new tests for `serializeReturningCommits` / `parseReturningCommits` / `appendReturningCommit` / `removeReturningCommit`)
- [x] Manual: sign up for 2 slots in the same signup → both rows show Edit, banner says \"as Sarah for 2 slots\"
- [x] Manual: sign up for 1 slot → banner says \"as Sarah. Edit or cancel\"
- [x] Manual: cancel a commitment → that row's Edit link disappears, others remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)