### PR TITLE
Add editToken to log redaction list

### DIFF
--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -11,6 +11,7 @@ export const log = pino({
       'req.headers.cookie',
       '*.password',
       '*.token',
+      '*.editToken',
       '*.apiKey',
       '*.RESEND_API_KEY',
       '*.SMTP_PASSWORD',


### PR DESCRIPTION
## Summary
Added `editToken` to the list of sensitive fields that are redacted from logs to prevent accidental exposure of authentication tokens.

## Changes
- Added `*.editToken` to the Pino logger's redaction list in `src/lib/log.ts`

## Details
The `editToken` field is now treated as a sensitive value and will be automatically redacted from all log output, consistent with other authentication-related fields like `password`, `token`, `apiKey`, and `RESEND_API_KEY`.

https://claude.ai/code/session_01YTqpLT5hmEGtmLYZ2BoExf