### PR TITLE
Add conflict handling to idempotency key insertion

### DIFF
--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -41,16 +41,19 @@ export async function saveResponse(
   response: { status: number; body: string },
 ): Promise<void> {
   const ttl = ctx.ttlSeconds ?? 60 * 60 * 24;
-  await db.insert(idempotencyKeys).values({
-    id: makeId('idm'),
-    key: ctx.key,
-    organizerId: ctx.organizerId ?? null,
-    participantScope: ctx.participantScope ?? null,
-    requestHash: hashBody(ctx.requestBody),
-    responseBody: response.body,
-    responseStatus: response.status,
-    expiresAt: new Date(Date.now() + ttl * 1000),
-  });
+  await db
+    .insert(idempotencyKeys)
+    .values({
+      id: makeId('idm'),
+      key: ctx.key,
+      organizerId: ctx.organizerId ?? null,
+      participantScope: ctx.participantScope ?? null,
+      requestHash: hashBody(ctx.requestBody),
+      responseBody: response.body,
+      responseStatus: response.status,
+      expiresAt: new Date(Date.now() + ttl * 1000),
+    })
+    .onConflictDoNothing();
 }
 
 function hashBody(body: unknown): string {


### PR DESCRIPTION
## Summary
Updated the idempotency key insertion logic to gracefully handle duplicate key conflicts instead of throwing an error.

## Changes
- Reformatted the database insert statement for better readability by breaking it into multiple lines
- Added `.onConflictDoNothing()` clause to the insert query, which silently ignores attempts to insert duplicate idempotency keys

## Implementation Details
This change ensures that when a duplicate idempotency key is encountered (which can happen in retry scenarios), the operation completes successfully without throwing a database constraint violation error. The existing response data remains unchanged, maintaining idempotent behavior as intended.

https://claude.ai/code/session_01LE4rb5oQAeno36MTLE3aCD