### PR TITLE
feat(participant): signup-flow polish

### DIFF
--- a/src/app/s/[slug]/c/[id]/edit-form.tsx
+++ b/src/app/s/[slug]/c/[id]/edit-form.tsx
@@ -23,6 +23,7 @@ export default function EditForm({
   const router = useRouter();
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  const [confirmingCancel, setConfirmingCancel] = useState(false);
 
   async function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -49,9 +50,9 @@ export default function EditForm({
     setSaving(false);
   }
 
-  async function handleCancel() {
-    if (!confirm('Cancel this signup? This cannot be undone.')) return;
+  async function handleConfirmCancel() {
     setSaving(true);
+    setMessage(null);
     const res = await fetch(`/api/commitments/${commitmentId}?token=${encodeURIComponent(token)}`, {
       method: 'DELETE',
     });
@@ -60,6 +61,7 @@ export default function EditForm({
     } else {
       const payload = await res.json().catch(() => null);
       setMessage({ kind: 'err', text: payload?.error?.message ?? 'cancel failed' });
+      setConfirmingCancel(false);
     }
     setSaving(false);
   }
@@ -108,23 +110,53 @@ export default function EditForm({
           {message.text}
         </p>
       ) : null}
-      <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={handleCancel}
-          disabled={saving}
-          className="text-danger rounded-lg border border-surface-sunk px-4 py-2 text-sm font-medium transition disabled:opacity-50"
-        >
-          Cancel signup
-        </button>
-        <div className="flex-1" />
-        <button
-          type="submit"
-          disabled={saving}
-          className="bg-brand rounded-lg px-5 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:opacity-50"
-        >
-          {saving ? 'Saving…' : 'Save'}
-        </button>
+      <div className="flex flex-wrap items-center gap-3">
+        {confirmingCancel ? (
+          <div
+            role="alertdialog"
+            aria-label="Confirm cancellation"
+            className="flex flex-1 flex-wrap items-center gap-2 rounded-lg bg-danger/10 px-3 py-2 text-sm"
+          >
+            <span className="text-danger font-medium">Cancel this signup?</span>
+            <div className="ml-auto flex gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmingCancel(false)}
+                disabled={saving}
+                className="rounded-lg border border-surface-sunk bg-white px-3 py-1.5 text-xs font-medium transition disabled:opacity-50"
+              >
+                Keep
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmCancel}
+                disabled={saving}
+                className="bg-danger rounded-lg px-3 py-1.5 text-xs font-medium text-white transition disabled:opacity-50"
+              >
+                {saving ? 'Cancelling…' : 'Yes, cancel'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => setConfirmingCancel(true)}
+              disabled={saving}
+              className="text-danger rounded-lg border border-surface-sunk px-4 py-2 text-sm font-medium transition disabled:opacity-50"
+            >
+              Cancel signup
+            </button>
+            <div className="flex-1" />
+            <button
+              type="submit"
+              disabled={saving}
+              className="bg-brand rounded-lg px-5 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </>
+        )}
       </div>
     </form>
   );

--- a/src/app/s/[slug]/commit-dialog.tsx
+++ b/src/app/s/[slug]/commit-dialog.tsx
@@ -63,7 +63,7 @@ export default function CommitDialog({
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
-  const [success, setSuccess] = useState<{ editUrl: string } | null>(null);
+  const [success, setSuccess] = useState<{ commitmentId: string; editUrl: string } | null>(null);
   const [prefill, setPrefill] = useState<PrefillState | null>(null);
   const [emailValue, setEmailValue] = useState('');
   const [shareCopied, setShareCopied] = useState(false);
@@ -119,7 +119,10 @@ export default function CommitDialog({
         return;
       }
       writePrefill({ name, email });
-      setSuccess({ editUrl: payload.data.editUrl });
+      setSuccess({
+        commitmentId: payload.data.commitment.id,
+        editUrl: payload.data.editUrl,
+      });
       // Don't refresh server state yet — that would re-render the parent and
       // replace this dialog (slot row swaps to "Edit" once cookie is read),
       // dismissing the success view with its calendar/share affordances.
@@ -144,7 +147,7 @@ export default function CommitDialog({
     if (!slotAt || !success) return;
     const start = new Date(slotAt);
     const ics = buildIcs({
-      uid: `${success.editUrl.split('/').slice(-1)[0] ?? 'opensignup'}@opensignup.org`,
+      uid: `${success.commitmentId}@opensignup.org`,
       title: `${signupTitle} — ${slotTitle}`,
       description: `Edit or cancel: ${success.editUrl}`,
       url: success.editUrl,

--- a/src/app/s/[slug]/commit-dialog.tsx
+++ b/src/app/s/[slug]/commit-dialog.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { suggestEmail } from '@/lib/email-suggest';
+import { buildIcs } from '@/lib/ics';
 
 interface CommitDialogProps {
   slotId: string;
   slotTitle: string;
+  slotAt: string | null;
+  signupTitle: string;
   slug: string;
 }
 
@@ -13,24 +17,92 @@ interface ApiError {
   code: string;
   message: string;
   suggestion?: string;
-  details?: { alternatives?: { id: string; title: string }[] };
+  details?: {
+    alternatives?: { id: string; title: string }[];
+    remaining?: number;
+  };
 }
 
-export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogProps) {
+interface PrefillState {
+  name: string;
+  email: string;
+}
+
+const PREFILL_KEY = 'opensignup:lastCommit';
+
+function readPrefill(): PrefillState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(PREFILL_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PrefillState>;
+    if (typeof parsed.name !== 'string' || typeof parsed.email !== 'string') return null;
+    return { name: parsed.name, email: parsed.email };
+  } catch {
+    return null;
+  }
+}
+
+function writePrefill(value: PrefillState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PREFILL_KEY, JSON.stringify(value));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+export default function CommitDialog({
+  slotId,
+  slotTitle,
+  slotAt,
+  signupTitle,
+  slug,
+}: CommitDialogProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<ApiError | null>(null);
   const [success, setSuccess] = useState<{ editUrl: string } | null>(null);
+  const [prefill, setPrefill] = useState<PrefillState | null>(null);
+  const [emailValue, setEmailValue] = useState('');
+  const [shareCopied, setShareCopied] = useState(false);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const stored = readPrefill();
+    setPrefill(stored);
+    setEmailValue(stored?.email ?? '');
+    // autofocus name on open (or email if name already filled)
+    queueMicrotask(() => {
+      if (stored?.name) {
+        const emailEl = document.querySelector<HTMLInputElement>(
+          'input[name="email"]:not([disabled])',
+        );
+        emailEl?.focus();
+      } else {
+        nameRef.current?.focus();
+      }
+    });
+  }, [open]);
+
+  const emailHint = useMemo(() => suggestEmail(emailValue), [emailValue]);
+
+  function handleAcceptSuggestion() {
+    if (emailHint) setEmailValue(emailHint);
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setSubmitting(true);
     setError(null);
     const data = new FormData(e.currentTarget);
+    const name = String(data.get('name') ?? '').trim();
+    const email = String(data.get('email') ?? '').trim();
     const body = {
-      name: String(data.get('name') ?? ''),
-      email: String(data.get('email') ?? ''),
+      name,
+      email,
       notes: String(data.get('notes') ?? '') || undefined,
       quantity: Number(data.get('quantity') ?? 1),
     };
@@ -46,12 +118,71 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
         setSubmitting(false);
         return;
       }
+      writePrefill({ name, email });
       setSuccess({ editUrl: payload.data.editUrl });
-      router.refresh();
+      // Don't refresh server state yet — that would re-render the parent and
+      // replace this dialog (slot row swaps to "Edit" once cookie is read),
+      // dismissing the success view with its calendar/share affordances.
+      // Refresh on close instead.
     } catch {
       setError({ code: 'internal', message: 'network error' });
     } finally {
       setSubmitting(false);
+    }
+  }
+
+  function handleClose() {
+    const wasSuccess = success !== null;
+    setOpen(false);
+    setSuccess(null);
+    setError(null);
+    setShareCopied(false);
+    if (wasSuccess) router.refresh();
+  }
+
+  function handleDownloadIcs() {
+    if (!slotAt || !success) return;
+    const start = new Date(slotAt);
+    const ics = buildIcs({
+      uid: `${success.editUrl.split('/').slice(-1)[0] ?? 'opensignup'}@opensignup.org`,
+      title: `${signupTitle} — ${slotTitle}`,
+      description: `Edit or cancel: ${success.editUrl}`,
+      url: success.editUrl,
+      start,
+    });
+    const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${slug}-${slotTitle}.ics`.replace(/[^A-Za-z0-9._-]+/g, '-');
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+
+  async function handleShare() {
+    if (!success) return;
+    const shareData = {
+      title: signupTitle,
+      text: `I'm signed up for "${slotTitle}".`,
+      url: success.editUrl,
+    };
+    const nav = navigator as Navigator & { share?: (d: ShareData) => Promise<void> };
+    if (typeof nav.share === 'function') {
+      try {
+        await nav.share(shareData);
+        return;
+      } catch {
+        // user cancelled or share failed; fall through to copy
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(success.editUrl);
+      setShareCopied(true);
+      setTimeout(() => setShareCopied(false), 2000);
+    } catch {
+      // last resort: do nothing — link is already on screen
     }
   }
 
@@ -79,7 +210,7 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
       <div
         className="fixed inset-0 z-40 flex items-end justify-center bg-ink/30 backdrop-blur-sm sm:items-center"
         onClick={(e) => {
-          if (e.target === e.currentTarget && !submitting) setOpen(false);
+          if (e.target === e.currentTarget && !submitting) handleClose();
         }}
       >
         <div className="w-full max-w-md rounded-t-xl bg-white p-6 shadow-card sm:rounded-xl">
@@ -96,12 +227,27 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
               >
                 {success.editUrl}
               </a>
+              <div className="flex flex-wrap gap-2">
+                {slotAt ? (
+                  <button
+                    type="button"
+                    onClick={handleDownloadIcs}
+                    className="flex-1 rounded-lg border border-surface-sunk px-3 py-2 text-sm font-medium transition hover:bg-surface-raised"
+                  >
+                    Add to calendar
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={handleShare}
+                  className="flex-1 rounded-lg border border-surface-sunk px-3 py-2 text-sm font-medium transition hover:bg-surface-raised"
+                >
+                  {shareCopied ? 'Link copied' : 'Share link'}
+                </button>
+              </div>
               <button
                 type="button"
-                onClick={() => {
-                  setOpen(false);
-                  setSuccess(null);
-                }}
+                onClick={handleClose}
                 className="bg-brand w-full rounded-lg px-4 py-3 text-sm font-medium text-white"
               >
                 Done
@@ -113,11 +259,13 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
               <label className="block">
                 <span className="mb-1 block text-sm font-medium">Your name</span>
                 <input
+                  ref={nameRef}
                   type="text"
                   name="name"
                   required
                   minLength={1}
                   autoComplete="name"
+                  defaultValue={prefill?.name ?? ''}
                   className="focus:border-brand focus:ring-brand w-full rounded-lg border border-surface-sunk px-4 py-3 focus:outline-none focus:ring-1"
                 />
               </label>
@@ -129,8 +277,23 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
                   required
                   autoComplete="email"
                   inputMode="email"
+                  value={emailValue}
+                  onChange={(e) => setEmailValue(e.target.value)}
                   className="focus:border-brand focus:ring-brand w-full rounded-lg border border-surface-sunk px-4 py-3 focus:outline-none focus:ring-1"
                 />
+                {emailHint ? (
+                  <p className="text-ink-muted mt-1 text-xs">
+                    Did you mean{' '}
+                    <button
+                      type="button"
+                      onClick={handleAcceptSuggestion}
+                      className="text-brand font-medium underline"
+                    >
+                      {emailHint}
+                    </button>
+                    ?
+                  </p>
+                ) : null}
               </label>
               <div className="grid grid-cols-[1fr_auto] gap-3">
                 <label className="block">
@@ -158,7 +321,7 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
                 <div role="alert" className="rounded-lg bg-danger/10 p-3 text-sm text-danger">
                   <p className="font-medium">{error.message}</p>
                   {error.suggestion ? <p className="text-xs">{error.suggestion}</p> : null}
-                  {error.details?.alternatives?.length ? (
+                  {error.details?.alternatives?.length && error.details.remaining === 0 ? (
                     <div className="mt-2 space-y-1 text-xs">
                       <p>Try another slot:</p>
                       <a
@@ -174,7 +337,7 @@ export default function CommitDialog({ slotId, slotTitle, slug }: CommitDialogPr
               <div className="flex gap-3 pt-2">
                 <button
                   type="button"
-                  onClick={() => setOpen(false)}
+                  onClick={handleClose}
                   disabled={submitting}
                   className="flex-1 rounded-lg border border-surface-sunk px-4 py-3 text-sm font-medium transition disabled:opacity-50"
                 >

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getDb } from '@/db/client';
@@ -9,16 +10,36 @@ import {
 import type { SignupStatus } from '@/schemas/signups';
 import type { SlotStatus } from '@/schemas/slots';
 import { getOwnCommitmentsForSignup } from '@/services/commitments';
-import { getPublicSignup } from '@/services/signups';
+import { loadPublicSignup } from '@/services/signups.cached';
 import SignupView, { type SignupViewField, type SignupViewSlot } from './signup-view';
-
-export const metadata = { title: 'Sign up' };
 
 type PageParams = { params: Promise<{ slug: string }> };
 
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
+  const { slug } = await params;
+  const result = await loadPublicSignup(slug);
+  if (!result.ok) return { title: 'Sign up' };
+  const sig = result.value;
+  const description = sig.description?.slice(0, 200) ?? 'Sign up via OpenSignup';
+  return {
+    title: sig.title,
+    description,
+    openGraph: {
+      title: sig.title,
+      description,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title: sig.title,
+      description,
+    },
+  };
+}
+
 export default async function PublicSignupPage({ params }: PageParams) {
   const { slug } = await params;
-  const result = await getPublicSignup(getDb(), slug);
+  const result = await loadPublicSignup(slug);
   if (!result.ok) {
     const received = result.error.received;
     if (received === 'draft' || received === 'archived') {

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -15,12 +15,21 @@ import SignupView, { type SignupViewField, type SignupViewSlot } from './signup-
 
 type PageParams = { params: Promise<{ slug: string }> };
 
+function trimToBoundary(value: string | null | undefined, max: number): string | null {
+  if (!value) return null;
+  if (value.length <= max) return value;
+  const sliced = value.slice(0, max);
+  const lastSpace = sliced.search(/\s\S*$/);
+  const trimmed = (lastSpace > 0 ? sliced.slice(0, lastSpace) : sliced).trimEnd();
+  return trimmed.length > 0 ? `${trimmed}…` : sliced;
+}
+
 export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
   const { slug } = await params;
   const result = await loadPublicSignup(slug);
   if (!result.ok) return { title: 'Sign up' };
   const sig = result.value;
-  const description = sig.description?.slice(0, 200) ?? 'Sign up via OpenSignup';
+  const description = trimToBoundary(sig.description, 200) ?? 'Sign up via OpenSignup';
   return {
     title: sig.title,
     description,

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -215,6 +215,8 @@ export default function SignupView({
                           <CommitDialog
                             slotId={slot.id}
                             slotTitle={summary}
+                            slotAt={slot.slotAt}
+                            signupTitle={signup.title}
                             slug={slug}
                           />
                         )}

--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { buildIcs } from './ics';
+
+describe('buildIcs', () => {
+  it('renders a minimal event with required fields', () => {
+    const ics = buildIcs({
+      uid: 'com_abc@opensignup.org',
+      title: 'Saturday snack',
+      start: new Date('2026-05-02T15:00:00Z'),
+      end: new Date('2026-05-02T16:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).toContain('BEGIN:VCALENDAR');
+    expect(ics).toContain('END:VCALENDAR');
+    expect(ics).toContain('BEGIN:VEVENT');
+    expect(ics).toContain('END:VEVENT');
+    expect(ics).toContain('UID:com_abc@opensignup.org');
+    expect(ics).toContain('SUMMARY:Saturday snack');
+    expect(ics).toContain('DTSTART:20260502T150000Z');
+    expect(ics).toContain('DTEND:20260502T160000Z');
+    expect(ics).toContain('DTSTAMP:20260430T120000Z');
+  });
+
+  it('defaults end to start + 1 hour when not provided', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Pickup',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).toContain('DTSTART:20260502T150000Z');
+    expect(ics).toContain('DTEND:20260502T160000Z');
+  });
+
+  it('escapes commas, semicolons, backslashes, and newlines in text fields', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Snack; Day, fun\\time',
+      description: 'line1\nline2',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).toContain('SUMMARY:Snack\\; Day\\, fun\\\\time');
+    expect(ics).toContain('DESCRIPTION:line1\\nline2');
+  });
+
+  it('uses CRLF line endings', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Pickup',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).toContain('\r\n');
+    expect(ics.split('\r\n')[0]).toBe('BEGIN:VCALENDAR');
+  });
+
+  it('omits DESCRIPTION/LOCATION/URL when not provided', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Pickup',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).not.toContain('DESCRIPTION');
+    expect(ics).not.toContain('LOCATION');
+    expect(ics).not.toContain('URL');
+  });
+
+  it('includes optional URL and LOCATION', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Pickup',
+      url: 'https://opensignup.org/s/team/c/com_x?token=abc',
+      location: 'Main gym',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).toContain('URL:https://opensignup.org/s/team/c/com_x?token=abc');
+    expect(ics).toContain('LOCATION:Main gym');
+  });
+});

--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -67,6 +67,31 @@ describe('buildIcs', () => {
     expect(ics).not.toContain('URL');
   });
 
+  it('folds lines longer than 75 octets per RFC 5545', () => {
+    const longDescription = 'x'.repeat(200);
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Pickup',
+      description: longDescription,
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    for (const physical of ics.split('\r\n')) {
+      expect(Buffer.byteLength(physical, 'utf8')).toBeLessThanOrEqual(75);
+    }
+    expect(ics).toMatch(/\r\n /);
+  });
+
+  it('does not fold lines that fit under 75 octets', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Short',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    expect(ics).not.toMatch(/\r\n /);
+  });
+
   it('includes optional URL and LOCATION', () => {
     const ics = buildIcs({
       uid: 'com_x@opensignup.org',

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -1,0 +1,57 @@
+export interface IcsEventInput {
+  uid: string;
+  title: string;
+  description?: string;
+  location?: string;
+  url?: string;
+  start: Date;
+  end?: Date;
+  now?: Date;
+}
+
+const CRLF = '\r\n';
+
+function pad(n: number): string {
+  return n.toString().padStart(2, '0');
+}
+
+function formatUtc(d: Date): string {
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  );
+}
+
+function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+}
+
+export function buildIcs(input: IcsEventInput): string {
+  const start = input.start;
+  const end = input.end ?? new Date(start.getTime() + 60 * 60 * 1000);
+  const now = input.now ?? new Date();
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//OpenSignup//opensignup.org//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${input.uid}`,
+    `DTSTAMP:${formatUtc(now)}`,
+    `DTSTART:${formatUtc(start)}`,
+    `DTEND:${formatUtc(end)}`,
+    `SUMMARY:${escapeText(input.title)}`,
+  ];
+  if (input.description) lines.push(`DESCRIPTION:${escapeText(input.description)}`);
+  if (input.location) lines.push(`LOCATION:${escapeText(input.location)}`);
+  if (input.url) lines.push(`URL:${input.url}`);
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+
+  return lines.join(CRLF) + CRLF;
+}

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -30,12 +30,36 @@ function escapeText(value: string): string {
     .replace(/;/g, '\\;');
 }
 
+/**
+ * RFC 5545 §3.1: content lines longer than 75 octets must be folded by
+ * inserting CRLF + a single space at each fold point. We fold by octet
+ * length (UTF-8) so multi-byte characters split safely.
+ */
+function foldLine(line: string): string {
+  const bytes = Buffer.from(line, 'utf8');
+  if (bytes.length <= 75) return line;
+  const parts: string[] = [];
+  let offset = 0;
+  // First chunk: 75 octets. Continuations: 74 octets (reserve 1 for the leading space).
+  let chunkSize = 75;
+  while (offset < bytes.length) {
+    let end = Math.min(offset + chunkSize, bytes.length);
+    // Avoid splitting in the middle of a multi-byte UTF-8 sequence: a
+    // continuation byte is 10xxxxxx (0x80–0xBF). Walk back to a leading byte.
+    while (end < bytes.length && ((bytes[end] ?? 0) & 0xc0) === 0x80) end--;
+    parts.push(bytes.subarray(offset, end).toString('utf8'));
+    offset = end;
+    chunkSize = 74;
+  }
+  return parts.join(`${CRLF} `);
+}
+
 export function buildIcs(input: IcsEventInput): string {
   const start = input.start;
   const end = input.end ?? new Date(start.getTime() + 60 * 60 * 1000);
   const now = input.now ?? new Date();
 
-  const lines = [
+  const rawLines = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
     'PRODID:-//OpenSignup//opensignup.org//EN',
@@ -48,10 +72,10 @@ export function buildIcs(input: IcsEventInput): string {
     `DTEND:${formatUtc(end)}`,
     `SUMMARY:${escapeText(input.title)}`,
   ];
-  if (input.description) lines.push(`DESCRIPTION:${escapeText(input.description)}`);
-  if (input.location) lines.push(`LOCATION:${escapeText(input.location)}`);
-  if (input.url) lines.push(`URL:${input.url}`);
-  lines.push('END:VEVENT', 'END:VCALENDAR');
+  if (input.description) rawLines.push(`DESCRIPTION:${escapeText(input.description)}`);
+  if (input.location) rawLines.push(`LOCATION:${escapeText(input.location)}`);
+  if (input.url) rawLines.push(`URL:${input.url}`);
+  rawLines.push('END:VEVENT', 'END:VCALENDAR');
 
-  return lines.join(CRLF) + CRLF;
+  return rawLines.map(foldLine).join(CRLF) + CRLF;
 }


### PR DESCRIPTION
> Stacked on top of #29 → #28. Review/merge those first.

## Summary
- Inline cancel confirmation in the edit form (replaces `window.confirm`)
- ICS calendar download from the success view of a slot with `slotAt`
- Email-typo suggestion + share + post-commit success view in the commit dialog, with focus management
- OG/Twitter metadata generated from signup title/description; the page handler and `generateMetadata` share one DB query via React's request-scoped cache (`loadPublicSignup`)

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test` (new tests for `buildIcs` + escaping/CRLF)
- [x] Manual: sign up → see success view with \"Add to calendar\" / \"Share\" buttons; ICS opens cleanly
- [x] Manual: type `name@gmial.com` → suggestion offers `gmail.com`
- [x] Manual: cancel from edit form → inline \"Cancel this signup?\" with Keep / Yes, cancel
- [ ] Manual: paste signup URL into Slack → preview shows title + description

🤖 Generated with [Claude Code](https://claude.com/claude-code)