### PR TITLE
Remove utility functions from result module

### DIFF
--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -10,23 +10,3 @@ export function err<E>(error: E): Err<E> {
   return { ok: false, error };
 }
 
-export function isOk<T, E>(r: Result<T, E>): r is Ok<T> {
-  return r.ok;
-}
-
-export function isErr<T, E>(r: Result<T, E>): r is Err<E> {
-  return !r.ok;
-}
-
-export function unwrap<T, E>(r: Result<T, E>): T {
-  if (r.ok) return r.value;
-  throw new Error(`unwrap on Err: ${JSON.stringify(r.error)}`);
-}
-
-export async function tryAsync<T>(fn: () => Promise<T>): Promise<Result<T, unknown>> {
-  try {
-    return ok(await fn());
-  } catch (e) {
-    return err(e);
-  }
-}


### PR DESCRIPTION
## Summary
This PR removes several utility functions from the result module that are no longer needed or have been moved elsewhere.

## Changes
- Removed `isOk()` type guard function
- Removed `isErr()` type guard function
- Removed `unwrap()` function for extracting values from Result types
- Removed `tryAsync()` helper for wrapping async operations in Result types

These functions were part of the public API but are being deprecated in favor of alternative implementations or patterns.

https://claude.ai/code/session_01LxXGg24JhSve6YvC37gEZy