### PR TITLE
refactor(policy): return role from requireWorkspaceAccess

### DIFF
--- a/src/lib/policy.test.ts
+++ b/src/lib/policy.test.ts
@@ -50,6 +50,11 @@ describe('policy', () => {
     expect(() => requireWorkspaceAccess(anon, 'ws_any')).toThrow(/organizer session/);
   });
 
+  it('anonymous cannot write to workspace', () => {
+    const anon: Actor = { kind: 'anonymous' };
+    expect(() => requireWorkspaceWrite(anon, 'ws_any')).toThrow(/organizer session/);
+  });
+
   it('workspaceRole returns null for anon and unknown ws', () => {
     const a = organizer({ ws_one: 'owner' });
     expect(workspaceRole(a, 'ws_unknown')).toBeNull();

--- a/src/lib/policy.test.ts
+++ b/src/lib/policy.test.ts
@@ -50,9 +50,9 @@ describe('policy', () => {
     expect(() => requireWorkspaceAccess(anon, 'ws_any')).toThrow(/organizer session/);
   });
 
-  it('anonymous cannot write to workspace', () => {
-    const anon: Actor = { kind: 'anonymous' };
-    expect(() => requireWorkspaceWrite(anon, 'ws_any')).toThrow(/organizer session/);
+  it('organizer from different workspace cannot write', () => {
+    const a = organizer({ ws_one: 'owner' });
+    expect(() => requireWorkspaceWrite(a, 'ws_other')).toThrow(/not a member/);
   });
 
   it('workspaceRole returns null for anon and unknown ws', () => {

--- a/src/lib/policy.test.ts
+++ b/src/lib/policy.test.ts
@@ -50,6 +50,11 @@ describe('policy', () => {
     expect(() => requireWorkspaceAccess(anon, 'ws_any')).toThrow(/organizer session/);
   });
 
+  it('anonymous cannot write to workspace', () => {
+    const anon: Actor = { kind: 'anonymous' };
+    expect(() => requireWorkspaceWrite(anon, 'ws_any')).toThrow(/organizer session/);
+  });
+
   it('organizer from different workspace cannot write', () => {
     const a = organizer({ ws_one: 'owner' });
     expect(() => requireWorkspaceWrite(a, 'ws_other')).toThrow(/not a member/);

--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -60,15 +60,14 @@ export function requireWorkspaceAccess(actor: Actor, workspaceId: string | null)
 
 export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null): void {
   requireWorkspaceAccess(actor, workspaceId);
-  if (workspaceId !== null) {
-    const role = workspaceRole(actor, workspaceId);
-    if (!role || !ROLE_CAN_WRITE[role]) {
-      throw new ServiceException(
-        serviceError('forbidden', 'your role cannot modify this workspace', {
-          suggestion: 'ask an owner or editor',
-        }),
-      );
-    }
+  if (workspaceId === null) return;
+  const role = workspaceRole(actor, workspaceId);
+  if (!role || !ROLE_CAN_WRITE[role]) {
+    throw new ServiceException(
+      serviceError('forbidden', 'your role cannot modify this workspace', {
+        suggestion: 'ask an owner or editor',
+      }),
+    );
   }
 }
 

--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -46,23 +46,24 @@ export function requireOrganizerId(actor: Actor): string {
   return actor.id;
 }
 
-export function requireWorkspaceAccess(actor: Actor, workspaceId: string | null): void {
-  if (workspaceId === null) return; // guest-scope, only covered by ownership checks elsewhere
+export function requireWorkspaceAccess(actor: Actor, workspaceId: string | null): WorkspaceRole | null {
+  if (workspaceId === null) return null; // guest-scope, only covered by ownership checks elsewhere
   requireOrganizer(actor);
-  if (!isInWorkspace(actor, workspaceId)) {
+  const role = workspaceRole(actor, workspaceId);
+  if (!role) {
     throw new ServiceException(
       serviceError('forbidden', 'not a member of that workspace', {
         suggestion: 'switch to the correct workspace or ask an owner to invite you',
       }),
     );
   }
+  return role;
 }
 
 export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null): void {
-  requireWorkspaceAccess(actor, workspaceId);
-  if (workspaceId === null) return;
-  const role = workspaceRole(actor, workspaceId);
-  if (!role || !ROLE_CAN_WRITE[role]) {
+  const role = requireWorkspaceAccess(actor, workspaceId);
+  if (role === null) return;
+  if (!ROLE_CAN_WRITE[role]) {
     throw new ServiceException(
       serviceError('forbidden', 'your role cannot modify this workspace', {
         suggestion: 'ask an owner or editor',

--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -60,7 +60,7 @@ export function requireWorkspaceAccess(actor: Actor, workspaceId: string | null)
 
 export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null): void {
   requireWorkspaceAccess(actor, workspaceId);
-  if (workspaceId && actor.kind === 'organizer') {
+  if (workspaceId !== null) {
     const role = workspaceRole(actor, workspaceId);
     if (!role || !ROLE_CAN_WRITE[role]) {
       throw new ServiceException(


### PR DESCRIPTION
## Summary
Refactor of `src/lib/policy.ts` — no behavior change for any caller. The original framing as an anonymous-write *bypass* was incorrect: `requireWorkspaceWrite` calls `requireWorkspaceAccess` first, which calls `requireOrganizer`, so anonymous and participant actors were already rejected for any non-null `workspaceId`. The conditions removed here were dead code, not a security gap.

## Changes
- `requireWorkspaceAccess` now returns `WorkspaceRole | null` (null for the guest-scope `workspaceId === null` case) instead of `void`.
- `requireWorkspaceWrite` consumes that returned role directly:
  - removes the redundant second `workspaceRole()` lookup
  - removes the dead `actor.kind === 'organizer'` guard (unreachable-false after `requireWorkspaceAccess` succeeds)
  - removes the dead `!role` null guard (`requireWorkspaceAccess` would have thrown)
  - early-returns on the guest-scope null case, mirroring `requireWorkspaceAccess`'s shape
- Added two `policy.test.ts` cases:
  - `anonymous cannot write to workspace` — documents that `requireWorkspaceWrite` rejects non-organizers via its `requireWorkspaceAccess` delegation.
  - `organizer from different workspace cannot write` — exercises the membership guard inside `requireWorkspaceWrite`'s call to `requireWorkspaceAccess`.

## Compatibility
The `void → WorkspaceRole | null` widening is non-breaking: all 12 existing call sites use these functions purely for their throw side-effects.

## Verification
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 141/141 pass (12 in `policy.test.ts`)