### PR TITLE
Add rate limiting to slot commitment endpoint

### DIFF
--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -22,8 +22,8 @@ export async function POST(
     const { id: slotId } = await ctx.params;
     const db = getDb();
     const clientIp =
-      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-      req.headers.get('x-real-ip') ??
+      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      req.headers.get('x-real-ip')?.trim() ||
       null;
     if (clientIp) {
       await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp.slice(0, 45));

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server';
+import { isIP } from 'node:net';
 import { eq } from 'drizzle-orm';
 import { getDb } from '@/db/client';
 import { signups } from '@/db/schema/signups';
@@ -21,12 +22,13 @@ export async function POST(
   return handle(async () => {
     const { id: slotId } = await ctx.params;
     const db = getDb();
-    const clientIp =
+    const rawIp =
       req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
       req.headers.get('x-real-ip')?.trim() ||
       null;
+    const clientIp = rawIp && isIP(rawIp) ? rawIp : null;
     if (clientIp) {
-      await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp.slice(0, 45));
+      await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp);
     }
     const body = await req.json().catch(() => ({}));
     const result = await commitToSlot(db, slotId, body);

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -20,13 +20,15 @@ export async function POST(
 ) {
   return handle(async () => {
     const { id: slotId } = await ctx.params;
-    const body = await req.json().catch(() => ({}));
     const db = getDb();
     const clientIp =
       req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
       req.headers.get('x-real-ip') ??
-      'unknown';
-    await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp);
+      null;
+    if (clientIp) {
+      await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp.slice(0, 45));
+    }
+    const body = await req.json().catch(() => ({}));
     const result = await commitToSlot(db, slotId, body);
     if (!result.ok) return fail(result.error);
 

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/returning-participant';
 import { serviceError } from '@/lib/errors';
 import { commitmentEditUrl, link } from '@/lib/links';
+import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
 import { commitToSlot } from '@/services/commitments';
 
 export async function POST(
@@ -21,6 +22,11 @@ export async function POST(
     const { id: slotId } = await ctx.params;
     const body = await req.json().catch(() => ({}));
     const db = getDb();
+    const clientIp =
+      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+      req.headers.get('x-real-ip') ??
+      'unknown';
+    await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp);
     const result = await commitToSlot(db, slotId, body);
     if (!result.ok) return fail(result.error);
 


### PR DESCRIPTION
## Summary
This change adds rate limiting protection to the slot commitment API endpoint to prevent abuse and ensure fair resource usage.

## Key Changes
- Import rate limiting utilities (`consumeRateLimit` and `RateLimits`) from the rate-limit library
- Extract client IP address from request headers with fallback logic:
  - Primary: `x-forwarded-for` header (first IP in the list, trimmed)
  - Secondary: `x-real-ip` header (trimmed)
  - Fallback: `null` if neither header is present
- Validate the extracted value with `net.isIP()`; non-IP / spoofed tokens are treated as `null`
- Apply rate limit check before request body parsing using `commitmentPerIp` when a valid IP is available

## Implementation Details
The rate limit is enforced per validated client IP. When no valid IP can be derived (header missing, empty, or non-IP value), the per-IP check is **skipped** rather than bucketing all such requests under a shared subject — this avoids unintentionally throttling legitimate traffic (dev/local, misconfigured proxies) and prevents pollution of `rate_limits.subject` with attacker-controlled values. The CDN/edge layer is the primary defence for requests without trustworthy IP headers in production (see comment in `rate-limit.ts`). The check runs before `req.json()` so throttled requests are rejected before body parsing work.

https://claude.ai/code/session_01C86zXdx7mPEaGYLnSbDsfu