### PR TITLE
Only apply rate limit when client IP is available

### DIFF
--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -23,7 +23,7 @@ export async function POST(
       req.headers.get('x-real-ip')?.trim() ||
       null;
     const clientIp = rawIp && isIP(rawIp) ? rawIp : null;
-    await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp ?? 'unknown');
+    if (clientIp) await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp);
     const body = await req.json().catch(() => ({}));
     const result = await commitToSlot(db, slotId, body);
     if (!result.ok) return fail(result.error);


### PR DESCRIPTION
## Summary
Modified the rate limiting logic in the slot commitments endpoint to only enforce rate limits when a valid client IP address is available, rather than falling back to a generic 'unknown' identifier.

## Key Changes
- Changed rate limit consumption to be conditional on `clientIp` being present
- Removed the fallback to `'unknown'` string when IP detection fails
- Rate limiting is now skipped entirely if the client IP cannot be determined

## Implementation Details
The previous implementation would always call `consumeRateLimit()` with either the detected IP or the string `'unknown'` as a fallback. This could result in all requests without a detectable IP being rate limited under the same bucket, potentially causing issues with legitimate traffic from certain network configurations.

The updated logic only applies rate limiting when a valid IP address is successfully extracted and validated, providing more granular and accurate rate limit tracking.

https://claude.ai/code/session_01CnJ8o7d5kxwzbPzRHo2Qhb