### PR TITLE
Remove sendMagicLink email function

### DIFF
--- a/src/email/send.ts
+++ b/src/email/send.ts
@@ -1,18 +1,7 @@
 import { createElement } from 'react';
 import { getEmailTransport } from './index';
-import { MagicLinkEmail, type MagicLinkEmailProps } from './templates/magic-link';
 import { ReminderEmail, type ReminderEmailProps } from './templates/reminder';
 import { renderEmail } from './render';
-
-export async function sendMagicLink(to: string, props: MagicLinkEmailProps) {
-  const { html, text } = await renderEmail(createElement(MagicLinkEmail, props));
-  return getEmailTransport().send({
-    to,
-    subject: 'Sign in to OpenSignup',
-    html,
-    text,
-  });
-}
 
 export async function sendReminder(to: string, props: ReminderEmailProps) {
   const { html, text } = await renderEmail(createElement(ReminderEmail, props));


### PR DESCRIPTION
## Summary
Removed the `sendMagicLink` function from the email sending module as it is no longer needed.

## Changes
- Removed `sendMagicLink` async function that handled sending magic link authentication emails
- Removed the import of `MagicLinkEmail` component and its type definition
- Kept the `sendReminder` function and other email infrastructure intact

## Notes
This appears to be a cleanup of unused email functionality. The magic link authentication feature has been removed or replaced with an alternative approach.

https://claude.ai/code/session_01RUR65PHT518Z3HgPrPmCVs