### PR TITLE
Remove pagination and HATEOAS schemas from common

### DIFF
--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -29,23 +29,3 @@ export const DateOnlySchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD');
 
-export const PaginationSchema = z.object({
-  limit: z.coerce.number().int().positive().max(100).default(50),
-  cursor: z.string().optional(),
-});
-
-export const HateoasLinkSchema = z.object({
-  href: z.string(),
-  method: z.enum(['GET', 'POST', 'PATCH', 'DELETE']).default('GET'),
-  rel: z.string().optional(),
-});
-
-export type HateoasLink = z.infer<typeof HateoasLinkSchema>;
-
-export function envelope<T extends z.ZodTypeAny>(data: T) {
-  return z.object({
-    data,
-    _links: z.record(z.string(), HateoasLinkSchema.or(z.string())).optional(),
-    idempotencyKey: z.string().optional(),
-  });
-}


### PR DESCRIPTION
## Summary
Removed pagination and HATEOAS-related schema definitions from the common schemas module. These schemas are no longer needed in the shared schema definitions.

## Changes
- Removed `PaginationSchema` - schema for cursor-based pagination with limit and cursor parameters
- Removed `HateoasLinkSchema` - schema for HATEOAS link objects with href, method, and rel properties
- Removed `HateoasLink` type export - TypeScript type inference from HateoasLinkSchema
- Removed `envelope()` helper function - utility function for wrapping response data with HATEOAS links and idempotency keys

## Notes
These schemas and utilities were likely moved to a more specific location or are no longer required by the application architecture.

https://claude.ai/code/session_012CP51kmZBLLurKALUy5iAH