### PR TITLE
Fix workspace write permission check logic

### DIFF
--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -60,7 +60,7 @@ export function requireWorkspaceAccess(actor: Actor, workspaceId: string | null)
 
 export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null): void {
   requireWorkspaceAccess(actor, workspaceId);
-  if (workspaceId && actor.kind === 'organizer') {
+  if (workspaceId !== null) {
     const role = workspaceRole(actor, workspaceId);
     if (!role || !ROLE_CAN_WRITE[role]) {
       throw new ServiceException(


### PR DESCRIPTION
## Summary
Fixed the condition in `requireWorkspaceWrite` to properly validate workspace write permissions by checking if `workspaceId` is not null, rather than also checking the actor kind.

## Key Changes
- Changed the permission check condition from `workspaceId && actor.kind === 'organizer'` to `workspaceId !== null`
- This ensures the role-based write permission validation is performed for all actor types when a workspace ID is present, not just for organizers

## Implementation Details
The previous condition was overly restrictive by only performing the role check for organizer actors. The updated logic now:
- Explicitly checks that `workspaceId` is not null (more precise than truthy check)
- Applies the role-based write permission validation consistently across all actor kinds
- Maintains the existing role validation logic that follows the condition

https://claude.ai/code/session_012oP1pakxrcAHixf24YZkzm