### PR TITLE
Remove dev email transport documentation from check email page

### DIFF
--- a/src/app/login/check/page.tsx
+++ b/src/app/login/check/page.tsx
@@ -10,10 +10,6 @@ export default function CheckEmailPage() {
           minutes.
         </p>
       </div>
-      <p className="text-ink-soft text-sm">
-        Dev: with <code className="font-mono">EMAIL_TRANSPORT=console</code>, the link is logged to
-        the server console.
-      </p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Removed developer-facing documentation about the email transport console logging feature from the check email page.

## Changes
- Removed the informational paragraph that documented the `EMAIL_TRANSPORT=console` environment variable behavior for local development
- This text was displayed to all users on the email verification page and is no longer needed in the UI

## Details
The removed content was a developer note explaining that when `EMAIL_TRANSPORT=console` is configured, the verification link is logged to the server console. This information is better suited for documentation or developer guides rather than being displayed on the user-facing check email page.

https://claude.ai/code/session_0118FUFEM75AELBLsD1zNnNU