### PR TITLE
feat(ui): async button loading states + inline /login states

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/add-field-form.tsx
+++ b/src/app/app/(chrome)/signups/[id]/add-field-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 
 interface AddFieldFormProps {
   action: (formData: FormData) => void | Promise<void>;
@@ -42,12 +43,12 @@ export default function AddFieldForm({ action }: AddFieldFormProps) {
       <label className="flex min-h-[42px] items-center justify-center gap-2 text-sm">
         <input type="checkbox" name="required" defaultChecked /> Required
       </label>
-      <button
-        type="submit"
-        className="bg-brand rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
+      <AsyncSubmitButton
+        loadingLabel="Adding…"
+        className="bg-brand rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
       >
         Add field
-      </button>
+      </AsyncSubmitButton>
       {fieldType === 'enum' ? (
         <label className="block sm:col-span-4">
           <span className="mb-1 block text-sm font-medium">Choices (one per line)</span>

--- a/src/app/app/(chrome)/signups/[id]/fields/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/fields/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { fieldEnumChoices, fieldTypeLabel } from '@/lib/field-labels';
+import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 import AddFieldForm from '../add-field-form';
 import { addFieldAction, deleteFieldAction, updateSettingsAction } from '../actions';
 
@@ -57,12 +58,12 @@ export default async function FieldsTab({ params }: PageParams) {
                 </div>
                 <form action={deleteFieldAction.bind(null, id)}>
                   <input type="hidden" name="fieldId" value={f.id} />
-                  <button
-                    type="submit"
-                    className="text-danger text-sm transition hover:underline"
+                  <AsyncSubmitButton
+                    loadingLabel="Removing…"
+                    className="text-danger text-sm transition hover:underline disabled:cursor-not-allowed disabled:opacity-70"
                   >
                     Remove
-                  </button>
+                  </AsyncSubmitButton>
                 </form>
               </li>
             );
@@ -113,12 +114,12 @@ export default async function FieldsTab({ params }: PageParams) {
           ) : (
             <input type="hidden" name="reminderFromFieldRef" value={reminderRef} />
           )}
-          <button
-            type="submit"
-            className="hover:bg-surface-raised rounded-lg border border-surface-sunk px-4 py-2 text-sm font-medium transition"
+          <AsyncSubmitButton
+            loadingLabel="Saving…"
+            className="hover:bg-surface-raised rounded-lg border border-surface-sunk px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-70"
           >
             Save settings
-          </button>
+          </AsyncSubmitButton>
         </form>
       ) : null}
     </section>

--- a/src/app/app/(chrome)/signups/[id]/settings/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
+import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 import { updateBasicsAction } from '../actions';
 
 type PageParams = {
@@ -49,12 +50,12 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
           />
         </label>
         <div className="flex items-center justify-end">
-          <button
-            type="submit"
-            className="bg-brand rounded-lg px-5 py-2 font-medium text-white transition hover:brightness-110"
+          <AsyncSubmitButton
+            loadingLabel="Saving…"
+            className="bg-brand rounded-lg px-5 py-2 font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
           >
             Save changes
-          </button>
+          </AsyncSubmitButton>
         </div>
       </form>
     </section>

--- a/src/app/app/(chrome)/signups/[id]/slots/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/slots/page.tsx
@@ -6,6 +6,7 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { listCommitmentsForSignup } from '@/services/commitments';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 import { addSlotAction, deleteSlotAction } from '../actions';
 
 type PageParams = { params: Promise<{ id: string }> };
@@ -120,12 +121,12 @@ export default async function SlotsTab({ params }: PageParams) {
             className="focus:border-brand focus:ring-brand block min-h-[42px] w-full appearance-none rounded-lg border border-surface-sunk bg-white px-3 py-2 focus:outline-none focus:ring-1"
           />
         </label>
-        <button
-          type="submit"
-          className="bg-brand rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 sm:col-span-2 sm:justify-self-start"
+        <AsyncSubmitButton
+          loadingLabel="Adding…"
+          className="bg-brand rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90 sm:col-span-2 sm:justify-self-start"
         >
           Add slot
-        </button>
+        </AsyncSubmitButton>
       </form>
 
       {sig.slots.length === 0 ? (
@@ -153,12 +154,12 @@ export default async function SlotsTab({ params }: PageParams) {
                 </div>
                 <form action={deleteSlotAction.bind(null, id)}>
                   <input type="hidden" name="slotId" value={slot.id} />
-                  <button
-                    type="submit"
-                    className="text-danger text-sm transition hover:underline"
+                  <AsyncSubmitButton
+                    loadingLabel="Removing…"
+                    className="text-danger text-sm transition hover:underline disabled:cursor-not-allowed disabled:opacity-70"
                   >
                     Remove
-                  </button>
+                  </AsyncSubmitButton>
                 </form>
               </li>
             );

--- a/src/app/app/(chrome)/signups/new/page.tsx
+++ b/src/app/app/(chrome)/signups/new/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { createSignup } from '@/services/signups';
+import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 
 export const metadata = { title: 'New signup' };
 
@@ -63,12 +64,12 @@ export default async function NewSignupPage() {
           >
             Cancel
           </a>
-          <button
-            type="submit"
-            className="bg-brand rounded-lg px-5 py-2 font-medium text-white transition hover:brightness-110"
+          <AsyncSubmitButton
+            loadingLabel="Creating…"
+            className="bg-brand rounded-lg px-5 py-2 font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
           >
             Create signup
-          </button>
+          </AsyncSubmitButton>
         </div>
       </form>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,16 +27,16 @@
     outline-offset: 2px;
     border-radius: 6px;
   }
+}
 
-  @media (prefers-reduced-motion: reduce) {
-    .animate-spin-720 {
-      animation: none;
-      opacity: 0.7;
-    }
-    .animate-check-draw {
-      animation: none;
-      stroke-dashoffset: 0;
-    }
+@media (prefers-reduced-motion: reduce) {
+  .animate-spin-720 {
+    animation: none;
+    opacity: 0.7;
+  }
+  .animate-check-draw {
+    animation: none;
+    stroke-dashoffset: 0;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,17 @@
     outline-offset: 2px;
     border-radius: 6px;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-spin-720 {
+      animation: none;
+      opacity: 0.7;
+    }
+    .animate-check-draw {
+      animation: none;
+      stroke-dashoffset: 0;
+    }
+  }
 }
 
 @layer components {

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+import { Spinner } from '@/components/ui/spinner';
+
+export type LoginActionResult = { ok: true; email: string } | { ok: false };
+
+type Props = {
+  action: (formData: FormData) => Promise<LoginActionResult>;
+};
+
+type View = 'idle' | 'success' | 'error';
+
+const MIN_LOADING_MS = 500;
+
+export function LoginForm({ action }: Props) {
+  const [view, setView] = useState<View>('idle');
+  const [pending, startTransition] = useTransition();
+  const [confirmedEmail, setConfirmedEmail] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const state: 'idle' | 'loading' | 'success' | 'error' = pending ? 'loading' : view;
+  const inert = state === 'loading' || state === 'success';
+
+  const handleSubmit = (formData: FormData) => {
+    if (inert) return;
+    startTransition(async () => {
+      const start = Date.now();
+      let result: LoginActionResult;
+      try {
+        result = await action(formData);
+      } catch {
+        result = { ok: false };
+      }
+      const elapsed = Date.now() - start;
+      if (elapsed < MIN_LOADING_MS) {
+        await new Promise((r) => setTimeout(r, MIN_LOADING_MS - elapsed));
+      }
+      if (result.ok) {
+        setConfirmedEmail(result.email);
+        setView('success');
+      } else {
+        setView('error');
+      }
+    });
+  };
+
+  const reset = () => {
+    setView('idle');
+    setTimeout(() => inputRef.current?.focus(), 60);
+  };
+
+  const buttonBg =
+    state === 'success' ? 'bg-success' : state === 'error' ? 'bg-danger' : 'bg-brand';
+  const buttonHover = state === 'idle' ? 'hover:brightness-110' : '';
+  const buttonLoading = state === 'loading' ? 'brightness-90' : '';
+
+  return (
+    <form action={handleSubmit} className="space-y-4" noValidate>
+      <label className="block">
+        <span className="mb-1 block text-sm font-medium">Email</span>
+        <input
+          ref={inputRef}
+          type="email"
+          name="email"
+          required
+          autoComplete="email"
+          inputMode="email"
+          disabled={inert}
+          className="focus:border-brand focus:ring-brand w-full rounded-lg border border-surface-sunk bg-white px-4 py-3 text-base shadow-sm transition focus:outline-none focus:ring-1 disabled:bg-white disabled:opacity-100"
+          placeholder="you@example.com"
+        />
+      </label>
+      <button
+        type="submit"
+        aria-disabled={inert}
+        aria-busy={state === 'loading'}
+        data-state={state}
+        className={`relative w-full rounded-lg px-5 py-3 font-medium text-white transition-colors duration-180 ease-emphasized ${buttonBg} ${buttonHover} ${buttonLoading}`}
+      >
+        <ButtonLabel state={state} />
+      </button>
+      <HelperText state={state} email={confirmedEmail} onReset={reset} />
+    </form>
+  );
+}
+
+function ButtonLabel({ state }: { state: 'idle' | 'loading' | 'success' | 'error' }) {
+  if (state === 'loading') {
+    return (
+      <span className="inline-flex items-center justify-center gap-2">
+        <Spinner />
+        <span>Sending…</span>
+      </span>
+    );
+  }
+  if (state === 'success') {
+    return (
+      <span className="inline-flex items-center justify-center gap-2">
+        <CheckIcon />
+        <span>Sent — check your email</span>
+      </span>
+    );
+  }
+  return <span>Send magic link</span>;
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className="shrink-0"
+    >
+      <path
+        d="M5 12.5l4.5 4.5L19 7.5"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeDasharray="24"
+        strokeDashoffset="24"
+        className="animate-check-draw"
+      />
+    </svg>
+  );
+}
+
+type HelperProps = {
+  state: 'idle' | 'loading' | 'success' | 'error';
+  email: string;
+  onReset: () => void;
+};
+
+function HelperText({ state, email, onReset }: HelperProps) {
+  return (
+    <p
+      aria-live="polite"
+      className={`text-ink-soft min-h-[1.2em] text-xs ${state === 'error' ? 'text-danger' : ''}`}
+    >
+      {state === 'success' && (
+        <>
+          Link sent to <strong className="text-ink font-medium">{email}</strong>. Check your inbox.{' '}
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-brand underline-offset-2 hover:underline"
+          >
+            Send again
+          </button>
+        </>
+      )}
+      {state === 'error' && (
+        <>
+          Couldn&rsquo;t send.{' '}
+          <button
+            type="button"
+            onClick={onReset}
+            className="underline-offset-2 hover:underline"
+          >
+            Try again
+          </button>
+        </>
+      )}
+    </p>
+  );
+}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -3,7 +3,10 @@
 import { useRef, useState, useTransition } from 'react';
 import { Spinner } from '@/components/ui/spinner';
 
-export type LoginActionResult = { ok: true; email: string } | { ok: false };
+export type LoginErrorReason = 'invalid_email' | 'send_failed';
+export type LoginActionResult =
+  | { ok: true; email: string }
+  | { ok: false; reason: LoginErrorReason };
 
 type Props = {
   action: (formData: FormData) => Promise<LoginActionResult>;
@@ -17,6 +20,7 @@ export function LoginForm({ action }: Props) {
   const [view, setView] = useState<View>('idle');
   const [pending, startTransition] = useTransition();
   const [confirmedEmail, setConfirmedEmail] = useState('');
+  const [errorReason, setErrorReason] = useState<LoginErrorReason>('send_failed');
   const inputRef = useRef<HTMLInputElement>(null);
 
   const state: 'idle' | 'loading' | 'success' | 'error' = pending ? 'loading' : view;
@@ -30,7 +34,7 @@ export function LoginForm({ action }: Props) {
       try {
         result = await action(formData);
       } catch {
-        result = { ok: false };
+        result = { ok: false, reason: 'send_failed' };
       }
       const elapsed = Date.now() - start;
       if (elapsed < MIN_LOADING_MS) {
@@ -40,6 +44,7 @@ export function LoginForm({ action }: Props) {
         setConfirmedEmail(result.email);
         setView('success');
       } else {
+        setErrorReason(result.reason);
         setView('error');
       }
     });
@@ -80,7 +85,7 @@ export function LoginForm({ action }: Props) {
       >
         <ButtonLabel state={state} />
       </button>
-      <HelperText state={state} email={confirmedEmail} onReset={reset} />
+      <HelperText state={state} email={confirmedEmail} errorReason={errorReason} onReset={reset} />
     </form>
   );
 }
@@ -132,10 +137,11 @@ function CheckIcon() {
 type HelperProps = {
   state: 'idle' | 'loading' | 'success' | 'error';
   email: string;
+  errorReason: LoginErrorReason;
   onReset: () => void;
 };
 
-function HelperText({ state, email, onReset }: HelperProps) {
+function HelperText({ state, email, errorReason, onReset }: HelperProps) {
   return (
     <p
       role={state === 'error' ? 'alert' : undefined}
@@ -156,7 +162,9 @@ function HelperText({ state, email, onReset }: HelperProps) {
       )}
       {state === 'error' && (
         <>
-          Couldn&rsquo;t send.{' '}
+          {errorReason === 'invalid_email'
+            ? 'That doesn’t look like a valid email address.'
+            : 'Couldn’t send. Please try again.'}{' '}
           <button
             type="button"
             onClick={onReset}

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -138,7 +138,8 @@ type HelperProps = {
 function HelperText({ state, email, onReset }: HelperProps) {
   return (
     <p
-      aria-live="polite"
+      role={state === 'error' ? 'alert' : undefined}
+      aria-live={state === 'error' ? undefined : 'polite'}
       className={`text-ink-soft min-h-[1.2em] text-xs ${state === 'error' ? 'text-danger' : ''}`}
     >
       {state === 'success' && (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,7 +20,8 @@ export default async function LoginPage({
 }) {
   const params = await searchParams;
   const session = await getOrganizerSession();
-  if (session) redirect(safeCallbackUrl(params.callbackUrl));
+  const callbackUrl = safeCallbackUrl(params.callbackUrl);
+  if (session) redirect(callbackUrl);
 
   async function handle(formData: FormData): Promise<LoginActionResult> {
     'use server';
@@ -29,7 +30,7 @@ export default async function LoginPage({
     if (!parsed.success) return { ok: false, reason: 'invalid_email' };
     const email = parsed.data;
     try {
-      await signIn('nodemailer', { email, redirect: false });
+      await signIn('nodemailer', { email, redirect: false, redirectTo: callbackUrl });
       return { ok: true, email };
     } catch (error) {
       log.error({ err: error }, 'login: signIn failed');

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,12 +1,12 @@
 import { redirect } from 'next/navigation';
 import { signIn } from '@/auth/config';
 import { getOrganizerSession } from '@/auth/session';
+import { LoginForm, type LoginActionResult } from './login-form';
 
 export const metadata = { title: 'Sign in' };
 
 function safeCallbackUrl(raw: string | undefined): string {
   if (!raw) return '/app';
-  // Same-origin paths only: must start with '/', must not be protocol-relative '//' or backslash-relative.
   if (!raw.startsWith('/') || raw.startsWith('//') || raw.startsWith('/\\')) return '/app';
   return raw;
 }
@@ -20,14 +20,16 @@ export default async function LoginPage({
   const session = await getOrganizerSession();
   if (session) redirect(safeCallbackUrl(params.callbackUrl));
 
-  async function handle(formData: FormData) {
+  async function handle(formData: FormData): Promise<LoginActionResult> {
     'use server';
     const email = String(formData.get('email') ?? '').trim();
-    if (!email) return;
-    await signIn('nodemailer', {
-      email,
-      redirectTo: '/app',
-    });
+    if (!email) return { ok: false };
+    try {
+      await signIn('nodemailer', { email, redirect: false });
+      return { ok: true, email };
+    } catch {
+      return { ok: false };
+    }
   }
 
   return (
@@ -35,34 +37,15 @@ export default async function LoginPage({
       <div className="space-y-3">
         <h1 className="text-3xl font-semibold tracking-tight">Sign in to OpenSignup</h1>
         <p className="text-ink-muted">
-          Enter your email and we&apos;ll send you a magic link. No passwords.
+          Enter your email and we&apos;ll send you a magic link to sign in. No passwords.
         </p>
       </div>
-      <form action={handle} className="space-y-4">
-        <label className="block">
-          <span className="mb-1 block text-sm font-medium">Email</span>
-          <input
-            type="email"
-            name="email"
-            required
-            autoComplete="email"
-            inputMode="email"
-            className="focus:border-brand focus:ring-brand w-full rounded-lg border border-surface-sunk bg-white px-4 py-3 text-base shadow-sm transition focus:outline-none focus:ring-1"
-            placeholder="you@example.com"
-          />
-        </label>
-        <button
-          type="submit"
-          className="bg-brand w-full rounded-lg px-5 py-3 font-medium text-white transition hover:brightness-110"
-        >
-          Send magic link
-        </button>
-        {params.error ? (
-          <p className="text-danger text-sm" role="alert">
-            Something went wrong. Try again.
-          </p>
-        ) : null}
-      </form>
+      {params.error ? (
+        <p className="text-danger text-sm" role="alert">
+          Something went wrong. Try again.
+        </p>
+      ) : null}
+      <LoginForm action={handle} />
     </main>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation';
 import { signIn } from '@/auth/config';
 import { getOrganizerSession } from '@/auth/session';
+import { log } from '@/lib/log';
+import { EmailSchema } from '@/schemas/common';
 import { LoginForm, type LoginActionResult } from './login-form';
 
 export const metadata = { title: 'Sign in' };
@@ -22,13 +24,16 @@ export default async function LoginPage({
 
   async function handle(formData: FormData): Promise<LoginActionResult> {
     'use server';
-    const email = String(formData.get('email') ?? '').trim();
-    if (!email) return { ok: false };
+    const raw = String(formData.get('email') ?? '').trim();
+    const parsed = EmailSchema.safeParse(raw);
+    if (!parsed.success) return { ok: false, reason: 'invalid_email' };
+    const email = parsed.data;
     try {
       await signIn('nodemailer', { email, redirect: false });
       return { ok: true, email };
-    } catch {
-      return { ok: false };
+    } catch (error) {
+      log.error({ err: error }, 'login: signIn failed');
+      return { ok: false, reason: 'send_failed' };
     }
   }
 

--- a/src/components/signup/SignupHeader.tsx
+++ b/src/components/signup/SignupHeader.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Download, Eye } from 'lucide-react';
 import { PublicLinkChip } from '@/components/PublicLinkChip';
 import { StatusPill } from '@/components/status-pill';
+import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 
 interface SignupHeaderProps {
   signupId: string;
@@ -56,22 +57,22 @@ export function SignupHeader({
           </Link>
           {status === 'draft' ? (
             <form action={publishAction}>
-              <button
-                type="submit"
-                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
+              <AsyncSubmitButton
+                loadingLabel="Publishing…"
+                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
               >
                 Publish
-              </button>
+              </AsyncSubmitButton>
             </form>
           ) : null}
           {status === 'open' ? (
             <form action={closeAction}>
-              <button
-                type="submit"
-                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110"
+              <AsyncSubmitButton
+                loadingLabel="Closing…"
+                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
               >
                 Close signup
-              </button>
+              </AsyncSubmitButton>
             </form>
           ) : null}
         </div>

--- a/src/components/ui/async-submit-button.tsx
+++ b/src/components/ui/async-submit-button.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { Spinner } from './spinner';
+
+type Props = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'disabled'> & {
+  loadingLabel: string;
+  children: ReactNode;
+  disabled?: boolean;
+};
+
+export function AsyncSubmitButton({
+  loadingLabel,
+  children,
+  className,
+  disabled,
+  ...rest
+}: Props) {
+  const { pending } = useFormStatus();
+  const isDisabled = pending || disabled;
+
+  return (
+    <button
+      type="submit"
+      aria-busy={pending}
+      disabled={isDisabled}
+      className={className}
+      {...rest}
+    >
+      <span className="inline-flex items-center gap-2 transition-opacity duration-180 ease-emphasized">
+        {pending ? (
+          <>
+            <Spinner />
+            <span>{loadingLabel}</span>
+          </>
+        ) : (
+          children
+        )}
+      </span>
+    </button>
+  );
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,12 @@
+type SpinnerProps = {
+  className?: string;
+};
+
+export function Spinner({ className = 'size-4 border-2' }: SpinnerProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`animate-spin-720 inline-block rounded-full border-current border-t-transparent ${className}`}
+    />
+  );
+}

--- a/src/email/console.ts
+++ b/src/email/console.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { getEnv } from '@/lib/env';
 import { log } from '@/lib/log';
 import type { EmailMessage, EmailResult, EmailTransport } from './transport';
 
@@ -8,7 +9,11 @@ export class ConsoleTransport implements EmailTransport {
   async send(msg: EmailMessage): Promise<EmailResult> {
     const id = randomUUID();
     const from = msg.from ?? this.from;
-    const urls = msg.text.match(/https?:\/\/\S+/g) ?? [];
+    const matched = msg.text.match(/https?:\/\/\S+/g) ?? [];
+    // Magic-link tokens live in the query string; only emit them in dev so they
+    // don't land in prod log aggregation if EMAIL_TRANSPORT defaults to console.
+    const urls =
+      getEnv().NODE_ENV === 'development' ? matched : matched.map((u) => u.split('?')[0]);
     log.info(
       {
         emailId: id,

--- a/src/email/console.ts
+++ b/src/email/console.ts
@@ -8,12 +8,14 @@ export class ConsoleTransport implements EmailTransport {
   async send(msg: EmailMessage): Promise<EmailResult> {
     const id = randomUUID();
     const from = msg.from ?? this.from;
+    const urls = msg.text.match(/https?:\/\/\S+/g) ?? [];
     log.info(
       {
         emailId: id,
         to: msg.to,
         from,
         subject: msg.subject,
+        urls,
         textPreview: msg.text.slice(0, 600),
       },
       '[email:console] 📬 would send',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,22 @@ export default {
       boxShadow: {
         card: '0 1px 2px rgba(11,18,32,0.04), 0 4px 16px rgba(11,18,32,0.06)',
       },
+      transitionDuration: {
+        180: '180ms',
+      },
+      transitionTimingFunction: {
+        emphasized: 'cubic-bezier(0.2, 0.7, 0.2, 1)',
+      },
+      keyframes: {
+        'check-draw': {
+          from: { strokeDashoffset: '24' },
+          to: { strokeDashoffset: '0' },
+        },
+      },
+      animation: {
+        'spin-720': 'spin 720ms linear infinite',
+        'check-draw': 'check-draw 360ms cubic-bezier(0.2, 0.7, 0.2, 1) forwards',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

- **`/login` magic-link button** gets a full `idle → loading → success → error` state machine per the design handoff (Option A — Spinner swap). Kills the redirect to `/login/check`; success and error are now inline on the page with a "Send again" / "Try again" affordance. A 500 ms minimum loading hold smooths over instant dev responses so the spinner + check-draw animation arc actually registers.
- **Nine other server-action buttons** (Create signup, Save changes, Add/Remove field, Save field settings, Add/Remove slot, Publish, Close) get a shared `AsyncSubmitButton` driven by `useFormStatus` — loading label + spinner during submit, then revalidation. Three fetch-to-API buttons that already had pending states are unchanged.
- **Dev DX:** the console email transport extracts URLs from the body and logs them at the top level of the JSON, so the magic link is grabbable from the dev server output without fishing through React Email's preheader padding.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` (115 tests pass)
- [x] `/login` happy path: submit → loading (≥500 ms) → success with email + "Send again" → reset returns to idle, focuses input
- [x] Magic-link URL pulled from dev log → `/api/auth/callback/nodemailer?...` → `/app` redirect works
- [x] Create signup, add field, add slot all show loading label + spinner during submit
- [ ] Manually verify error state (set `EMAIL_TRANSPORT=resend` with bad key, submit `/login`)
- [ ] Manually verify `prefers-reduced-motion: reduce` (DevTools rendering panel) — spinner static, check no draw-on
- [ ] Manually verify keyboard a11y — tab into form, submit with Enter, focus ring intact
- [ ] Smoke `/login/check` direct hit — still renders for stale magic links

## Notes

- `/login/check` is preserved as defense-in-depth for any leaked Auth.js auto-redirects and stale links; the new flow does not navigate to it.
- Tailwind gains `duration-180`, `ease-emphasized`, `animate-spin-720`, `animate-check-draw`. Reduced-motion overrides for both animations live in `globals.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)