### PR TITLE
fix(auth): re-anchor magic-link URLs to AUTH_URL

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,12 +5,12 @@
 #
 # Required secrets (set via `fly secrets set KEY=value`):
 #   AUTH_SECRET   — 32+ char random string (e.g. `openssl rand -base64 32`)
-#   AUTH_URL      — public app URL, e.g. https://opensignup.org. Used as the
-#                   canonical origin for magic-link emails; without it (or set
-#                   to the *.fly.dev hostname) sign-in links will point at the
-#                   internal Fly host.
+#   AUTH_URL      — public app URL, e.g. https://signup.example.com. Used as
+#                   the canonical origin for magic-link emails; without it (or
+#                   set to the *.fly.dev hostname) sign-in links will point at
+#                   the internal Fly host.
 #   DATABASE_URL  — populated automatically by `fly postgres attach`
-#   EMAIL_FROM    — e.g. "OpenSignup <hello@opensignup.org>"
+#   EMAIL_FROM    — e.g. "OpenSignup <hello@signup.example.com>"
 #   EMAIL_TRANSPORT + RESEND_API_KEY (or SMTP_* vars) — see .env.example
 
 app = "signups"

--- a/fly.toml
+++ b/fly.toml
@@ -2,6 +2,16 @@
 # First time: `fly launch --no-deploy --copy-config` (or `fly apps create signups`),
 # then `fly postgres create` + `fly postgres attach`, then set secrets (see below),
 # then `fly deploy`.
+#
+# Required secrets (set via `fly secrets set KEY=value`):
+#   AUTH_SECRET   — 32+ char random string (e.g. `openssl rand -base64 32`)
+#   AUTH_URL      — public app URL, e.g. https://opensignup.org. Used as the
+#                   canonical origin for magic-link emails; without it (or set
+#                   to the *.fly.dev hostname) sign-in links will point at the
+#                   internal Fly host.
+#   DATABASE_URL  — populated automatically by `fly postgres attach`
+#   EMAIL_FROM    — e.g. "OpenSignup <hello@opensignup.org>"
+#   EMAIL_TRANSPORT + RESEND_API_KEY (or SMTP_* vars) — see .env.example
 
 app = "signups"
 primary_region = "iad"

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -6,8 +6,10 @@ import { renderEmail } from '@/email/render';
 import { getEmailTransport } from '@/email';
 import { MagicLinkEmail } from '@/email/templates/magic-link';
 import { recordActivity } from '@/lib/activity';
+import { getEnv } from '@/lib/env';
 import { log } from '@/lib/log';
 import { SignupAdapter } from './adapter';
+import { canonicalizeMagicLinkUrl } from './magic-link-url';
 
 // Built lazily on first request: SignupAdapter() touches getDb() → getEnv(),
 // which would otherwise fire at module-load and break `next build`'s page-data
@@ -31,7 +33,12 @@ function buildConfig(): NextAuthConfig {
             1,
             Math.round((expires.getTime() - Date.now()) / 60_000),
           );
-          const node = createElement(MagicLinkEmail, { url, email: identifier, expiresInMinutes });
+          const safeUrl = canonicalizeMagicLinkUrl(url, getEnv().AUTH_URL);
+          const node = createElement(MagicLinkEmail, {
+            url: safeUrl,
+            email: identifier,
+            expiresInMinutes,
+          });
           const { html, text } = await renderEmail(node);
           await getEmailTransport().send({
             to: identifier,

--- a/src/auth/magic-link-url.test.ts
+++ b/src/auth/magic-link-url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalizeMagicLinkUrl } from './magic-link-url';
+
+describe('canonicalizeMagicLinkUrl', () => {
+  it('rewrites a fly.dev origin to the AUTH_URL origin', () => {
+    const raw =
+      'https://signups.fly.dev/api/auth/callback/nodemailer?token=abc&email=user%40example.com';
+    const result = canonicalizeMagicLinkUrl(raw, 'https://opensignup.org');
+    expect(result).toBe(
+      'https://opensignup.org/api/auth/callback/nodemailer?token=abc&email=user%40example.com',
+    );
+  });
+
+  it('preserves path, query, and hash', () => {
+    const raw = 'http://internal-host/api/auth/callback/nodemailer?token=t&callbackUrl=%2Fapp#frag';
+    const result = canonicalizeMagicLinkUrl(raw, 'https://opensignup.org');
+    expect(result).toBe(
+      'https://opensignup.org/api/auth/callback/nodemailer?token=t&callbackUrl=%2Fapp#frag',
+    );
+  });
+
+  it('keeps a non-default port from AUTH_URL', () => {
+    const raw = 'http://0.0.0.0:3000/api/auth/callback/nodemailer?token=t';
+    const result = canonicalizeMagicLinkUrl(raw, 'http://localhost:3000');
+    expect(result).toBe('http://localhost:3000/api/auth/callback/nodemailer?token=t');
+  });
+
+  it('switches protocol when AUTH_URL is https and request was http', () => {
+    const raw = 'http://signups.fly.dev/api/auth/callback/nodemailer?token=t';
+    const result = canonicalizeMagicLinkUrl(raw, 'https://opensignup.org');
+    expect(result.startsWith('https://opensignup.org/')).toBe(true);
+  });
+});

--- a/src/auth/magic-link-url.ts
+++ b/src/auth/magic-link-url.ts
@@ -1,0 +1,11 @@
+// `trustHost: true` makes NextAuth derive the magic-link origin from the
+// request's Host header, which on Fly.io can be the internal `*.fly.dev`
+// hostname rather than the public domain. Re-anchor the URL to AUTH_URL
+// (the canonical origin) before sending — path/query/hash are preserved.
+export function canonicalizeMagicLinkUrl(rawUrl: string, authUrl: string): string {
+  const canonical = new URL(authUrl);
+  const link = new URL(rawUrl);
+  link.protocol = canonical.protocol;
+  link.host = canonical.host;
+  return link.toString();
+}


### PR DESCRIPTION
NextAuth v5 with `trustHost: true` derives the magic-link origin from
the request's Host header, which on Fly.io can be the internal
*.fly.dev hostname rather than the public domain. Rewrite the URL
to AUTH_URL's origin before sending so the email always points at
the canonical host. Also document the required AUTH_URL secret in
fly.toml.