### PR TITLE
Remove SlotPublicSchema and related imports from slots schema

### DIFF
--- a/src/schemas/slots.ts
+++ b/src/schemas/slots.ts
@@ -1,6 +1,4 @@
 import { z } from 'zod';
-import { idOf } from './common';
-import { SlotFieldPublicSchema } from './slot-fields';
 
 export const SLOT_STATUSES = ['open', 'closed'] as const;
 export type SlotStatus = (typeof SLOT_STATUSES)[number];
@@ -39,20 +37,3 @@ export const SlotUpdateInputSchema = z
   })
   .strict();
 export type SlotUpdateInput = z.infer<typeof SlotUpdateInputSchema>;
-
-export const SlotPublicSchema = z.object({
-  id: idOf('slot'),
-  ref: z.string(),
-  fields: z.array(SlotFieldPublicSchema),
-  capacity: z.number().int().nullable(),
-  committedCount: z.number().int(),
-  status: z.enum(SLOT_STATUSES),
-  sortOrder: z.number().int(),
-  /** Canonical UTC timestamp derived from the signup's reminder field, if any. */
-  slotAt: z.string().datetime().nullable(),
-  /** Identified committers when showWhoSignedUp is on. */
-  committers: z
-    .array(z.object({ id: idOf('par'), name: z.string() }))
-    .optional(),
-});
-export type SlotPublic = z.infer<typeof SlotPublicSchema>;


### PR DESCRIPTION
## Summary
Removed the `SlotPublicSchema` type definition and its associated exports from the slots schema module, along with unused imports that were only required by this schema.

## Changes
- Removed `SlotPublicSchema` Zod schema definition that was used for validating public slot data
- Removed `SlotPublic` type export (inferred from the schema)
- Removed unused imports:
  - `idOf` from `./common`
  - `SlotFieldPublicSchema` from `./slot-fields`

## Notes
This appears to be a cleanup/refactoring to move the public slot schema definition elsewhere or consolidate schema organization. The internal slot schemas (`SlotCreateInputSchema`, `SlotUpdateInputSchema`) and their types remain intact.

https://claude.ai/code/session_01VKDoNrvZR9LVghtE376Bom