### PR TITLE
Add Retry-After header support for rate limit errors

### DIFF
--- a/src/lib/api-response.test.ts
+++ b/src/lib/api-response.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { ZodError } from 'zod';
+import { ServiceException, serviceError } from './errors';
+import { handle } from './api-response';
+
+describe('handle()', () => {
+  it('sets Retry-After header when rate_limited with retryAfterSeconds', async () => {
+    const res = await handle(() => {
+      throw new ServiceException(
+        serviceError('rate_limited', 'too many requests', {
+          details: { retryAfterSeconds: 10 },
+        }),
+      );
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('10');
+  });
+
+  it('does not set Retry-After for non-rate-limit errors', async () => {
+    const res = await handle(() => {
+      throw new ServiceException(serviceError('not_found', 'missing'));
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get('Retry-After')).toBeNull();
+  });
+
+  it('does not set Retry-After when retryAfterSeconds is absent', async () => {
+    const res = await handle(() => {
+      throw new ServiceException(serviceError('rate_limited', 'too many requests'));
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeNull();
+  });
+
+  it('returns 400 for a ZodError', async () => {
+    const res = await handle(() => {
+      throw new ZodError([
+        {
+          code: 'too_small',
+          minimum: 1,
+          type: 'string',
+          inclusive: true,
+          message: 'too short',
+          path: ['name'],
+        },
+      ]);
+    });
+    expect(res.status).toBe(400);
+    expect(res.headers.get('Retry-After')).toBeNull();
+  });
+
+  it('returns 500 for unknown errors', async () => {
+    const res = await handle(() => {
+      throw new Error('boom');
+    });
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -64,7 +64,12 @@ export async function handle(fn: () => Promise<Response>): Promise<Response> {
   } catch (e) {
     if (e instanceof ZodError) return fail(fromZodError(e));
     if (e && typeof e === 'object' && 'serviceError' in e) {
-      return fail((e as { serviceError: ServiceError }).serviceError);
+      const se = (e as { serviceError: ServiceError }).serviceError;
+      const headers: HeadersInit | undefined =
+        se.code === 'rate_limited' && typeof se.details?.retryAfterSeconds === 'number'
+          ? { 'Retry-After': String(se.details.retryAfterSeconds) }
+          : undefined;
+      return fail(se, headers);
     }
     log.error({ err: e }, 'unhandled route error');
     return fail({ code: 'internal', message: 'something went wrong' });


### PR DESCRIPTION
## Summary
Enhanced error handling in the API response handler to include the `Retry-After` header when rate limit errors occur, providing clients with information about when they can retry their requests.

## Key Changes
- Modified the service error handling in `handle()` to extract the `ServiceError` object separately
- Added conditional logic to check if the error code is `'rate_limited'` and if `retryAfterSeconds` is available in the error details
- When rate limit conditions are met, construct a `Retry-After` header with the retry delay value
- Pass the constructed headers to the `fail()` function for inclusion in the error response

## Implementation Details
- The `Retry-After` header value is converted to a string as per HTTP specification requirements
- Headers are only included when the error is specifically a rate limit error with valid retry timing information
- This follows HTTP 429 (Too Many Requests) best practices by informing clients of the appropriate backoff duration

https://claude.ai/code/session_01STdQYLVWsqw9Lis8QufZUj