### PR TITLE
Enable secure cookie flag in production environment

### DIFF
--- a/src/lib/returning-participant.test.ts
+++ b/src/lib/returning-participant.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NextResponse } from 'next/server';
 import {
   COMMIT_COOKIE_NAME,
   appendReturningCommit,
   parseReturningCommits,
   removeReturningCommit,
   serializeReturningCommits,
+  setReturningCommitCookie,
 } from './returning-participant';
 
 describe('returning-participant cookie', () => {
@@ -82,5 +84,38 @@ describe('returning-participant cookie', () => {
       { commitmentId: 'com_old', token: 'tokOld' },
       { commitmentId: 'com_new', token: 'tokNew', signupId: 'sig_z' },
     ]);
+  });
+});
+
+describe('setReturningCommitCookie', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function mockResponse() {
+    const set = vi.fn();
+    return { response: { cookies: { set } } as unknown as NextResponse, set };
+  }
+
+  it('sets secure:true in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { response, set } = mockResponse();
+    setReturningCommitCookie(response, 'com_a.tok');
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ secure: true }));
+  });
+
+  it('sets secure:false outside production', () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    const { response, set } = mockResponse();
+    setReturningCommitCookie(response, 'com_a.tok');
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ secure: false }));
+  });
+
+  it('always sets httpOnly and sameSite:lax', () => {
+    const { response, set } = mockResponse();
+    setReturningCommitCookie(response, 'com_a.tok');
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax', name: COMMIT_COOKIE_NAME }),
+    );
   });
 });

--- a/src/lib/returning-participant.ts
+++ b/src/lib/returning-participant.ts
@@ -99,5 +99,6 @@ export function setReturningCommitCookie(response: NextResponse, value: string):
     maxAge: MAX_AGE_DAYS * 24 * 60 * 60,
     sameSite: 'lax',
     httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
   });
 }


### PR DESCRIPTION
## Summary
Added conditional `secure` flag to the returning participant commit cookie to ensure cookies are only transmitted over HTTPS in production environments.

## Key Changes
- Set `secure: true` for cookies when `NODE_ENV` is 'production'
- Cookies will be transmitted over HTTP in non-production environments to support local development
- Improves security posture by preventing cookie transmission over unencrypted connections in production

## Implementation Details
The `secure` flag is now conditionally set based on the environment:
- **Production**: `secure: true` - cookies only sent over HTTPS
- **Development/Testing**: `secure: false` - cookies sent over HTTP for local development compatibility

This follows security best practices for cookie handling while maintaining developer experience in non-production environments.

https://claude.ai/code/session_012kzQStHdybtjTFv6qfEPvm