### PR TITLE
Refactor commitment response to include signup slug

### DIFF
--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -1,15 +1,11 @@
 import type { NextRequest } from 'next/server';
-import { eq } from 'drizzle-orm';
 import { getDb } from '@/db/client';
-import { signups } from '@/db/schema/signups';
-import { slots } from '@/db/schema/slots';
 import { fail, handle, respond } from '@/lib/api-response';
 import {
   COMMIT_COOKIE_NAME,
   appendReturningCommit,
   setReturningCommitCookie,
 } from '@/lib/returning-participant';
-import { serviceError } from '@/lib/errors';
 import { commitmentEditUrl, link } from '@/lib/links';
 import { commitToSlot } from '@/services/commitments';
 
@@ -24,14 +20,7 @@ export async function POST(
     const result = await commitToSlot(db, slotId, body);
     if (!result.ok) return fail(result.error);
 
-    const slotRow = await db.select().from(slots).where(eq(slots.id, slotId)).limit(1);
-    const first = slotRow[0];
-    if (!first) return fail(serviceError('not_found', 'slot vanished'));
-    const signupRow = await db.select().from(signups).where(eq(signups.id, first.signupId)).limit(1);
-    const sig = signupRow[0];
-    if (!sig) return fail(serviceError('not_found', 'signup missing'));
-
-    const editUrl = commitmentEditUrl(sig.slug, result.value.commitment.id, result.value.editToken);
+    const editUrl = commitmentEditUrl(result.value.signupSlug, result.value.commitment.id, result.value.editToken);
     const response = respond(
       { ok: true, value: { ...result.value, editUrl } },
       {
@@ -47,7 +36,7 @@ export async function POST(
       req.cookies.get(COMMIT_COOKIE_NAME)?.value ?? null,
       result.value.commitment.id,
       result.value.editToken,
-      sig.id,
+      result.value.commitment.signupId,
     );
     setReturningCommitCookie(response, nextCookie);
     return response;

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -20,23 +20,24 @@ export async function POST(
     const result = await commitToSlot(db, slotId, body);
     if (!result.ok) return fail(result.error);
 
-    const editUrl = commitmentEditUrl(result.value.signupSlug, result.value.commitment.id, result.value.editToken);
+    const { signupSlug, ...responseValue } = result.value;
+    const editUrl = commitmentEditUrl(signupSlug, responseValue.commitment.id, responseValue.editToken);
     const response = respond(
-      { ok: true, value: { ...result.value, editUrl } },
+      { ok: true, value: { ...responseValue, editUrl } },
       {
         edit: link(editUrl),
-        self: link(`/api/commitments/${result.value.commitment.id}?token=${result.value.editToken}`),
+        self: link(`/api/commitments/${responseValue.commitment.id}?token=${responseValue.editToken}`),
         cancel: link(
-          `/api/commitments/${result.value.commitment.id}?token=${result.value.editToken}`,
+          `/api/commitments/${responseValue.commitment.id}?token=${responseValue.editToken}`,
           'DELETE',
         ),
       },
     );
     const nextCookie = appendReturningCommit(
       req.cookies.get(COMMIT_COOKIE_NAME)?.value ?? null,
-      result.value.commitment.id,
-      result.value.editToken,
-      result.value.commitment.signupId,
+      responseValue.commitment.id,
+      responseValue.editToken,
+      responseValue.commitment.signupId,
     );
     setReturningCommitCookie(response, nextCookie);
     return response;

--- a/src/services/commitments.db.test.ts
+++ b/src/services/commitments.db.test.ts
@@ -5,6 +5,7 @@ import { activity } from '@/db/schema/activity';
 import { commitments } from '@/db/schema/commitments';
 import { workspaceMembers } from '@/db/schema/members';
 import { organizers } from '@/db/schema/organizers';
+import { signups } from '@/db/schema/signups';
 import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
 import type { Actor } from '@/lib/policy';
@@ -86,6 +87,36 @@ async function makeOpenSignupWithSlot(fx: Fixture, title: string) {
 
   return { signupId: created.value.id, slotId: slot.value.id };
 }
+
+describe('commitToSlot (db)', () => {
+  let fx: Fixture;
+
+  beforeAll(async () => {
+    fx = await setupWorkspace();
+  });
+
+  afterAll(async () => {
+    await teardownWorkspace(fx.db, fx.workspaceId, fx.organizerId);
+  });
+
+  it('returns signupSlug matching the signup slug', async () => {
+    const { signupId, slotId } = await makeOpenSignupWithSlot(fx, 'Slug test signup');
+    const [signupRow] = await fx.db
+      .select({ slug: signups.slug })
+      .from(signups)
+      .where(eq(signups.id, signupId))
+      .limit(1);
+    if (!signupRow) throw new Error('signup not found');
+
+    const result = await commitToSlot(fx.db, slotId, {
+      name: 'Slug Tester',
+      email: 'slugtester@example.test',
+      quantity: 1,
+    });
+    if (!result.ok) throw new Error(`commitToSlot failed: ${result.error.message}`);
+    expect(result.value.signupSlug).toBe(signupRow.slug);
+  });
+});
 
 describe('updateOwnCommitment swap (db)', () => {
   let fx: Fixture;

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -22,6 +22,7 @@ type CommitmentRow = typeof commitments.$inferSelect;
 export interface CommitResult {
   commitment: CommitmentRow;
   editToken: string;
+  signupSlug: string;
 }
 
 export async function commitToSlot(
@@ -212,7 +213,7 @@ export async function commitToSlot(
       payload: { commitmentId, slotId },
     });
 
-    return ok({ commitment: row, editToken });
+    return ok({ commitment: row, editToken, signupSlug: signupRow.slug });
   });
 }
 


### PR DESCRIPTION
## Summary
Refactored the commitment creation flow to reduce database queries and improve data encapsulation by returning the signup slug from the `commitToSlot` service function instead of querying for it in the route handler.

## Key Changes
- Modified `CommitResult` interface to include `signupSlug` field
- Updated `commitToSlot` service to return the signup slug alongside the commitment and edit token
- Removed redundant database queries from the POST route handler that were fetching slot and signup records
- Simplified the route handler to use the signup slug directly from the service response

## Implementation Details
- The signup slug is now retrieved once within the `commitToSlot` transaction and included in the response, eliminating the need for separate queries in the route handler
- This change maintains the same external behavior while reducing database round trips and improving code maintainability
- The `appendReturningCommit` call now uses `result.value.commitment.signupId` instead of the separately queried `sig.id`

https://claude.ai/code/session_01UCUK1RfhAU2gVd5H1RNu83