### PR TITLE
Remove unused token generation and logging utility functions

### DIFF
--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -25,6 +25,3 @@ export const log = pino({
   }),
 });
 
-export function childLog(bindings: Record<string, unknown>) {
-  return log.child(bindings);
-}

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -1,13 +1,8 @@
-import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import { getEnv } from './env';
 
 function secret(): string {
   return getEnv().AUTH_SECRET;
-}
-
-/** Generates a URL-safe opaque token (32 random bytes, base64url). */
-export function generateToken(bytes = 32): string {
-  return randomBytes(bytes).toString('base64url');
 }
 
 export function hashToken(token: string): string {


### PR DESCRIPTION
## Summary
This PR removes two unused utility functions that are no longer needed in the codebase.

## Key Changes
- **token.ts**: Removed `generateToken()` function and its `randomBytes` import, keeping only the `hashToken()` function for token hashing operations
- **log.ts**: Removed `childLog()` wrapper function that was providing minimal value over direct `log.child()` calls

## Details
These functions appear to have been superseded by other implementations or are no longer actively used in the codebase. Removing them reduces maintenance burden and clarifies the public API surface of these modules.

https://claude.ai/code/session_0171Ep4TfXGCVdB8bQN6Rey9