### PR TITLE
Remove unused email transport reset and policy error type

### DIFF
--- a/src/email/index.ts
+++ b/src/email/index.ts
@@ -32,8 +32,4 @@ export function getEmailTransport(): EmailTransport {
   return cached;
 }
 
-export function resetEmailTransport() {
-  cached = null;
-}
-
 export * from './transport';

--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -1,4 +1,4 @@
-import { serviceError, ServiceException, type ServiceError } from './errors';
+import { serviceError, ServiceException } from './errors';
 
 export type Actor =
   | {
@@ -75,5 +75,3 @@ export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null):
 export function anon(): Extract<Actor, { kind: 'anonymous' }> {
   return { kind: 'anonymous' };
 }
-
-export type PolicyError = ServiceError;


### PR DESCRIPTION
## Summary
This PR removes unused code from the email transport and policy modules to reduce unnecessary exports and improve code clarity.

## Key Changes
- **Email Transport**: Removed the `resetEmailTransport()` function which was not being used anywhere in the codebase
- **Policy Module**: 
  - Removed the unused `PolicyError` type alias that was simply re-exporting `ServiceError`
  - Removed the unused `ServiceError` import that was only used by the deleted type alias

## Implementation Details
These changes are purely cleanup with no functional impact. The removed code was not referenced elsewhere in the codebase and removing it reduces the public API surface while maintaining all necessary functionality.

https://claude.ai/code/session_01AoAhKfsqFpSUZ5QizxBb7d