### PR TITLE
Add telemetry and activity logging for signup views and interactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Helpers used by every service:
 - `src/lib/result.ts` — `Result<T, E>`, `ok`, `err`. Services return `Result`; route handlers convert to HTTP via `api-response.ts`.
 - `src/lib/errors.ts` — `ServiceError` with `code` from a closed enum (`not_found | conflict | capacity_full | closed | forbidden | unauthorized | invalid_input | rate_limited | already_consumed | internal`), `httpStatusFor`, `fromZodError`, `ServiceException` (thrown by guards).
 - `src/lib/parse.ts` — wraps Zod parsing into a `Result`.
-- `src/lib/activity.ts` — `recordActivity(tx, …)` writes to the append-only activity log **inside the same transaction** as the mutation it describes.
+- `src/lib/activity.ts` — `recordActivity(tx, …)` writes to the append-only activity log **inside the same transaction** as the mutation it describes. Telemetry-only events (no describing mutation) write outside a tx; see `src/lib/view-tracker.ts` and `safeRecordAttemptFailed` in `src/services/commitments.ts`.
 - `src/lib/ids.ts` — UUIDv7 + base62 + 3–4 char type prefix (`sig_`, `slot_`, `org_`, `ws_`, `mem_`, `com_`, `par_`).
 - `src/lib/idempotency.ts`, `src/lib/rate-limit.ts` — Postgres-backed (no Redis); applied at API boundaries.
 
@@ -96,7 +96,7 @@ From `CONTRIBUTING.md` and the v1 plan:
 - **Workspace scoping at the policy layer.** No raw DB query in a service without a `requireWorkspaceAccess` / `requireWorkspaceWrite` upstream.
 - **TDD for pure logic** (capacity, slugs, IDs, email-typo suggestion, policy, env). UI is not TDD'd; covered by Playwright smokes.
 - **No vendor lock-in.** Anything requiring an external account (Resend, Sentry, PostHog) must be opt-in via env var with a console/noop default.
-- **Activity log is append-only and writes inside the same transaction as the mutation.**
+- **Activity log is append-only and writes inside the same transaction as the mutation.** Telemetry-only events that don't describe a mutation (page views, auth funnel, attempt-failed) are an exception: write them outside the tx (or via a SAVEPOINT helper if the only entry point is inside one) so a transient activity-insert failure never aborts the user's actual operation. See `safeRecordAttemptFailed` in `src/services/commitments.ts` and the `workspace.created` write in `src/auth/adapter.ts` for the patterns.
 - **`pnpm lint && pnpm typecheck && pnpm test` must pass before any PR.**
 
 ## Test layout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Run `pnpm test` for unit tests, `pnpm test:db` for integration tests against the
 - Include tests. For service logic, tests are required and go first (TDD).
 - `pnpm lint && pnpm typecheck && pnpm test` must pass locally.
 - UI changes should include a Playwright smoke or a screenshot.
+- If you add or change an `ACTIVITY_EVENTS` entry or its payload shape, update [`docs/telemetry.md`](docs/telemetry.md).
 
 ## Reporting security issues
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,247 @@
+# Telemetry
+
+OpenSignup writes an append-only event log to the `activity` table in
+Postgres. There is no built-in analytics dashboard — by design. Operators
+point Metabase, Grafana, Superset, or any SQL-aware BI tool at the database
+and answer whatever question they care about.
+
+## Schema
+
+Source: [`src/db/schema/activity.ts`](../src/db/schema/activity.ts).
+
+| column         | type           | notes                                                  |
+|----------------|----------------|--------------------------------------------------------|
+| `id`           | text PK        | prefix `act_`                                          |
+| `signup_id`    | text FK        | nullable; cascade delete                               |
+| `workspace_id` | text FK        | nullable; cascade delete                               |
+| `actor_id`     | text           | organizer id, participant id, or NULL for system       |
+| `actor_type`   | text           | `'organizer'` &#124; `'participant'` &#124; `'system'` |
+| `event_type`   | text           | one of the events below                                |
+| `payload`      | jsonb          | event-specific; see catalogue                          |
+| `occurred_at`  | timestamptz    | defaults to `now()`                                    |
+
+Indices: `(signup_id, occurred_at)`, `(workspace_id, occurred_at)`, `(event_type)`.
+The column is `text`, not a PG enum, so adding a new event type is a code-only
+change — no migration required.
+
+## Event catalogue
+
+Every entry maps to a fired event in the codebase. If you change a payload
+shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
+
+### Signup lifecycle
+
+| event | actor | payload | fired from |
+|---|---|---|---|
+| `signup.created` | organizer | `{ title }` | `services/signups.ts` |
+| `signup.updated` | organizer | `{ changes }` | `services/signups.ts` |
+| `signup.published` | organizer | `{}` | `services/signups.ts` |
+| `signup.closed` | organizer | `{}` | `services/signups.ts` |
+| `signup.archived` | organizer | `{}` | `services/signups.ts` |
+| `signup.duplicated` | organizer | `{ sourceSignupId }` | `services/signups.ts` |
+| `signup.deleted` | organizer | `{}` | `services/signups.ts` |
+| `signup.draft_started` | organizer | `{}` | RSC at `/app/signups/new` |
+| `signup.editor_opened` | organizer | `{ section: 'fields' \| 'slots' \| 'settings' \| 'responses' }` | RSC under `/app/signups/[id]/...` |
+| `signup.previewed` | organizer | `{}` | RSC at `/app/signups/[id]/preview` |
+| `signup.viewed` | system | `{ uaClass, refererHost, isReturning, signupStatus }` | RSC at `/s/[slug]` |
+
+### Slot / field lifecycle
+
+| event | actor | payload | fired from |
+|---|---|---|---|
+| `slot.created` / `slot.updated` / `slot.deleted` | organizer | `{ ref }` | `services/slots.ts` |
+| `field.created` / `field.updated` / `field.deleted` | organizer | `{ ref, fieldType }` | `services/slot-fields.ts` |
+
+### Participant funnel
+
+| event | actor | payload | fired from |
+|---|---|---|---|
+| `participant.created` | participant | `{ participantId }` | `services/commitments.ts` |
+| `commitment.created` | participant | `{ commitmentId, slotId }` | `services/commitments.ts` |
+| `commitment.updated` | participant | `{ changes }` | `services/commitments.ts` |
+| `commitment.cancelled` | participant | `{ slotId }` | `services/commitments.ts` |
+| `commitment.swapped` | participant | `{ from, to }` | `services/commitments.ts` |
+| `commitment.orphaned` | system | `{ slotId }` | `services/commitments.ts` |
+| `commitment.attempt_failed` | system or participant | `{ slotId, reason: 'closed' \| 'over_window' \| 'capacity_full', detail?, requested?, remaining? }` | `services/commitments.ts` (each rejection site) |
+| `commitment.edit_link_followed` | participant | `{ commitmentId }` | RSC at `/s/[slug]/c/[id]` |
+
+### Reminder pipeline
+
+| event | actor | payload | fired from |
+|---|---|---|---|
+| `reminder.scheduled` | system | `{ commitmentId, sendAt }` | `services/commitments.ts` |
+| `reminder.sent` | system | `{ commitmentId, channel }` | `jobs/reminders.ts` |
+| `reminder.failed` | system | `{ commitmentId, error }` | `jobs/reminders.ts` |
+
+### Auth & workspace
+
+| event | actor | payload | fired from |
+|---|---|---|---|
+| `auth.magic_link_sent` | system | `{ email, expiresInMinutes }` | `auth/config.ts` (`sendVerificationRequest`) |
+| `auth.signed_in` | organizer | `{ isNewUser }` | `auth/config.ts` (`events.signIn`) |
+| `workspace.created` | organizer | `{ kind: 'personal' }` | `auth/adapter.ts` (first-login tx) |
+
+> Note: `auth.magic_link_sent` and `auth.signed_in` are workspace-scoped to
+> `NULL` because magic-link delivery happens before the workspace is known
+> (and after, in the case of the response). Filter by `event_type` alone
+> when computing auth funnels.
+
+## Privacy guarantees
+
+The `signup.viewed` and `commitment.edit_link_followed` events are
+deliberately minimal:
+
+- **No IP address.** Postgres receives no client IP for view events.
+- **No request body, form input, or email address** (in view events).
+- `uaClass` is one of `'browser'` / `'bot'` / `'unknown'` — never the full
+  User-Agent string.
+- `refererHost` is the host only (e.g. `news.ycombinator.com`), never the
+  path or query string.
+- `DNT: 1` and `Sec-GPC: 1` short-circuit the insert before any DB write.
+- Bots are skipped via a User-Agent regex.
+
+`auth.magic_link_sent` deliberately keeps the email address in the payload
+(it's necessary to compute consumption rate by linking with `auth.signed_in`).
+Treat the activity table as PII-bearing for retention purposes.
+
+## Workspace scoping
+
+Every analytics query against tenant-scoped events **must** include
+`workspace_id = $1`. Missing this predicate mixes data across workspaces.
+The application enforces it at the policy layer; BI consumers must enforce
+it in their queries.
+
+## Example queries
+
+### Daily signups created (last 30 days)
+
+```sql
+SELECT date_trunc('day', occurred_at) AS day, count(*)
+FROM activity
+WHERE workspace_id = $1
+  AND event_type = 'signup.created'
+  AND occurred_at >= now() - interval '30 days'
+GROUP BY 1
+ORDER BY 1;
+```
+
+### View → commit funnel per signup (last 30 days)
+
+```sql
+SELECT
+  s.id, s.title,
+  count(*) FILTER (WHERE a.event_type = 'signup.viewed')                                       AS views,
+  count(*) FILTER (WHERE a.event_type = 'signup.viewed' AND a.payload->>'isReturning' = 'true') AS views_returning,
+  count(*) FILTER (WHERE a.event_type = 'signup.viewed' AND a.payload->>'uaClass'    = 'bot')   AS views_bot,
+  count(*) FILTER (WHERE a.event_type = 'commitment.created')                                  AS commits,
+  count(*) FILTER (WHERE a.event_type = 'commitment.attempt_failed')                           AS attempt_failures,
+  count(*) FILTER (WHERE a.event_type = 'commitment.cancelled')                                AS cancels
+FROM activity a
+JOIN signups s ON s.id = a.signup_id
+WHERE a.workspace_id = $1
+  AND a.occurred_at >= now() - interval '30 days'
+GROUP BY s.id, s.title
+ORDER BY views DESC;
+```
+
+### Magic-link consumption rate (last 7 days)
+
+```sql
+SELECT
+  count(*) FILTER (WHERE event_type = 'auth.magic_link_sent') AS sent,
+  count(*) FILTER (WHERE event_type = 'auth.signed_in')       AS signed_in,
+  count(*) FILTER (WHERE event_type = 'auth.signed_in'
+                     AND payload->>'isNewUser' = 'true')      AS first_logins
+FROM activity
+WHERE occurred_at >= now() - interval '7 days';
+```
+
+### Commit-attempt failures broken down by reason
+
+```sql
+SELECT
+  payload->>'reason' AS reason,
+  count(*)
+FROM activity
+WHERE workspace_id = $1
+  AND event_type = 'commitment.attempt_failed'
+  AND occurred_at >= now() - interval '30 days'
+GROUP BY 1
+ORDER BY 2 DESC;
+```
+
+### Reminder pipeline health (last 7 days)
+
+```sql
+SELECT
+  count(*) FILTER (WHERE event_type = 'reminder.scheduled') AS scheduled,
+  count(*) FILTER (WHERE event_type = 'reminder.sent')      AS sent,
+  count(*) FILTER (WHERE event_type = 'reminder.failed')    AS failed
+FROM activity
+WHERE workspace_id = $1
+  AND occurred_at >= now() - interval '7 days';
+```
+
+### Organizer engagement: editor pageviews per section
+
+```sql
+SELECT
+  payload->>'section' AS section,
+  count(*) AS opens,
+  count(DISTINCT actor_id) AS distinct_organizers
+FROM activity
+WHERE workspace_id = $1
+  AND event_type = 'signup.editor_opened'
+  AND occurred_at >= now() - interval '30 days'
+GROUP BY 1
+ORDER BY 2 DESC;
+```
+
+### Bot / DNT impact check (sanity)
+
+```sql
+SELECT payload->>'uaClass' AS ua_class, count(*)
+FROM activity
+WHERE event_type = 'signup.viewed'
+GROUP BY 1;
+-- expected: 'browser' >> 'unknown' > 0; 'bot' should be 0 (filtered upstream).
+```
+
+## Operational notes
+
+### Volume
+
+Pageview-shaped events (`signup.editor_opened`, `signup.previewed`,
+`signup.viewed`, `signup.draft_started`, `commitment.edit_link_followed`)
+fire on every RSC render. Refreshes count. The activity table grows mostly
+with these events. All dashboard queries should filter on `event_type` so
+read performance scales with the queried subset, not the table size.
+
+If write volume becomes a concern, splitting pageview events into a separate
+table is a future optimization and would not change the egress contract
+documented here.
+
+### Adding event types
+
+1. Append the new string literal to the `ACTIVITY_EVENTS` tuple in
+   `src/db/schema/activity.ts`.
+2. Fire it via `recordActivity(tx, { ... })` from a service or RSC.
+3. Update the catalogue in this file.
+
+The TypeScript compiler will enforce that every `recordActivity` call site
+uses a known event type.
+
+### What's not captured
+
+- Slot click / commit-dialog open on the participant page — would require
+  client JS, deliberately excluded to keep `/s/[slug]` vendor-free and
+  privacy-friendly.
+- Share-link copy on the organizer side — would require client JS.
+- Email delivery, bounce, or complaint events — would require a Resend
+  webhook handler. Not implemented; magic-link / reminder delivery success
+  is currently observable only via `reminder.sent` / `reminder.failed` and
+  pino logs.
+- HTTP errors and Web Vitals — these belong in pino + Sentry, not the
+  activity log. Sentry env stubs (`SENTRY_DSN`) exist in `src/lib/env.ts`
+  but are not yet wired up; see Task 2.8 in
+  [`docs/plans/2026-04-19-signup-v1.md`](plans/2026-04-19-signup-v1.md).

--- a/src/app/app/(chrome)/signups/[id]/fields/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/fields/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { after } from 'next/server';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { fieldEnumChoices, fieldTypeLabel } from '@/lib/field-labels';
@@ -15,13 +16,15 @@ export default async function FieldsTab({ params }: PageParams) {
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
-  void recordOrganizerView({
-    actor: { actorId: session.organizerId, actorType: 'organizer' },
-    signupId: sig.id,
-    workspaceId: sig.workspaceId,
-    eventType: 'signup.editor_opened',
-    payload: { section: 'fields' },
-  });
+  after(() =>
+    recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      eventType: 'signup.editor_opened',
+      payload: { section: 'fields' },
+    }),
+  );
   const fields = sig.fields;
   const dateFieldCount = fields.filter((f) => f.fieldType === 'date').length;
   const settings = (sig.settings ?? {}) as {

--- a/src/app/app/(chrome)/signups/[id]/fields/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/fields/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { fieldEnumChoices, fieldTypeLabel } from '@/lib/field-labels';
+import { recordOrganizerView } from '@/lib/view-tracker';
 import AddFieldForm from '../add-field-form';
 import { addFieldAction, deleteFieldAction, updateSettingsAction } from '../actions';
 
@@ -14,6 +15,13 @@ export default async function FieldsTab({ params }: PageParams) {
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
+  void recordOrganizerView({
+    actor: { actorId: session.organizerId, actorType: 'organizer' },
+    signupId: sig.id,
+    workspaceId: sig.workspaceId,
+    eventType: 'signup.editor_opened',
+    payload: { section: 'fields' },
+  });
   const fields = sig.fields;
   const dateFieldCount = fields.filter((f) => f.fieldType === 'date').length;
   const settings = (sig.settings ?? {}) as {

--- a/src/app/app/(chrome)/signups/[id]/responses/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/responses/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { after } from 'next/server';
 import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
@@ -28,13 +29,15 @@ export default async function ResponsesTab({ params }: PageParams) {
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
-  void recordOrganizerView({
-    actor: { actorId: session.organizerId, actorType: 'organizer' },
-    signupId: sig.id,
-    workspaceId: sig.workspaceId,
-    eventType: 'signup.editor_opened',
-    payload: { section: 'responses' },
-  });
+  after(() =>
+    recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      eventType: 'signup.editor_opened',
+      payload: { section: 'responses' },
+    }),
+  );
   const commitments = await listCommitmentsForSignup(getDb(), id);
 
   return (

--- a/src/app/app/(chrome)/signups/[id]/responses/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/responses/page.tsx
@@ -4,6 +4,7 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { listCommitmentsForSignup } from '@/services/commitments';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+import { recordOrganizerView } from '@/lib/view-tracker';
 
 type PageParams = { params: Promise<{ id: string }> };
 
@@ -27,6 +28,13 @@ export default async function ResponsesTab({ params }: PageParams) {
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
+  void recordOrganizerView({
+    actor: { actorId: session.organizerId, actorType: 'organizer' },
+    signupId: sig.id,
+    workspaceId: sig.workspaceId,
+    eventType: 'signup.editor_opened',
+    payload: { section: 'responses' },
+  });
   const commitments = await listCommitmentsForSignup(getDb(), id);
 
   return (

--- a/src/app/app/(chrome)/signups/[id]/settings/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/settings/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { after } from 'next/server';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { recordOrganizerView } from '@/lib/view-tracker';
@@ -17,13 +18,15 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
-  void recordOrganizerView({
-    actor: { actorId: session.organizerId, actorType: 'organizer' },
-    signupId: sig.id,
-    workspaceId: sig.workspaceId,
-    eventType: 'signup.editor_opened',
-    payload: { section: 'settings' },
-  });
+  after(() =>
+    recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      eventType: 'signup.editor_opened',
+      payload: { section: 'settings' },
+    }),
+  );
 
   return (
     <section className="max-w-2xl space-y-6">

--- a/src/app/app/(chrome)/signups/[id]/settings/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
+import { recordOrganizerView } from '@/lib/view-tracker';
 import { updateBasicsAction } from '../actions';
 
 type PageParams = {
@@ -16,6 +17,13 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
+  void recordOrganizerView({
+    actor: { actorId: session.organizerId, actorType: 'organizer' },
+    signupId: sig.id,
+    workspaceId: sig.workspaceId,
+    eventType: 'signup.editor_opened',
+    payload: { section: 'settings' },
+  });
 
   return (
     <section className="max-w-2xl space-y-6">

--- a/src/app/app/(chrome)/signups/[id]/slots/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/slots/page.tsx
@@ -6,6 +6,7 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { listCommitmentsForSignup } from '@/services/commitments';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+import { recordOrganizerView } from '@/lib/view-tracker';
 import { addSlotAction, deleteSlotAction } from '../actions';
 
 type PageParams = { params: Promise<{ id: string }> };
@@ -30,6 +31,13 @@ export default async function SlotsTab({ params }: PageParams) {
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
+  void recordOrganizerView({
+    actor: { actorId: session.organizerId, actorType: 'organizer' },
+    signupId: sig.id,
+    workspaceId: sig.workspaceId,
+    eventType: 'signup.editor_opened',
+    payload: { section: 'slots' },
+  });
   const fields = sig.fields;
   const commitments = await listCommitmentsForSignup(getDb(), id);
 

--- a/src/app/app/(chrome)/signups/[id]/slots/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/slots/page.tsx
@@ -6,6 +6,7 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { listCommitmentsForSignup } from '@/services/commitments';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+import { after } from 'next/server';
 import { recordOrganizerView } from '@/lib/view-tracker';
 import { addSlotAction, deleteSlotAction } from '../actions';
 
@@ -31,13 +32,15 @@ export default async function SlotsTab({ params }: PageParams) {
   const result = await loadSignupForOrganizer(toActor(session), id);
   if (!result.ok) return null;
   const sig = result.value;
-  void recordOrganizerView({
-    actor: { actorId: session.organizerId, actorType: 'organizer' },
-    signupId: sig.id,
-    workspaceId: sig.workspaceId,
-    eventType: 'signup.editor_opened',
-    payload: { section: 'slots' },
-  });
+  after(() =>
+    recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      eventType: 'signup.editor_opened',
+      payload: { section: 'slots' },
+    }),
+  );
   const fields = sig.fields;
   const commitments = await listCommitmentsForSignup(getDb(), id);
 

--- a/src/app/app/(chrome)/signups/new/page.tsx
+++ b/src/app/app/(chrome)/signups/new/page.tsx
@@ -2,12 +2,22 @@ import { redirect } from 'next/navigation';
 import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { createSignup } from '@/services/signups';
+import { recordOrganizerView } from '@/lib/view-tracker';
 
 export const metadata = { title: 'New signup' };
 
 export default async function NewSignupPage() {
   const session = await getOrganizerSession();
   if (!session) redirect('/login?callbackUrl=/app/signups/new');
+
+  if (session.defaultWorkspaceId) {
+    void recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: null,
+      workspaceId: session.defaultWorkspaceId,
+      eventType: 'signup.draft_started',
+    });
+  }
 
   async function createAction(formData: FormData) {
     'use server';

--- a/src/app/app/(chrome)/signups/new/page.tsx
+++ b/src/app/app/(chrome)/signups/new/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { after } from 'next/server';
 import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { createSignup } from '@/services/signups';
@@ -11,12 +12,15 @@ export default async function NewSignupPage() {
   if (!session) redirect('/login?callbackUrl=/app/signups/new');
 
   if (session.defaultWorkspaceId) {
-    void recordOrganizerView({
-      actor: { actorId: session.organizerId, actorType: 'organizer' },
-      signupId: null,
-      workspaceId: session.defaultWorkspaceId,
-      eventType: 'signup.draft_started',
-    });
+    const workspaceId = session.defaultWorkspaceId;
+    after(() =>
+      recordOrganizerView({
+        actor: { actorId: session.organizerId, actorType: 'organizer' },
+        signupId: null,
+        workspaceId,
+        eventType: 'signup.draft_started',
+      }),
+    );
   }
 
   async function createAction(formData: FormData) {

--- a/src/app/app/signups/[id]/preview/page.tsx
+++ b/src/app/app/signups/[id]/preview/page.tsx
@@ -5,6 +5,7 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import type { SignupStatus } from '@/schemas/signups';
 import type { SlotStatus } from '@/schemas/slots';
 import { getSignupForOrganizer } from '@/services/signups';
+import { recordOrganizerView } from '@/lib/view-tracker';
 import SignupView, {
   type SignupViewField,
   type SignupViewSlot,
@@ -31,6 +32,13 @@ export default async function SignupPreviewPage({ params }: PageParams) {
     );
   }
   const sig = result.value;
+
+  void recordOrganizerView({
+    actor: { actorId: session.organizerId, actorType: 'organizer' },
+    signupId: sig.id,
+    workspaceId: sig.workspaceId,
+    eventType: 'signup.previewed',
+  });
 
   const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
     id: slot.id,

--- a/src/app/app/signups/[id]/preview/page.tsx
+++ b/src/app/app/signups/[id]/preview/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { after } from 'next/server';
 import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import type { SignupStatus } from '@/schemas/signups';
@@ -33,12 +34,14 @@ export default async function SignupPreviewPage({ params }: PageParams) {
   }
   const sig = result.value;
 
-  void recordOrganizerView({
-    actor: { actorId: session.organizerId, actorType: 'organizer' },
-    signupId: sig.id,
-    workspaceId: sig.workspaceId,
-    eventType: 'signup.previewed',
-  });
+  after(() =>
+    recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      eventType: 'signup.previewed',
+    }),
+  );
 
   const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
     id: slot.id,

--- a/src/app/s/[slug]/c/[id]/page.tsx
+++ b/src/app/s/[slug]/c/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import { after } from 'next/server';
 import { getDb } from '@/db/client';
 import { getOwnCommitment } from '@/services/commitments';
 import { recordEditLinkFollowed } from '@/lib/view-tracker';
@@ -19,12 +20,14 @@ export default async function CommitmentEditPage({ params, searchParams }: PageP
   if (!result.ok) notFound();
   const c = result.value;
 
-  void recordEditLinkFollowed({
-    signupId: c.signupId,
-    workspaceId: c.workspaceId,
-    commitmentId: c.id,
-    participantId: c.participantId,
-  });
+  after(() =>
+    recordEditLinkFollowed({
+      signupId: c.signupId,
+      workspaceId: c.workspaceId,
+      commitmentId: c.id,
+      participantId: c.participantId,
+    }),
+  );
 
   return (
     <main className="container-tight flex min-h-[100svh] flex-col gap-6 py-8">

--- a/src/app/s/[slug]/c/[id]/page.tsx
+++ b/src/app/s/[slug]/c/[id]/page.tsx
@@ -1,8 +1,9 @@
+import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { after } from 'next/server';
 import { getDb } from '@/db/client';
 import { getOwnCommitment } from '@/services/commitments';
-import { recordEditLinkFollowed } from '@/lib/view-tracker';
+import { readRequestSignals, recordEditLinkFollowed } from '@/lib/view-tracker';
 import EditForm from './edit-form';
 
 export const metadata = { title: 'Your signup' };
@@ -20,12 +21,16 @@ export default async function CommitmentEditPage({ params, searchParams }: PageP
   if (!result.ok) notFound();
   const c = result.value;
 
+  // Read headers in the request context — `after(...)` runs outside it and
+  // Next.js 15 forbids dynamic APIs (headers/cookies) inside the callback.
+  const signals = readRequestSignals(await headers());
   after(() =>
     recordEditLinkFollowed({
       signupId: c.signupId,
       workspaceId: c.workspaceId,
       commitmentId: c.id,
       participantId: c.participantId,
+      signals,
     }),
   );
 

--- a/src/app/s/[slug]/c/[id]/page.tsx
+++ b/src/app/s/[slug]/c/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { getDb } from '@/db/client';
 import { getOwnCommitment } from '@/services/commitments';
+import { recordEditLinkFollowed } from '@/lib/view-tracker';
 import EditForm from './edit-form';
 
 export const metadata = { title: 'Your signup' };
@@ -17,6 +18,13 @@ export default async function CommitmentEditPage({ params, searchParams }: PageP
   const result = await getOwnCommitment(getDb(), id, token);
   if (!result.ok) notFound();
   const c = result.value;
+
+  void recordEditLinkFollowed({
+    signupId: c.signupId,
+    workspaceId: c.workspaceId,
+    commitmentId: c.id,
+    participantId: c.participantId,
+  });
 
   return (
     <main className="container-tight flex min-h-[100svh] flex-col gap-6 py-8">

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   COMMIT_COOKIE_NAME,
   parseReturningCommits,
 } from '@/lib/returning-participant';
+import { recordPublicView } from '@/lib/view-tracker';
 import type { SignupStatus } from '@/schemas/signups';
 import type { SlotStatus } from '@/schemas/slots';
 import { getOwnCommitmentsForSignup } from '@/services/commitments';
@@ -87,6 +88,13 @@ export default async function PublicSignupPage({ params }: PageParams) {
     editUrl: commitmentEditUrl(slug, c.id, tokenById.get(c.id) ?? ''),
     participantName: c.participantName,
   }));
+
+  void recordPublicView({
+    signupId: sig.id,
+    workspaceId: sig.workspaceId,
+    signupStatus: sig.status,
+    isReturning: ownCommitments.length > 0,
+  });
 
   const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
     id: slot.id,

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { after } from 'next/server';
 import { getDb } from '@/db/client';
@@ -8,7 +8,7 @@ import {
   COMMIT_COOKIE_NAME,
   parseReturningCommits,
 } from '@/lib/returning-participant';
-import { recordPublicView } from '@/lib/view-tracker';
+import { readRequestSignals, recordPublicView } from '@/lib/view-tracker';
 import type { SignupStatus } from '@/schemas/signups';
 import type { SlotStatus } from '@/schemas/slots';
 import { getOwnCommitmentsForSignup } from '@/services/commitments';
@@ -90,12 +90,17 @@ export default async function PublicSignupPage({ params }: PageParams) {
     participantName: c.participantName,
   }));
 
+  // Read headers in the request context — `after(...)` runs outside it and
+  // Next.js 15 forbids dynamic APIs (headers/cookies) inside the callback.
+  const signals = readRequestSignals(await headers());
+  const isReturning = ownCommitments.length > 0;
   after(() =>
     recordPublicView({
       signupId: sig.id,
       workspaceId: sig.workspaceId,
       signupStatus: sig.status,
-      isReturning: ownCommitments.length > 0,
+      isReturning,
+      signals,
     }),
   );
 

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
+import { after } from 'next/server';
 import { getDb } from '@/db/client';
 import { commitmentEditUrl } from '@/lib/links';
 import {
@@ -89,12 +90,14 @@ export default async function PublicSignupPage({ params }: PageParams) {
     participantName: c.participantName,
   }));
 
-  void recordPublicView({
-    signupId: sig.id,
-    workspaceId: sig.workspaceId,
-    signupStatus: sig.status,
-    isReturning: ownCommitments.length > 0,
-  });
+  after(() =>
+    recordPublicView({
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      signupStatus: sig.status,
+      isReturning: ownCommitments.length > 0,
+    }),
+  );
 
   const slots: SignupViewSlot[] = sig.slots.map((slot) => ({
     id: slot.id,

--- a/src/auth/adapter.ts
+++ b/src/auth/adapter.ts
@@ -6,6 +6,7 @@ import { organizers } from '@/db/schema/organizers';
 import { workspaceMembers } from '@/db/schema/members';
 import { workspaces } from '@/db/schema/workspaces';
 import { accounts, sessions, verificationTokens } from '@/db/schema/auth';
+import { recordActivity } from '@/lib/activity';
 import { makeId } from '@/lib/ids';
 import { toSlug } from '@/lib/slug';
 
@@ -63,6 +64,14 @@ export function SignupAdapter() {
           .update(organizers)
           .set({ defaultWorkspaceId: workspaceId })
           .where(eq(organizers.id, row.id));
+
+        await recordActivity(tx, {
+          signupId: null,
+          workspaceId,
+          actor: { actorId: row.id, actorType: 'organizer' },
+          eventType: 'workspace.created',
+          payload: { kind: 'personal' },
+        });
 
         return row;
       });

--- a/src/auth/adapter.ts
+++ b/src/auth/adapter.ts
@@ -8,6 +8,7 @@ import { workspaces } from '@/db/schema/workspaces';
 import { accounts, sessions, verificationTokens } from '@/db/schema/auth';
 import { recordActivity } from '@/lib/activity';
 import { makeId } from '@/lib/ids';
+import { log } from '@/lib/log';
 import { toSlug } from '@/lib/slug';
 
 /**
@@ -28,9 +29,9 @@ export function SignupAdapter() {
     ...base,
     async createUser(user: AdapterUser): Promise<AdapterUser> {
       if (!base.createUser) throw new Error('adapter missing createUser');
-      const inserted = await db.transaction(async (tx) => {
+      const { row, workspaceId } = await db.transaction(async (tx) => {
         const organizerId = makeId('org');
-        const [row] = await tx
+        const [orgRow] = await tx
           .insert(organizers)
           .values({
             id: organizerId,
@@ -40,47 +41,58 @@ export function SignupAdapter() {
             image: user.image ?? null,
           })
           .returning();
-        if (!row) throw new Error('failed to insert organizer');
+        if (!orgRow) throw new Error('failed to insert organizer');
 
-        const workspaceId = makeId('ws');
-        const baseSlug = toSlug(row.name ?? row.email.split('@')[0] ?? 'me', { suffix: true });
+        const newWorkspaceId = makeId('ws');
+        const baseSlug = toSlug(orgRow.name ?? orgRow.email.split('@')[0] ?? 'me', {
+          suffix: true,
+        });
         await tx.insert(workspaces).values({
-          id: workspaceId,
+          id: newWorkspaceId,
           slug: baseSlug,
-          name: row.name ?? row.email,
+          name: orgRow.name ?? orgRow.email,
           type: 'personal',
           plan: 'free',
         });
 
         await tx.insert(workspaceMembers).values({
           id: makeId('mem'),
-          workspaceId,
-          organizerId: row.id,
+          workspaceId: newWorkspaceId,
+          organizerId: orgRow.id,
           role: 'owner',
           status: 'active',
         });
 
         await tx
           .update(organizers)
-          .set({ defaultWorkspaceId: workspaceId })
-          .where(eq(organizers.id, row.id));
+          .set({ defaultWorkspaceId: newWorkspaceId })
+          .where(eq(organizers.id, orgRow.id));
 
-        await recordActivity(tx, {
+        return { row: orgRow, workspaceId: newWorkspaceId };
+      });
+
+      // Best-effort telemetry, written outside the onboarding transaction.
+      // A failed activity insert here would have aborted the whole tx (a
+      // failed statement inside a Postgres tx poisons subsequent queries),
+      // so it lives outside and is wrapped in try/catch.
+      try {
+        await recordActivity(db, {
           signupId: null,
           workspaceId,
           actor: { actorId: row.id, actorType: 'organizer' },
           eventType: 'workspace.created',
           payload: { kind: 'personal' },
         });
+      } catch (err) {
+        log.warn({ err }, 'recordActivity workspace.created failed');
+      }
 
-        return row;
-      });
       return {
-        id: inserted.id,
-        email: inserted.email,
-        emailVerified: inserted.emailVerified,
-        name: inserted.name,
-        image: inserted.image,
+        id: row.id,
+        email: row.email,
+        emailVerified: row.emailVerified,
+        name: row.name,
+        image: row.image,
       };
     },
   };

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -1,9 +1,11 @@
 import NextAuth, { type NextAuthConfig } from 'next-auth';
 import Nodemailer from 'next-auth/providers/nodemailer';
 import { createElement } from 'react';
+import { getDb } from '@/db/client';
 import { renderEmail } from '@/email/render';
 import { getEmailTransport } from '@/email';
 import { MagicLinkEmail } from '@/email/templates/magic-link';
+import { recordActivity } from '@/lib/activity';
 import { log } from '@/lib/log';
 import { SignupAdapter } from './adapter';
 
@@ -38,6 +40,17 @@ function buildConfig(): NextAuthConfig {
             text,
           });
           log.info({ email: identifier }, 'magic link dispatched');
+          try {
+            await recordActivity(getDb(), {
+              signupId: null,
+              workspaceId: null,
+              actor: { actorId: null, actorType: 'system' },
+              eventType: 'auth.magic_link_sent',
+              payload: { email: identifier, expiresInMinutes },
+            });
+          } catch (err) {
+            log.warn({ err }, 'recordActivity auth.magic_link_sent failed');
+          }
         },
       }),
     ],
@@ -51,6 +64,22 @@ function buildConfig(): NextAuthConfig {
           session.user.id = user.id;
         }
         return session;
+      },
+    },
+    events: {
+      async signIn({ user, isNewUser }) {
+        if (!user?.id) return;
+        try {
+          await recordActivity(getDb(), {
+            signupId: null,
+            workspaceId: null,
+            actor: { actorId: user.id, actorType: 'organizer' },
+            eventType: 'auth.signed_in',
+            payload: { isNewUser: Boolean(isNewUser) },
+          });
+        } catch (err) {
+          log.warn({ err }, 'recordActivity auth.signed_in failed');
+        }
       },
     },
   };

--- a/src/db/schema/activity.ts
+++ b/src/db/schema/activity.ts
@@ -31,6 +31,10 @@ export const ACTIVITY_EVENTS = [
   'signup.archived',
   'signup.duplicated',
   'signup.deleted',
+  'signup.draft_started',
+  'signup.editor_opened',
+  'signup.previewed',
+  'signup.viewed',
   'slot.created',
   'slot.updated',
   'slot.deleted',
@@ -43,9 +47,14 @@ export const ACTIVITY_EVENTS = [
   'commitment.cancelled',
   'commitment.swapped',
   'commitment.orphaned',
+  'commitment.attempt_failed',
+  'commitment.edit_link_followed',
   'reminder.scheduled',
   'reminder.sent',
   'reminder.failed',
+  'auth.magic_link_sent',
+  'auth.signed_in',
+  'workspace.created',
 ] as const;
 
 export type ActivityEvent = (typeof ACTIVITY_EVENTS)[number];

--- a/src/lib/view-tracker.db.test.ts
+++ b/src/lib/view-tracker.db.test.ts
@@ -1,0 +1,294 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { getDb, type Db } from '@/db/client';
+import { activity } from '@/db/schema/activity';
+import { workspaceMembers } from '@/db/schema/members';
+import { organizers } from '@/db/schema/organizers';
+import { signups } from '@/db/schema/signups';
+import { workspaces } from '@/db/schema/workspaces';
+import { makeId } from '@/lib/ids';
+
+const headerStore: { current: Map<string, string> } = { current: new Map() };
+
+vi.mock('next/headers', () => ({
+  headers: async () => ({
+    get: (name: string) => headerStore.current.get(name.toLowerCase()) ?? null,
+  }),
+}));
+
+function setHeaders(map: Record<string, string>): void {
+  headerStore.current = new Map(
+    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+}
+
+const realBrowserUa =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+describe('view-tracker (db)', () => {
+  let db: Db;
+  let workspaceId: string;
+  let organizerId: string;
+  let signupId: string;
+
+  beforeAll(async () => {
+    db = getDb();
+    organizerId = makeId('org');
+    workspaceId = makeId('ws');
+    signupId = makeId('sig');
+    const memberId = makeId('mem');
+    const slug = `vt-${workspaceId.slice(-8).toLowerCase()}`;
+
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(organizers)
+        .values({ id: organizerId, email: `${slug}@example.test`, name: 'View Tracker Test' });
+      await tx.insert(workspaces).values({
+        id: workspaceId,
+        slug,
+        name: 'View Tracker WS',
+        type: 'personal',
+        plan: 'free',
+      });
+      await tx.insert(workspaceMembers).values({
+        id: memberId,
+        workspaceId,
+        organizerId,
+        role: 'owner',
+        status: 'active',
+      });
+      await tx.insert(signups).values({
+        id: signupId,
+        workspaceId,
+        organizerId,
+        slug: `s-${signupId.slice(-8).toLowerCase()}`,
+        title: 'View Tracker signup',
+        status: 'open',
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    await db.delete(organizers).where(eq(organizers.id, organizerId));
+  });
+
+  beforeEach(async () => {
+    await db.delete(activity).where(eq(activity.signupId, signupId));
+    setHeaders({});
+  });
+
+  describe('recordPublicView', () => {
+    it('writes a signup.viewed row for a real browser UA', async () => {
+      setHeaders({ 'user-agent': realBrowserUa, referer: 'https://news.ycombinator.com/' });
+      const { recordPublicView } = await import('./view-tracker');
+      await recordPublicView({
+        signupId,
+        workspaceId,
+        signupStatus: 'open',
+        isReturning: false,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(
+          and(eq(activity.signupId, signupId), eq(activity.eventType, 'signup.viewed')),
+        );
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row.actorType).toBe('system');
+      expect(row.actorId).toBeNull();
+      expect(row.workspaceId).toBe(workspaceId);
+      const payload = row.payload as Record<string, unknown>;
+      expect(payload.uaClass).toBe('browser');
+      expect(payload.refererHost).toBe('news.ycombinator.com');
+      expect(payload.isReturning).toBe(false);
+      expect(payload.signupStatus).toBe('open');
+    });
+
+    it('records isReturning=true when passed', async () => {
+      setHeaders({ 'user-agent': realBrowserUa });
+      const { recordPublicView } = await import('./view-tracker');
+      await recordPublicView({
+        signupId,
+        workspaceId,
+        signupStatus: 'open',
+        isReturning: true,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(
+          and(eq(activity.signupId, signupId), eq(activity.eventType, 'signup.viewed')),
+        );
+      expect(rows).toHaveLength(1);
+      expect((rows[0]!.payload as Record<string, unknown>).isReturning).toBe(true);
+    });
+
+    it('does not write when DNT=1', async () => {
+      setHeaders({ 'user-agent': realBrowserUa, dnt: '1' });
+      const { recordPublicView } = await import('./view-tracker');
+      await recordPublicView({
+        signupId,
+        workspaceId,
+        signupStatus: 'open',
+        isReturning: false,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.signupId, signupId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('does not write when Sec-GPC=1', async () => {
+      setHeaders({ 'user-agent': realBrowserUa, 'sec-gpc': '1' });
+      const { recordPublicView } = await import('./view-tracker');
+      await recordPublicView({
+        signupId,
+        workspaceId,
+        signupStatus: 'open',
+        isReturning: false,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.signupId, signupId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('does not write for a Googlebot UA', async () => {
+      setHeaders({
+        'user-agent':
+          'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      });
+      const { recordPublicView } = await import('./view-tracker');
+      await recordPublicView({
+        signupId,
+        workspaceId,
+        signupStatus: 'open',
+        isReturning: false,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.signupId, signupId));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('writes when UA is missing (uaClass=unknown)', async () => {
+      setHeaders({});
+      const { recordPublicView } = await import('./view-tracker');
+      await recordPublicView({
+        signupId,
+        workspaceId,
+        signupStatus: 'closed',
+        isReturning: false,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(
+          and(eq(activity.signupId, signupId), eq(activity.eventType, 'signup.viewed')),
+        );
+      expect(rows).toHaveLength(1);
+      const payload = rows[0]!.payload as Record<string, unknown>;
+      expect(payload.uaClass).toBe('unknown');
+      expect(payload.signupStatus).toBe('closed');
+      expect(payload.refererHost).toBeNull();
+    });
+  });
+
+  describe('recordEditLinkFollowed', () => {
+    it('writes a row with participant actor', async () => {
+      setHeaders({ 'user-agent': realBrowserUa });
+      const { recordEditLinkFollowed } = await import('./view-tracker');
+      const participantId = makeId('par');
+      const commitmentId = makeId('com');
+      await recordEditLinkFollowed({
+        signupId,
+        workspaceId,
+        commitmentId,
+        participantId,
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(
+          and(
+            eq(activity.signupId, signupId),
+            eq(activity.eventType, 'commitment.edit_link_followed'),
+          ),
+        );
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row.actorType).toBe('participant');
+      expect(row.actorId).toBe(participantId);
+      expect((row.payload as Record<string, unknown>).commitmentId).toBe(commitmentId);
+    });
+
+    it('skips on DNT=1', async () => {
+      setHeaders({ 'user-agent': realBrowserUa, dnt: '1' });
+      const { recordEditLinkFollowed } = await import('./view-tracker');
+      await recordEditLinkFollowed({
+        signupId,
+        workspaceId,
+        commitmentId: makeId('com'),
+        participantId: makeId('par'),
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.signupId, signupId));
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('recordOrganizerView', () => {
+    it('writes a signup.editor_opened row with section payload', async () => {
+      const { recordOrganizerView } = await import('./view-tracker');
+      await recordOrganizerView({
+        actor: { actorId: organizerId, actorType: 'organizer' },
+        signupId,
+        workspaceId,
+        eventType: 'signup.editor_opened',
+        payload: { section: 'slots' },
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(
+          and(
+            eq(activity.signupId, signupId),
+            eq(activity.eventType, 'signup.editor_opened'),
+          ),
+        );
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row.actorType).toBe('organizer');
+      expect(row.actorId).toBe(organizerId);
+      expect((row.payload as Record<string, unknown>).section).toBe('slots');
+    });
+
+    it('writes signup.draft_started without a signupId', async () => {
+      const { recordOrganizerView } = await import('./view-tracker');
+      await recordOrganizerView({
+        actor: { actorId: organizerId, actorType: 'organizer' },
+        signupId: null,
+        workspaceId,
+        eventType: 'signup.draft_started',
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(
+          and(
+            eq(activity.workspaceId, workspaceId),
+            eq(activity.eventType, 'signup.draft_started'),
+          ),
+        );
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows[0]!.signupId).toBeNull();
+    });
+  });
+});

--- a/src/lib/view-tracker.db.test.ts
+++ b/src/lib/view-tracker.db.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
 import { getDb, type Db } from '@/db/client';
 import { activity } from '@/db/schema/activity';
@@ -7,23 +7,24 @@ import { organizers } from '@/db/schema/organizers';
 import { signups } from '@/db/schema/signups';
 import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
-
-const headerStore: { current: Map<string, string> } = { current: new Map() };
-
-vi.mock('next/headers', () => ({
-  headers: async () => ({
-    get: (name: string) => headerStore.current.get(name.toLowerCase()) ?? null,
-  }),
-}));
-
-function setHeaders(map: Record<string, string>): void {
-  headerStore.current = new Map(
-    Object.entries(map).map(([k, v]) => [k.toLowerCase(), v]),
-  );
-}
+import {
+  recordEditLinkFollowed,
+  recordOrganizerView,
+  recordPublicView,
+  type RequestSignals,
+} from './view-tracker';
 
 const realBrowserUa =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+function browserSignals(overrides: Partial<RequestSignals> = {}): RequestSignals {
+  return {
+    userAgent: realBrowserUa,
+    referer: null,
+    dnt: false,
+    ...overrides,
+  };
+}
 
 describe('view-tracker (db)', () => {
   let db: Db;
@@ -75,18 +76,16 @@ describe('view-tracker (db)', () => {
 
   beforeEach(async () => {
     await db.delete(activity).where(eq(activity.signupId, signupId));
-    setHeaders({});
   });
 
   describe('recordPublicView', () => {
     it('writes a signup.viewed row for a real browser UA', async () => {
-      setHeaders({ 'user-agent': realBrowserUa, referer: 'https://news.ycombinator.com/' });
-      const { recordPublicView } = await import('./view-tracker');
       await recordPublicView({
         signupId,
         workspaceId,
         signupStatus: 'open',
         isReturning: false,
+        signals: browserSignals({ referer: 'https://news.ycombinator.com/' }),
       });
       const rows = await db
         .select()
@@ -107,13 +106,12 @@ describe('view-tracker (db)', () => {
     });
 
     it('records isReturning=true when passed', async () => {
-      setHeaders({ 'user-agent': realBrowserUa });
-      const { recordPublicView } = await import('./view-tracker');
       await recordPublicView({
         signupId,
         workspaceId,
         signupStatus: 'open',
         isReturning: true,
+        signals: browserSignals(),
       });
       const rows = await db
         .select()
@@ -125,30 +123,13 @@ describe('view-tracker (db)', () => {
       expect((rows[0]!.payload as Record<string, unknown>).isReturning).toBe(true);
     });
 
-    it('does not write when DNT=1', async () => {
-      setHeaders({ 'user-agent': realBrowserUa, dnt: '1' });
-      const { recordPublicView } = await import('./view-tracker');
+    it('does not write when DNT is set', async () => {
       await recordPublicView({
         signupId,
         workspaceId,
         signupStatus: 'open',
         isReturning: false,
-      });
-      const rows = await db
-        .select()
-        .from(activity)
-        .where(eq(activity.signupId, signupId));
-      expect(rows).toHaveLength(0);
-    });
-
-    it('does not write when Sec-GPC=1', async () => {
-      setHeaders({ 'user-agent': realBrowserUa, 'sec-gpc': '1' });
-      const { recordPublicView } = await import('./view-tracker');
-      await recordPublicView({
-        signupId,
-        workspaceId,
-        signupStatus: 'open',
-        isReturning: false,
+        signals: browserSignals({ dnt: true }),
       });
       const rows = await db
         .select()
@@ -158,16 +139,15 @@ describe('view-tracker (db)', () => {
     });
 
     it('does not write for a Googlebot UA', async () => {
-      setHeaders({
-        'user-agent':
-          'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
-      });
-      const { recordPublicView } = await import('./view-tracker');
       await recordPublicView({
         signupId,
         workspaceId,
         signupStatus: 'open',
         isReturning: false,
+        signals: browserSignals({
+          userAgent:
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        }),
       });
       const rows = await db
         .select()
@@ -177,13 +157,12 @@ describe('view-tracker (db)', () => {
     });
 
     it('writes when UA is missing (uaClass=unknown)', async () => {
-      setHeaders({});
-      const { recordPublicView } = await import('./view-tracker');
       await recordPublicView({
         signupId,
         workspaceId,
         signupStatus: 'closed',
         isReturning: false,
+        signals: { userAgent: null, referer: null, dnt: false },
       });
       const rows = await db
         .select()
@@ -201,8 +180,6 @@ describe('view-tracker (db)', () => {
 
   describe('recordEditLinkFollowed', () => {
     it('writes a row with participant actor', async () => {
-      setHeaders({ 'user-agent': realBrowserUa });
-      const { recordEditLinkFollowed } = await import('./view-tracker');
       const participantId = makeId('par');
       const commitmentId = makeId('com');
       await recordEditLinkFollowed({
@@ -210,6 +187,7 @@ describe('view-tracker (db)', () => {
         workspaceId,
         commitmentId,
         participantId,
+        signals: browserSignals(),
       });
       const rows = await db
         .select()
@@ -227,14 +205,13 @@ describe('view-tracker (db)', () => {
       expect((row.payload as Record<string, unknown>).commitmentId).toBe(commitmentId);
     });
 
-    it('skips on DNT=1', async () => {
-      setHeaders({ 'user-agent': realBrowserUa, dnt: '1' });
-      const { recordEditLinkFollowed } = await import('./view-tracker');
+    it('skips when DNT is set', async () => {
       await recordEditLinkFollowed({
         signupId,
         workspaceId,
         commitmentId: makeId('com'),
         participantId: makeId('par'),
+        signals: browserSignals({ dnt: true }),
       });
       const rows = await db
         .select()
@@ -246,7 +223,6 @@ describe('view-tracker (db)', () => {
 
   describe('recordOrganizerView', () => {
     it('writes a signup.editor_opened row with section payload', async () => {
-      const { recordOrganizerView } = await import('./view-tracker');
       await recordOrganizerView({
         actor: { actorId: organizerId, actorType: 'organizer' },
         signupId,
@@ -271,7 +247,6 @@ describe('view-tracker (db)', () => {
     });
 
     it('writes signup.draft_started without a signupId', async () => {
-      const { recordOrganizerView } = await import('./view-tracker');
       await recordOrganizerView({
         actor: { actorId: organizerId, actorType: 'organizer' },
         signupId: null,

--- a/src/lib/view-tracker.test.ts
+++ b/src/lib/view-tracker.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { classifyUa, isDoNotTrack, refererHost } from './view-tracker';
+
+describe('classifyUa', () => {
+  it('returns browser for a real Chrome UA', () => {
+    expect(
+      classifyUa(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      ),
+    ).toBe('browser');
+  });
+
+  it('returns browser for a real Firefox UA', () => {
+    expect(
+      classifyUa(
+        'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+      ),
+    ).toBe('browser');
+  });
+
+  it('returns bot for Googlebot', () => {
+    expect(
+      classifyUa('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'),
+    ).toBe('bot');
+  });
+
+  it('returns bot for Bingbot', () => {
+    expect(
+      classifyUa('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+    ).toBe('bot');
+  });
+
+  it('returns bot for facebookexternalhit', () => {
+    expect(classifyUa('facebookexternalhit/1.1')).toBe('bot');
+  });
+
+  it('returns bot for Slackbot', () => {
+    expect(classifyUa('Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)')).toBe('bot');
+  });
+
+  it('returns bot for WhatsApp', () => {
+    expect(classifyUa('WhatsApp/2.23.20.0 A')).toBe('bot');
+  });
+
+  it('returns bot for Discord previews', () => {
+    expect(classifyUa('Mozilla/5.0 (compatible; Discordbot/2.0)')).toBe('bot');
+  });
+
+  it('returns bot for curl', () => {
+    expect(classifyUa('curl/8.4.0')).toBe('bot');
+  });
+
+  it('returns unknown for null', () => {
+    expect(classifyUa(null)).toBe('unknown');
+  });
+
+  it('returns unknown for undefined', () => {
+    expect(classifyUa(undefined)).toBe('unknown');
+  });
+
+  it('returns unknown for empty string', () => {
+    expect(classifyUa('')).toBe('unknown');
+  });
+});
+
+describe('refererHost', () => {
+  it('extracts host from a full URL', () => {
+    expect(refererHost('https://example.com/foo?x=1#bar')).toBe('example.com');
+  });
+
+  it('extracts host with port', () => {
+    expect(refererHost('http://localhost:3000/some/path')).toBe('localhost:3000');
+  });
+
+  it('returns null for an invalid URL', () => {
+    expect(refererHost('not a url')).toBeNull();
+  });
+
+  it('returns null for null', () => {
+    expect(refererHost(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(refererHost(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(refererHost('')).toBeNull();
+  });
+
+  it('strips path and query from the host', () => {
+    expect(refererHost('https://google.com/search?q=opensignup')).toBe('google.com');
+  });
+});
+
+describe('isDoNotTrack', () => {
+  function fakeHeaders(map: Record<string, string>) {
+    return {
+      get: (name: string) => map[name.toLowerCase()] ?? null,
+    };
+  }
+
+  it('returns true when DNT=1', () => {
+    expect(isDoNotTrack(fakeHeaders({ dnt: '1' }))).toBe(true);
+  });
+
+  it('returns true when Sec-GPC=1', () => {
+    expect(isDoNotTrack(fakeHeaders({ 'sec-gpc': '1' }))).toBe(true);
+  });
+
+  it('returns false when no signal headers present', () => {
+    expect(isDoNotTrack(fakeHeaders({}))).toBe(false);
+  });
+
+  it('returns false when DNT=0', () => {
+    expect(isDoNotTrack(fakeHeaders({ dnt: '0' }))).toBe(false);
+  });
+
+  it('returns false when DNT is some other value', () => {
+    expect(isDoNotTrack(fakeHeaders({ dnt: 'unspecified' }))).toBe(false);
+  });
+});

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers';
 import type { ActivityEvent } from '@/db/schema/activity';
 import { getDb } from '@/db/client';
 import { recordActivity, type ActivityActor } from '@/lib/activity';
@@ -29,6 +28,29 @@ export function isDoNotTrack(headerMap: {
   return headerMap.get('dnt') === '1' || headerMap.get('sec-gpc') === '1';
 }
 
+/**
+ * Plain-data view of the request signals these recorders care about.
+ * Callers MUST extract these from `headers()` BEFORE scheduling a recorder
+ * via `after(...)` — Next.js 15 forbids dynamic APIs (headers/cookies/etc.)
+ * inside `after()` callbacks, since `after()` runs outside the request
+ * context.
+ */
+export interface RequestSignals {
+  userAgent: string | null;
+  referer: string | null;
+  dnt: boolean;
+}
+
+export function readRequestSignals(headerMap: {
+  get: (name: string) => string | null;
+}): RequestSignals {
+  return {
+    userAgent: headerMap.get('user-agent'),
+    referer: headerMap.get('referer'),
+    dnt: isDoNotTrack(headerMap),
+  };
+}
+
 async function writeActivity(args: {
   signupId: string | null;
   workspaceId: string | null;
@@ -53,11 +75,11 @@ export async function recordPublicView(args: {
   workspaceId: string | null;
   signupStatus: string;
   isReturning: boolean;
+  signals: RequestSignals;
 }): Promise<void> {
   try {
-    const h = await headers();
-    if (isDoNotTrack(h)) return;
-    const uaClass = classifyUa(h.get('user-agent'));
+    if (args.signals.dnt) return;
+    const uaClass = classifyUa(args.signals.userAgent);
     if (uaClass === 'bot') return;
     await writeActivity({
       signupId: args.signupId,
@@ -66,7 +88,7 @@ export async function recordPublicView(args: {
       eventType: 'signup.viewed',
       payload: {
         uaClass,
-        refererHost: refererHost(h.get('referer')),
+        refererHost: refererHost(args.signals.referer),
         isReturning: args.isReturning,
         signupStatus: args.signupStatus,
       },
@@ -81,11 +103,11 @@ export async function recordEditLinkFollowed(args: {
   workspaceId: string | null;
   commitmentId: string;
   participantId: string | null;
+  signals: RequestSignals;
 }): Promise<void> {
   try {
-    const h = await headers();
-    if (isDoNotTrack(h)) return;
-    if (classifyUa(h.get('user-agent')) === 'bot') return;
+    if (args.signals.dnt) return;
+    if (classifyUa(args.signals.userAgent) === 'bot') return;
     await writeActivity({
       signupId: args.signupId,
       workspaceId: args.workspaceId,

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -1,0 +1,118 @@
+import { headers } from 'next/headers';
+import type { ActivityEvent } from '@/db/schema/activity';
+import { getDb } from '@/db/client';
+import { recordActivity, type ActivityActor } from '@/lib/activity';
+import { log } from '@/lib/log';
+
+const BOT_RE =
+  /bot|crawler|spider|slurp|facebookexternalhit|whatsapp|telegrambot|discordbot|slackbot|twitterbot|linkedinbot|googlebot|bingbot|preview|headlesschrome|phantomjs|httpie|curl|wget/i;
+
+export type UaClass = 'browser' | 'bot' | 'unknown';
+
+export function classifyUa(ua: string | null | undefined): UaClass {
+  if (!ua) return 'unknown';
+  return BOT_RE.test(ua) ? 'bot' : 'browser';
+}
+
+export function refererHost(ref: string | null | undefined): string | null {
+  if (!ref) return null;
+  try {
+    return new URL(ref).host || null;
+  } catch {
+    return null;
+  }
+}
+
+export function isDoNotTrack(headerMap: {
+  get: (name: string) => string | null;
+}): boolean {
+  return headerMap.get('dnt') === '1' || headerMap.get('sec-gpc') === '1';
+}
+
+async function writeActivity(args: {
+  signupId: string | null;
+  workspaceId: string | null;
+  actor: ActivityActor;
+  eventType: ActivityEvent;
+  payload?: Record<string, unknown>;
+}): Promise<void> {
+  await getDb().transaction((tx) =>
+    recordActivity(tx, {
+      signupId: args.signupId,
+      workspaceId: args.workspaceId,
+      actor: args.actor,
+      eventType: args.eventType,
+      payload: args.payload ?? {},
+    }),
+  );
+}
+
+export async function recordPublicView(args: {
+  signupId: string;
+  workspaceId: string | null;
+  signupStatus: string;
+  isReturning: boolean;
+}): Promise<void> {
+  try {
+    const h = await headers();
+    if (isDoNotTrack(h)) return;
+    const uaClass = classifyUa(h.get('user-agent'));
+    if (uaClass === 'bot') return;
+    await writeActivity({
+      signupId: args.signupId,
+      workspaceId: args.workspaceId,
+      actor: { actorId: null, actorType: 'system' },
+      eventType: 'signup.viewed',
+      payload: {
+        uaClass,
+        refererHost: refererHost(h.get('referer')),
+        isReturning: args.isReturning,
+        signupStatus: args.signupStatus,
+      },
+    });
+  } catch (err) {
+    log.warn({ err }, 'recordPublicView failed');
+  }
+}
+
+export async function recordEditLinkFollowed(args: {
+  signupId: string;
+  workspaceId: string | null;
+  commitmentId: string;
+  participantId: string | null;
+}): Promise<void> {
+  try {
+    const h = await headers();
+    if (isDoNotTrack(h)) return;
+    if (classifyUa(h.get('user-agent')) === 'bot') return;
+    await writeActivity({
+      signupId: args.signupId,
+      workspaceId: args.workspaceId,
+      actor: { actorId: args.participantId, actorType: 'participant' },
+      eventType: 'commitment.edit_link_followed',
+      payload: { commitmentId: args.commitmentId },
+    });
+  } catch (err) {
+    log.warn({ err }, 'recordEditLinkFollowed failed');
+  }
+}
+
+export async function recordOrganizerView(args: {
+  actor: ActivityActor;
+  signupId: string | null;
+  workspaceId: string | null;
+  eventType: ActivityEvent;
+  payload?: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await writeActivity({
+      signupId: args.signupId,
+      workspaceId: args.workspaceId,
+      actor: args.actor,
+      eventType: args.eventType,
+      payload: args.payload,
+    });
+  } catch (err) {
+    log.warn({ err, event: args.eventType }, 'recordOrganizerView failed');
+  }
+}

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -36,15 +36,16 @@ async function writeActivity(args: {
   eventType: ActivityEvent;
   payload?: Record<string, unknown>;
 }): Promise<void> {
-  await getDb().transaction((tx) =>
-    recordActivity(tx, {
-      signupId: args.signupId,
-      workspaceId: args.workspaceId,
-      actor: args.actor,
-      eventType: args.eventType,
-      payload: args.payload ?? {},
-    }),
-  );
+  // Single insert — no BEGIN/COMMIT wrapper. The activity log writes-in-tx rule
+  // applies when the activity row describes a mutation in the same tx; these
+  // helpers fire standalone telemetry.
+  await recordActivity(getDb(), {
+    signupId: args.signupId,
+    workspaceId: args.workspaceId,
+    actor: args.actor,
+    eventType: args.eventType,
+    payload: args.payload ?? {},
+  });
 }
 
 export async function recordPublicView(args: {

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -43,6 +43,13 @@ export async function commitToSlot(
     const slot = slotRows[0];
     if (!slot) return err(serviceError('not_found', 'slot not found'));
     if (slot.status !== 'open') {
+      await recordActivity(tx, {
+        signupId: slot.signupId,
+        workspaceId: slot.workspaceId,
+        actor: { actorId: null, actorType: 'system' },
+        eventType: 'commitment.attempt_failed',
+        payload: { slotId, reason: 'closed', detail: 'slot_closed' },
+      });
       return err(serviceError('closed', 'that slot is closed'));
     }
 
@@ -54,6 +61,13 @@ export async function commitToSlot(
     const signupRow = signupRows[0];
     if (!signupRow) return err(serviceError('not_found', 'signup missing'));
     if (signupRow.status !== 'open') {
+      await recordActivity(tx, {
+        signupId: signupRow.id,
+        workspaceId: signupRow.workspaceId,
+        actor: { actorId: null, actorType: 'system' },
+        eventType: 'commitment.attempt_failed',
+        payload: { slotId, reason: 'closed', detail: `signup_${signupRow.status}` },
+      });
       return err(
         serviceError('closed', 'signup is not accepting commitments', {
           field: 'status',
@@ -63,6 +77,13 @@ export async function commitToSlot(
       );
     }
     if (signupRow.closesAt && signupRow.closesAt.getTime() < Date.now()) {
+      await recordActivity(tx, {
+        signupId: signupRow.id,
+        workspaceId: signupRow.workspaceId,
+        actor: { actorId: null, actorType: 'system' },
+        eventType: 'commitment.attempt_failed',
+        payload: { slotId, reason: 'over_window', detail: 'closes_at_elapsed' },
+      });
       return err(serviceError('closed', 'signup has closed'));
     }
 
@@ -71,6 +92,13 @@ export async function commitToSlot(
     if (slot.slotAt && settings.lockoutHoursBeforeSlot && settings.lockoutHoursBeforeSlot > 0) {
       const lockoutMs = settings.lockoutHoursBeforeSlot * 3600 * 1000;
       if (Date.now() > slot.slotAt.getTime() - lockoutMs) {
+        await recordActivity(tx, {
+          signupId: signupRow.id,
+          workspaceId: signupRow.workspaceId,
+          actor: { actorId: null, actorType: 'system' },
+          eventType: 'commitment.attempt_failed',
+          payload: { slotId, reason: 'over_window', detail: 'slot_lockout' },
+        });
         return err(serviceError('closed', 'too close to the slot time to sign up'));
       }
     }
@@ -151,6 +179,18 @@ export async function commitToSlot(
         .where(and(eq(slots.signupId, slot.signupId), eq(slots.status, 'open'), ne(slots.id, slotId)))
         .orderBy(asc(slots.slotAt), asc(slots.sortOrder))
         .limit(3);
+      await recordActivity(tx, {
+        signupId: slot.signupId,
+        workspaceId: slot.workspaceId,
+        actor: { actorId: null, actorType: 'system' },
+        eventType: 'commitment.attempt_failed',
+        payload: {
+          slotId,
+          reason: 'capacity_full',
+          requested: data.quantity,
+          remaining,
+        },
+      });
       return err(
         serviceError(
           'capacity_full',
@@ -366,6 +406,19 @@ export async function updateOwnCommitment(
         const otherQty = sumRows[0]?.sum ?? 0;
         if (otherQty + data.quantity > cap) {
           const remaining = Math.max(0, cap - otherQty);
+          await recordActivity(tx, {
+            signupId: current.signupId,
+            workspaceId: current.workspaceId,
+            actor: { actorId: current.participantId, actorType: 'participant' },
+            eventType: 'commitment.attempt_failed',
+            payload: {
+              slotId: current.slotId,
+              reason: 'capacity_full',
+              source: 'update',
+              requested: data.quantity,
+              remaining,
+            },
+          });
           return err(
             serviceError(
               'capacity_full',

--- a/src/services/commitments.ts
+++ b/src/services/commitments.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, inArray, ne, or, sql } from 'drizzle-orm';
-import type { Db, Queryable } from '@/db/client';
+import type { Db, Queryable, Tx } from '@/db/client';
 import { commitments } from '@/db/schema/commitments';
 import { participants } from '@/db/schema/participants';
 import { signups } from '@/db/schema/signups';
@@ -7,6 +7,7 @@ import { slots } from '@/db/schema/slots';
 import { recordActivity } from '@/lib/activity';
 import { serviceError, type ServiceError } from '@/lib/errors';
 import { makeId } from '@/lib/ids';
+import { log } from '@/lib/log';
 import { parseInputSafe } from '@/lib/parse';
 import { err, ok, type Result } from '@/lib/result';
 import { editTokenFor, hashToken, verifyHash } from '@/lib/token';
@@ -18,6 +19,37 @@ import {
 } from '@/schemas/commitments';
 
 type CommitmentRow = typeof commitments.$inferSelect;
+
+// Telemetry write inside an outer tx where a raw INSERT would otherwise abort
+// the surrounding transaction on failure. Uses a SAVEPOINT (Drizzle's nested
+// `tx.transaction`) so a failed activity insert rolls back only the savepoint,
+// leaving the outer tx free to return its intended ServiceError. Errors are
+// logged and swallowed — telemetry must never turn a `closed`/`capacity_full`
+// rejection into a 500.
+async function safeRecordAttemptFailed(
+  tx: Tx,
+  args: {
+    signupId: string | null;
+    workspaceId: string | null;
+    actorId: string | null;
+    actorType: 'system' | 'participant';
+    payload: Record<string, unknown>;
+  },
+): Promise<void> {
+  try {
+    await tx.transaction(async (sp) => {
+      await recordActivity(sp, {
+        signupId: args.signupId,
+        workspaceId: args.workspaceId,
+        actor: { actorId: args.actorId, actorType: args.actorType },
+        eventType: 'commitment.attempt_failed',
+        payload: args.payload,
+      });
+    });
+  } catch (err) {
+    log.warn({ err, payload: args.payload }, 'recordActivity attempt_failed failed');
+  }
+}
 
 export interface CommitResult {
   commitment: CommitmentRow;
@@ -43,11 +75,11 @@ export async function commitToSlot(
     const slot = slotRows[0];
     if (!slot) return err(serviceError('not_found', 'slot not found'));
     if (slot.status !== 'open') {
-      await recordActivity(tx, {
+      await safeRecordAttemptFailed(tx, {
         signupId: slot.signupId,
         workspaceId: slot.workspaceId,
-        actor: { actorId: null, actorType: 'system' },
-        eventType: 'commitment.attempt_failed',
+        actorId: null,
+        actorType: 'system',
         payload: { slotId, reason: 'closed', detail: 'slot_closed' },
       });
       return err(serviceError('closed', 'that slot is closed'));
@@ -61,11 +93,11 @@ export async function commitToSlot(
     const signupRow = signupRows[0];
     if (!signupRow) return err(serviceError('not_found', 'signup missing'));
     if (signupRow.status !== 'open') {
-      await recordActivity(tx, {
+      await safeRecordAttemptFailed(tx, {
         signupId: signupRow.id,
         workspaceId: signupRow.workspaceId,
-        actor: { actorId: null, actorType: 'system' },
-        eventType: 'commitment.attempt_failed',
+        actorId: null,
+        actorType: 'system',
         payload: { slotId, reason: 'closed', detail: `signup_${signupRow.status}` },
       });
       return err(
@@ -77,11 +109,11 @@ export async function commitToSlot(
       );
     }
     if (signupRow.closesAt && signupRow.closesAt.getTime() < Date.now()) {
-      await recordActivity(tx, {
+      await safeRecordAttemptFailed(tx, {
         signupId: signupRow.id,
         workspaceId: signupRow.workspaceId,
-        actor: { actorId: null, actorType: 'system' },
-        eventType: 'commitment.attempt_failed',
+        actorId: null,
+        actorType: 'system',
         payload: { slotId, reason: 'over_window', detail: 'closes_at_elapsed' },
       });
       return err(serviceError('closed', 'signup has closed'));
@@ -92,11 +124,11 @@ export async function commitToSlot(
     if (slot.slotAt && settings.lockoutHoursBeforeSlot && settings.lockoutHoursBeforeSlot > 0) {
       const lockoutMs = settings.lockoutHoursBeforeSlot * 3600 * 1000;
       if (Date.now() > slot.slotAt.getTime() - lockoutMs) {
-        await recordActivity(tx, {
+        await safeRecordAttemptFailed(tx, {
           signupId: signupRow.id,
           workspaceId: signupRow.workspaceId,
-          actor: { actorId: null, actorType: 'system' },
-          eventType: 'commitment.attempt_failed',
+          actorId: null,
+          actorType: 'system',
           payload: { slotId, reason: 'over_window', detail: 'slot_lockout' },
         });
         return err(serviceError('closed', 'too close to the slot time to sign up'));
@@ -179,11 +211,11 @@ export async function commitToSlot(
         .where(and(eq(slots.signupId, slot.signupId), eq(slots.status, 'open'), ne(slots.id, slotId)))
         .orderBy(asc(slots.slotAt), asc(slots.sortOrder))
         .limit(3);
-      await recordActivity(tx, {
+      await safeRecordAttemptFailed(tx, {
         signupId: slot.signupId,
         workspaceId: slot.workspaceId,
-        actor: { actorId: null, actorType: 'system' },
-        eventType: 'commitment.attempt_failed',
+        actorId: null,
+        actorType: 'system',
         payload: {
           slotId,
           reason: 'capacity_full',
@@ -406,11 +438,11 @@ export async function updateOwnCommitment(
         const otherQty = sumRows[0]?.sum ?? 0;
         if (otherQty + data.quantity > cap) {
           const remaining = Math.max(0, cap - otherQty);
-          await recordActivity(tx, {
+          await safeRecordAttemptFailed(tx, {
             signupId: current.signupId,
             workspaceId: current.workspaceId,
-            actor: { actorId: current.participantId, actorType: 'participant' },
-            eventType: 'commitment.attempt_failed',
+            actorId: current.participantId,
+            actorType: 'participant',
             payload: {
               slotId: current.slotId,
               reason: 'capacity_full',

--- a/src/services/signups.db.test.ts
+++ b/src/services/signups.db.test.ts
@@ -412,9 +412,46 @@ describe('signups service (db)', () => {
       if (r.ok) return;
       expect(r.error.code).toBe('capacity_full');
 
+      const acts = await fx.db
+        .select()
+        .from(activity)
+        .where(eq(activity.signupId, created.value.id));
+      const failures = acts.filter((a) => a.eventType === 'commitment.attempt_failed');
+      expect(failures).toHaveLength(1);
+      expect((failures[0]!.payload as Record<string, unknown>).reason).toBe('capacity_full');
+      expect((failures[0]!.payload as Record<string, unknown>).slotId).toBe(slotR.value.id);
+
       const pubR = await getPublicSignup(fx.db, created.value.slug);
       if (!pubR.ok) throw new Error('public read failed');
       expect(pubR.value.committedBySlot).toEqual({});
+    });
+
+    it('logs commitment.attempt_failed with reason=closed when committing to a closed signup', async () => {
+      const created = await createSignup(fx.db, fx.actor, fx.workspaceId, validCreateInput('Closed for commit'));
+      if (!created.ok) throw new Error('setup failed');
+      const slotR = await addSlot(fx.db, fx.actor, created.value.id, { values: {}, capacity: 5 });
+      if (!slotR.ok) throw new Error('slot setup failed');
+      const pub = await publishSignup(fx.db, fx.actor, created.value.id);
+      if (!pub.ok) throw new Error('setup failed');
+      const closed = await closeSignup(fx.db, fx.actor, created.value.id);
+      if (!closed.ok) throw new Error('setup failed');
+
+      const r = await commitToSlot(fx.db, slotR.value.id, {
+        name: 'Late',
+        email: 'late@example.com',
+        quantity: 1,
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('closed');
+
+      const acts = await fx.db
+        .select()
+        .from(activity)
+        .where(eq(activity.signupId, created.value.id));
+      const failures = acts.filter((a) => a.eventType === 'commitment.attempt_failed');
+      expect(failures).toHaveLength(1);
+      expect((failures[0]!.payload as Record<string, unknown>).reason).toBe('closed');
     });
 
     it('reports committedBySlot as sum of quantities', async () => {


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive activity logging system to track user interactions across the OpenSignup platform. It adds telemetry for public signup views, participant edit-link follows, and organizer editor interactions, with privacy-first design principles.

## Key Changes

- **New view-tracker module** (`src/lib/view-tracker.ts`): Provides three main functions:
  - `recordPublicView()`: Logs signup page views with User-Agent classification, referrer tracking, and returning visitor detection
  - `recordEditLinkFollowed()`: Tracks when participants follow edit links for their commitments
  - `recordOrganizerView()`: Logs organizer editor interactions (section opens, draft starts, previews)

- **Privacy-first implementation**:
  - Respects `DNT: 1` and `Sec-GPC: 1` headers; no tracking when either is set
  - Filters out bot traffic (Googlebot, Bingbot, curl, etc.) via regex classification
  - Never logs full User-Agent strings; only classifies as `'browser'` / `'bot'` / `'unknown'`
  - Extracts only hostname from referrer (no paths or query strings)
  - No IP address collection

- **Activity schema updates** (`src/db/schema/activity.ts`):
  - Added new event types: `signup.draft_started`, `signup.editor_opened`, `signup.previewed`, `signup.viewed`, `commitment.edit_link_followed`, `commitment.attempt_failed`, `auth.magic_link_sent`, `auth.signed_in`, `workspace.created`

- **Service layer integration**:
  - `commitToSlot()` now logs `commitment.attempt_failed` events with detailed rejection reasons (`closed`, `over_window`, `capacity_full`)
  - Auth config logs `auth.magic_link_sent` and `auth.signed_in` events
  - Auth adapter logs `workspace.created` on first login

- **Page instrumentation**:
  - Public signup page (`/s/[slug]`) calls `recordPublicView()`
  - Edit link page (`/s/[slug]/c/[id]`) calls `recordEditLinkFollowed()`
  - Organizer editor pages call `recordOrganizerView()` for section tracking
  - New signup page logs `signup.draft_started`
  - Preview page logs `signup.previewed`

- **Comprehensive documentation** (`docs/telemetry.md`):
  - Full schema documentation with column descriptions
  - Event catalogue mapping all tracked events to their sources and payloads
  - Privacy guarantees and workspace scoping requirements
  - Example SQL queries for common analytics use cases
  - Operational notes on volume, adding new events, and what's intentionally not captured

- **Test coverage**:
  - Unit tests for UA classification, referrer parsing, and DNT header detection
  - Integration tests verifying database writes for all three tracking functions
  - Tests for privacy signal handling (DNT, Sec-GPC, bot filtering)

## Notable Implementation Details

- All tracking functions wrap database writes in try-catch to prevent tracking failures from breaking user flows
- The activity table uses `text` for `event_type` (not a PG enum) to allow code-only additions of new event types
- Workspace scoping is enforced at the schema level; all queries must include `workspace_id` predicate
- Pageview events (`signup.viewed`, `signup.editor_opened`, etc.) fire on every RSC render; volume is expected to be high
- The system is designed for self-hosted operators to query via their own BI tools (Metabase, Grafana, etc.) rather than providing a built-in dashboard

https://claude.ai/code/session_01WCqqaDKYyFWCe9wrQxNQGe