### PR TITLE
Remove unused anon() helper function from policy module

### DIFF
--- a/src/lib/policy.ts
+++ b/src/lib/policy.ts
@@ -72,8 +72,4 @@ export function requireWorkspaceWrite(actor: Actor, workspaceId: string | null):
   }
 }
 
-export function anon(): Extract<Actor, { kind: 'anonymous' }> {
-  return { kind: 'anonymous' };
-}
-
 export type PolicyError = ServiceError;


### PR DESCRIPTION
## Summary
Removed the `anon()` helper function from the policy module as it is no longer needed.

## Changes
- Deleted the `anon()` function that was used to create anonymous actor objects
- This function returned a simple object literal with `{ kind: 'anonymous' }` and had no callers in the codebase

## Details
The `anon()` helper was a simple utility function that provided no additional value over directly creating the anonymous actor object. Removing it reduces unnecessary code and simplifies the public API of the policy module.

https://claude.ai/code/session_01HGQbkUXMYSs5fZpx78CeGs