### PR TITLE
Remove unused assertOwnCommitment authorization function

### DIFF
--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -72,21 +72,6 @@ export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null):
   }
 }
 
-export function assertOwnCommitment(
-  actor: Actor,
-  target: { signupId: string; commitmentId: string },
-): void {
-  if (
-    actor.kind !== 'participant' ||
-    actor.signupId !== target.signupId ||
-    actor.commitmentId !== target.commitmentId
-  ) {
-    throw new ServiceException(
-      serviceError('forbidden', 'this action requires the commitment edit token'),
-    );
-  }
-}
-
 export function anon(): Extract<Actor, { kind: 'anonymous' }> {
   return { kind: 'anonymous' };
 }


### PR DESCRIPTION
## Summary
Removed the `assertOwnCommitment` function from the policy module as it is no longer used in the codebase.

## Changes
- Deleted the `assertOwnCommitment` function that validated whether an actor (participant) owned a specific commitment based on signupId and commitmentId matching
- This function was throwing a "forbidden" error when the actor lacked the commitment edit token

## Notes
This appears to be cleanup of dead code. The function was not being called anywhere in the codebase and has been safely removed.

https://claude.ai/code/session_01LYt6jrAv27qStxsXhz5JbT