### PR TITLE
fix: reject required-flip with empty slots; fix ResizeHandle stale drag; fix editCell full-values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test-results
 next-env.d.ts
 .remember
 .claude
+.worktrees

--- a/src/app/app/(chrome)/@crumbs/signups/[id]/build/page.tsx
+++ b/src/app/app/(chrome)/@crumbs/signups/[id]/build/page.tsx
@@ -1,0 +1,14 @@
+import { getOrganizerSession, toActor } from '@/auth/session';
+import { Crumb } from '@/components/chrome/Crumb';
+import { loadSignupForOrganizer } from '@/services/signups.cached';
+
+type CrumbParams = { params: Promise<{ id: string }> };
+
+export default async function BuildCrumb({ params }: CrumbParams) {
+  const { id } = await params;
+  const session = await getOrganizerSession();
+  if (!session) return null;
+  const result = await loadSignupForOrganizer(toActor(session), id);
+  if (!result.ok) return null;
+  return <Crumb truncate>{result.value.title}</Crumb>;
+}

--- a/src/app/app/(chrome)/signups/[id]/actions.ts
+++ b/src/app/app/(chrome)/signups/[id]/actions.ts
@@ -10,6 +10,7 @@ import { addSlot, deleteSlot } from '@/services/slots';
 import { addField, deleteField } from '@/services/slot-fields';
 import { toSlug } from '@/lib/slug';
 import type { SlotFieldConfig, SlotFieldDefinition } from '@/schemas/slot-fields';
+import { SignupSettingsSchema } from '@/schemas/signups';
 
 function revalidateSignup(id: string) {
   revalidatePath(`/app/signups/${id}`, 'layout');
@@ -123,6 +124,32 @@ export async function publishAction(signupId: string) {
 export async function closeAction(signupId: string) {
   const actor = await requireActor();
   await closeSignup(getDb(), actor, signupId);
+  revalidateSignup(signupId);
+}
+
+export async function updateReminderAction(signupId: string, formData: FormData) {
+  const actor = await requireActor();
+  const reminder = String(formData.get('reminderFromFieldRef') ?? '').trim();
+
+  // Read current settings so we can replace (not just merge) them.
+  // The service does a shallow spread, so omitting the key from the patch
+  // would leave any existing reminderFromFieldRef in place. We build the
+  // full settings object here with the field explicitly removed when clearing.
+  const current = await loadSignupForOrganizer(actor, signupId);
+  if (!current.ok) {
+    redirect(`/app/signups/${signupId}/settings?error=${encodeURIComponent(current.error.message)}`);
+  }
+  const parsedSettings = SignupSettingsSchema.safeParse(current.value.settings ?? {});
+  const prevSettings = parsedSettings.success
+    ? parsedSettings.data
+    : ({} as { reminderFromFieldRef?: string });
+  const { reminderFromFieldRef: _removed, ...restSettings } = prevSettings;
+  const nextSettings = reminder ? { ...restSettings, reminderFromFieldRef: reminder } : restSettings;
+
+  const result = await updateSignup(getDb(), actor, signupId, { settings: nextSettings });
+  if (!result.ok) {
+    redirect(`/app/signups/${signupId}/settings?error=${encodeURIComponent(result.error.message)}`);
+  }
   revalidateSignup(signupId);
 }
 

--- a/src/app/app/(chrome)/signups/[id]/build/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/build/page.tsx
@@ -1,0 +1,37 @@
+import { redirect } from 'next/navigation';
+import { after } from 'next/server';
+import { getOrganizerSession, toActor } from '@/auth/session';
+import { loadSignupForOrganizer } from '@/services/signups.cached';
+import { recordOrganizerView } from '@/lib/view-tracker';
+import { BuildGrid } from '@/components/build-grid';
+
+type PageParams = { params: Promise<{ id: string }> };
+
+export default async function BuildTab({ params }: PageParams) {
+  const { id } = await params;
+  const session = await getOrganizerSession();
+  if (!session) redirect(`/login?callbackUrl=/app/signups/${id}/build`);
+  const result = await loadSignupForOrganizer(toActor(session), id);
+  if (!result.ok) return null;
+  const sig = result.value;
+  after(() =>
+    recordOrganizerView({
+      actor: { actorId: session.organizerId, actorType: 'organizer' },
+      signupId: sig.id,
+      workspaceId: sig.workspaceId,
+      eventType: 'signup.viewed',
+    }),
+  );
+  return (
+    <BuildGrid
+      signupId={id}
+      initialFields={sig.fields}
+      initialSlots={sig.slots.map((s) => ({
+        id: s.id,
+        capacity: s.capacity ?? null,
+        sortOrder: s.sortOrder,
+        values: (s.values ?? {}) as Record<string, unknown>,
+      }))}
+    />
+  );
+}

--- a/src/app/app/(chrome)/signups/[id]/layout.tsx
+++ b/src/app/app/(chrome)/signups/[id]/layout.tsx
@@ -55,7 +55,7 @@ export default async function SignupDetailLayout({ children, params }: LayoutPro
       />
       <TabsNav
         signupId={id}
-        counts={{ fields: sig.fields.length, slots: sig.slots.length, responses: responsesCount }}
+        counts={{ build: sig.fields.length + sig.slots.length, responses: responsesCount }}
       />
       <div>{children}</div>
     </div>

--- a/src/app/app/(chrome)/signups/[id]/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/page.tsx
@@ -4,5 +4,5 @@ type PageParams = { params: Promise<{ id: string }> };
 
 export default async function SignupDetailPage({ params }: PageParams) {
   const { id } = await params;
-  redirect(`/app/signups/${id}/fields`);
+  redirect(`/app/signups/${id}/build`);
 }

--- a/src/app/app/(chrome)/signups/[id]/responses/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/responses/page.tsx
@@ -4,23 +4,10 @@ import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { listCommitmentsForSignup } from '@/services/commitments';
-import type { SlotFieldDefinition } from '@/schemas/slot-fields';
 import { recordOrganizerView } from '@/lib/view-tracker';
+import { summarizeSlot } from '@/lib/slot-summary';
 
 type PageParams = { params: Promise<{ id: string }> };
-
-function summarizeValues(
-  fields: SlotFieldDefinition[],
-  values: Record<string, unknown>,
-): string {
-  const parts: string[] = [];
-  for (const f of fields) {
-    const v = values[f.ref];
-    if (v === undefined || v === null || v === '') continue;
-    parts.push(`${f.label}: ${String(v)}`);
-  }
-  return parts.join(' · ');
-}
 
 export default async function ResponsesTab({ params }: PageParams) {
   const { id } = await params;
@@ -64,7 +51,7 @@ export default async function ResponsesTab({ params }: PageParams) {
               {commitments.map((c) => {
                 const slot = sig.slots.find((s) => s.id === c.slotId);
                 const summary = slot
-                  ? summarizeValues(sig.fields, (slot.values as Record<string, unknown>) ?? {})
+                  ? summarizeSlot(sig.fields, (slot.values as Record<string, unknown>) ?? {})
                   : '';
                 return (
                   <tr key={c.id}>

--- a/src/app/app/(chrome)/signups/[id]/settings/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/settings/page.tsx
@@ -4,7 +4,8 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 import { recordOrganizerView } from '@/lib/view-tracker';
-import { updateBasicsAction } from '../actions';
+import { SignupSettingsSchema } from '@/schemas/signups';
+import { updateBasicsAction, updateReminderAction } from '../actions';
 
 type PageParams = {
   params: Promise<{ id: string }>;
@@ -28,6 +29,9 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
       payload: { section: 'settings' },
     }),
   );
+
+  const parsedSettings = SignupSettingsSchema.safeParse(sig.settings ?? {});
+  const reminderRef = parsedSettings.success ? (parsedSettings.data.reminderFromFieldRef ?? '') : '';
 
   return (
     <section className="max-w-2xl space-y-6">
@@ -69,6 +73,42 @@ export default async function SettingsTab({ params, searchParams }: PageParams) 
           </AsyncSubmitButton>
         </div>
       </form>
+      {sig.fields.some((f) => f.fieldType === 'date') && (
+        <form
+          action={updateReminderAction.bind(null, id)}
+          className="space-y-4 rounded-xl border border-surface-sunk bg-white p-6"
+        >
+          <div>
+            <h2 className="text-sm font-semibold">Reminders</h2>
+            <p className="text-ink-muted mt-1 text-sm">
+              Send participants a reminder email before their slot.
+            </p>
+          </div>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">Reminder date field</span>
+            <select
+              name="reminderFromFieldRef"
+              defaultValue={reminderRef}
+              className="focus:border-brand focus:ring-brand block min-h-[42px] w-full appearance-none rounded-lg border border-surface-sunk bg-white px-3 py-2 focus:outline-none focus:ring-1"
+            >
+              <option value="">— No reminder —</option>
+              {sig.fields
+                .filter((f) => f.fieldType === 'date')
+                .map((f) => (
+                  <option key={f.id} value={f.ref}>{f.label}</option>
+                ))}
+            </select>
+          </label>
+          <div className="flex justify-end">
+            <AsyncSubmitButton
+              loadingLabel="Saving…"
+              className="bg-brand rounded-lg px-5 py-2 font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
+            >
+              Save
+            </AsyncSubmitButton>
+          </div>
+        </form>
+      )}
     </section>
   );
 }

--- a/src/app/app/(chrome)/signups/[id]/slots/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/slots/page.tsx
@@ -5,26 +5,13 @@ import { getDb } from '@/db/client';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { listCommitmentsForSignup } from '@/services/commitments';
-import type { SlotFieldDefinition } from '@/schemas/slot-fields';
 import { after } from 'next/server';
 import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
 import { recordOrganizerView } from '@/lib/view-tracker';
+import { summarizeSlot } from '@/lib/slot-summary';
 import { addSlotAction, deleteSlotAction } from '../actions';
 
 type PageParams = { params: Promise<{ id: string }> };
-
-function summarizeValues(
-  fields: SlotFieldDefinition[],
-  values: Record<string, unknown>,
-): string {
-  const parts: string[] = [];
-  for (const f of fields) {
-    const v = values[f.ref];
-    if (v === undefined || v === null || v === '') continue;
-    parts.push(`${f.label}: ${String(v)}`);
-  }
-  return parts.join(' · ');
-}
 
 export default async function SlotsTab({ params }: PageParams) {
   const { id } = await params;
@@ -152,7 +139,7 @@ export default async function SlotsTab({ params }: PageParams) {
                 (c) => c.slotId === slot.id && (c.status === 'confirmed' || c.status === 'tentative'),
               )
               .reduce((acc, c) => acc + c.quantity, 0);
-            const summary = summarizeValues(fields, (slot.values as Record<string, unknown>) ?? {});
+            const summary = summarizeSlot(fields, (slot.values as Record<string, unknown>) ?? {});
             return (
               <li key={slot.id} className="flex items-center justify-between gap-4 px-5 py-4">
                 <div className="min-w-0">

--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useGridState } from './useGridState';
+import type { GridField } from './useGridState';
+import { totalGridWidth } from './columnSizing';
+import { FIELD_TYPE_META } from './fieldTypes';
+import { Toolbar } from './Toolbar';
+import { ScrollableTable } from './ScrollableTable';
+import { GridHeader } from './GridHeader';
+import { GridBody } from './GridBody';
+import { SideRail } from './SideRail';
+import { FieldPicker } from './FieldPicker';
+import { FieldEditor } from './FieldEditor';
+import type { SlotFieldDefinition, SlotFieldConfig, FieldType } from '@/schemas/slot-fields';
+
+type BuildGridProps = {
+  signupId: string;
+  initialFields: SlotFieldDefinition[];
+  initialSlots: Array<{
+    id: string;
+    capacity: number | null;
+    sortOrder?: number | null;
+    values: Record<string, unknown>;
+  }>;
+};
+
+function buildDefaultConfig(type: Exclude<FieldType, 'enum'>): SlotFieldConfig {
+  switch (type) {
+    case 'text':   return { fieldType: 'text', maxLength: 200 };
+    case 'date':   return { fieldType: 'date' };
+    case 'time':   return { fieldType: 'time' };
+    case 'number': return { fieldType: 'number' };
+  }
+}
+
+function AddRowAffordance({ onAdd }: { onAdd: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onAdd}
+      aria-label="Add another slot"
+      className="w-full grid grid-cols-[38px_1fr] bg-surface-raised border-t border-surface-sunk cursor-pointer text-left font-[inherit] hover:bg-surface-sunk/50"
+    >
+      <span className="flex items-center justify-center text-ink-soft text-sm">+</span>
+      <span className="flex items-center gap-1.5 px-3 py-3 text-sm text-ink-soft">
+        <Plus size={13} />
+        Add another slot
+      </span>
+    </button>
+  );
+}
+
+export function BuildGrid({ signupId, initialFields, initialSlots }: BuildGridProps) {
+  const {
+    state,
+    addField,
+    updateField,
+    deleteField,
+    setFieldWidth,
+    addRow,
+    deleteRow,
+    moveRowUp,
+    moveRowDown,
+    editCell,
+    setCapacity,
+    setPreviewRow,
+    setShowPreview,
+    setGroupBy,
+  } = useGridState(
+    signupId,
+    initialFields,
+    initialSlots.map((s) => ({
+      id: s.id,
+      capacity: s.capacity,
+      sortOrder: s.sortOrder ?? undefined,
+      values: s.values,
+    })),
+  );
+
+  const [showFieldPicker, setShowFieldPicker] = useState(false);
+  const [editingField, setEditingField] = useState<GridField | null>(null);
+  const [showFieldEditorCreate, setShowFieldEditorCreate] = useState(false);
+
+  return (
+    <>
+      <div
+        className={`grid gap-5 items-start ${state.showPreview ? 'grid-cols-[1fr_320px]' : 'grid-cols-[1fr]'}`}
+      >
+        {/* Build Grid panel */}
+        <div className="border border-surface-sunk rounded-2xl bg-white overflow-hidden min-w-0">
+          <Toolbar
+            fields={state.fields}
+            rows={state.rows}
+            groupByFieldRef={state.groupByFieldRef}
+            onGroupByChange={(ref) => { void setGroupBy(ref); }}
+            showPreview={state.showPreview}
+            onTogglePreview={() => setShowPreview(!state.showPreview)}
+            saveStatus={state.saveStatus}
+            onAddField={() => setShowFieldPicker(true)}
+          />
+          <ScrollableTable totalWidth={totalGridWidth(state.fields)}>
+            <GridHeader
+              fields={state.fields}
+              onEditField={(field) => setEditingField(field)}
+              onAddField={() => setShowFieldPicker(true)}
+              onResize={(fieldId, width) => setFieldWidth(fieldId, width)}
+              onResetWidth={(fieldId) => setFieldWidth(fieldId, undefined)}
+            />
+            <GridBody
+              fields={state.fields}
+              rows={state.rows}
+              highlightedRowIdx={state.previewRowIdx}
+              onEditCell={(rowId, fieldRef, value) => editCell(rowId, fieldRef, value)}
+              onSetCapacity={(rowId, cap) => { void setCapacity(rowId, cap); }}
+              onDeleteRow={(rowId) => { void deleteRow(rowId); }}
+              onMoveRowUp={(rowId) => { void moveRowUp(rowId); }}
+              onMoveRowDown={(rowId) => { void moveRowDown(rowId); }}
+              onSelectRow={(idx) => setPreviewRow(idx)}
+            />
+          </ScrollableTable>
+          <AddRowAffordance onAdd={() => { void addRow(); }} />
+        </div>
+
+        {/* Side Rail */}
+        {state.showPreview && (
+          <SideRail
+            fields={state.fields}
+            rows={state.rows}
+            previewRowIdx={state.previewRowIdx}
+            onSelectRow={(idx) => setPreviewRow(idx)}
+          />
+        )}
+      </div>
+
+      {/* Modals */}
+      {showFieldPicker && (
+        <FieldPicker
+          onPick={(type) => {
+            const config = buildDefaultConfig(type);
+            const name = FIELD_TYPE_META[type].defaultName;
+            void addField(type, name, config, true);
+            setShowFieldPicker(false);
+          }}
+          onPickEnum={() => {
+            setShowFieldPicker(false);
+            setShowFieldEditorCreate(true);
+          }}
+          onClose={() => setShowFieldPicker(false)}
+        />
+      )}
+
+      {editingField && (
+        <FieldEditor
+          editorMode={{ mode: 'edit', field: editingField }}
+          onSave={(type, name, config, required) => {
+            void updateField(editingField.id, { name, type, config, required });
+            setEditingField(null);
+          }}
+          onDelete={() => {
+            void deleteField(editingField.id);
+            setEditingField(null);
+          }}
+          onClose={() => setEditingField(null)}
+        />
+      )}
+
+      {showFieldEditorCreate && (
+        <FieldEditor
+          editorMode={{ mode: 'create', type: 'enum' }}
+          onSave={(type, name, config, required) => {
+            void addField(type, name, config, required);
+            setShowFieldEditorCreate(false);
+          }}
+          onClose={() => setShowFieldEditorCreate(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/build-grid/CapacityCell.tsx
+++ b/src/components/build-grid/CapacityCell.tsx
@@ -1,0 +1,37 @@
+interface CapacityCellProps {
+  rowId: string;
+  capacity: number | null;
+  onChange: (rowId: string, capacity: number | null) => void;
+}
+
+const inputClass =
+  'border-none bg-transparent w-full font-inherit text-[13px] text-ink ' +
+  'focus:outline-none focus:ring-2 focus:ring-brand focus:ring-inset focus:ring-offset-[-2px] ' +
+  'px-2 py-2 placeholder:text-ink-soft';
+
+export function CapacityCell({ rowId, capacity, onChange }: CapacityCellProps) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (e.target.value === '') {
+      onChange(rowId, null);
+    } else {
+      onChange(rowId, Number(e.target.value));
+    }
+  }
+
+  function handleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+  }
+
+  return (
+    <input
+      type="number"
+      min={1}
+      step={1}
+      value={capacity ?? ''}
+      placeholder="∞"
+      onChange={handleChange}
+      onClick={handleClick}
+      className={inputClass}
+    />
+  );
+}

--- a/src/components/build-grid/CapacityCell.tsx
+++ b/src/components/build-grid/CapacityCell.tsx
@@ -1,20 +1,19 @@
 interface CapacityCellProps {
-  rowId: string;
   capacity: number | null;
-  onChange: (rowId: string, capacity: number | null) => void;
+  onChange: (v: number | null) => void;
 }
 
 const inputClass =
-  'border-none bg-transparent w-full font-inherit text-[13px] text-ink ' +
+  'border-none bg-transparent w-full font-[inherit] text-[13px] text-ink ' +
   'focus:outline-none focus:ring-2 focus:ring-brand focus:ring-inset focus:ring-offset-[-2px] ' +
   'px-2 py-2 placeholder:text-ink-soft';
 
-export function CapacityCell({ rowId, capacity, onChange }: CapacityCellProps) {
+export function CapacityCell({ capacity, onChange }: CapacityCellProps) {
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (e.target.value === '') {
-      onChange(rowId, null);
+      onChange(null);
     } else {
-      onChange(rowId, Number(e.target.value));
+      onChange(Number(e.target.value));
     }
   }
 

--- a/src/components/build-grid/CellInput.tsx
+++ b/src/components/build-grid/CellInput.tsx
@@ -1,3 +1,4 @@
+import type { SlotFieldConfig } from '@/schemas/slot-fields';
 import type { GridField } from './useGridState';
 
 interface CellInputProps {
@@ -9,13 +10,9 @@ interface CellInputProps {
 
 /** Shared input style classes applied to every input/select variant. */
 const inputClass =
-  'border-none bg-transparent w-full font-inherit text-[13px] text-ink ' +
+  'border-none bg-transparent w-full font-[inherit] text-[13px] text-ink ' +
   'focus:outline-none focus:ring-2 focus:ring-brand focus:ring-inset focus:ring-offset-[-2px] ' +
   'px-2 py-2 placeholder:text-ink-soft';
-
-interface EnumConfig {
-  choices: string[];
-}
 
 export function CellInput({ field, value, onChange, onClick }: CellInputProps) {
   function handleClick(e: React.MouseEvent) {
@@ -24,7 +21,7 @@ export function CellInput({ field, value, onChange, onClick }: CellInputProps) {
   }
 
   if (field.type === 'enum') {
-    const config = field.config as unknown as EnumConfig;
+    const config = field.config as Extract<SlotFieldConfig, { fieldType: 'enum' }>;
     const choices = config.choices ?? [];
     return (
       <select
@@ -47,7 +44,6 @@ export function CellInput({ field, value, onChange, onClick }: CellInputProps) {
     text: 'text',
     date: 'date',
     time: 'time',
-    number: 'number',
   };
 
   const inputType = typeMap[field.type] ?? 'text';

--- a/src/components/build-grid/CellInput.tsx
+++ b/src/components/build-grid/CellInput.tsx
@@ -1,0 +1,78 @@
+import type { GridField } from './useGridState';
+
+interface CellInputProps {
+  field: GridField;
+  value: string;
+  onChange: (value: string) => void;
+  onClick?: (e: React.MouseEvent) => void;
+}
+
+/** Shared input style classes applied to every input/select variant. */
+const inputClass =
+  'border-none bg-transparent w-full font-inherit text-[13px] text-ink ' +
+  'focus:outline-none focus:ring-2 focus:ring-brand focus:ring-inset focus:ring-offset-[-2px] ' +
+  'px-2 py-2 placeholder:text-ink-soft';
+
+interface EnumConfig {
+  choices: string[];
+}
+
+export function CellInput({ field, value, onChange, onClick }: CellInputProps) {
+  function handleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    onClick?.(e);
+  }
+
+  if (field.type === 'enum') {
+    const config = field.config as unknown as EnumConfig;
+    const choices = config.choices ?? [];
+    return (
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onClick={handleClick}
+        className={inputClass}
+      >
+        <option value="">—</option>
+        {choices.map((choice) => (
+          <option key={choice} value={choice}>
+            {choice}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  const typeMap: Record<string, string> = {
+    text: 'text',
+    date: 'date',
+    time: 'time',
+    number: 'number',
+  };
+
+  const inputType = typeMap[field.type] ?? 'text';
+
+  if (field.type === 'number') {
+    return (
+      <input
+        type="number"
+        min={0}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onClick={handleClick}
+        className={inputClass}
+      />
+    );
+  }
+
+  return (
+    <input
+      type={inputType}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onClick={handleClick}
+      className={inputClass}
+    />
+  );
+}

--- a/src/components/build-grid/FieldEditor.tsx
+++ b/src/components/build-grid/FieldEditor.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { FIELD_TYPE_META } from './fieldTypes';
+import { FIELD_TYPES } from '@/schemas/slot-fields';
+import type { FieldType, SlotFieldConfig } from '@/schemas/slot-fields';
+import type { GridField } from './useGridState';
+
+type FieldEditorMode =
+  | { mode: 'edit'; field: GridField }
+  | { mode: 'create'; type: 'enum' };
+
+type FieldEditorProps = {
+  editorMode: FieldEditorMode;
+  onSave: (type: FieldType, name: string, config: SlotFieldConfig, required: boolean) => void;
+  onDelete?: () => void;
+  onClose: () => void;
+};
+
+function buildConfig(type: FieldType, choices: string[]): SlotFieldConfig {
+  switch (type) {
+    case 'text':
+      return { fieldType: 'text', maxLength: 200 };
+    case 'date':
+      return { fieldType: 'date' };
+    case 'time':
+      return { fieldType: 'time' };
+    case 'number':
+      return { fieldType: 'number' };
+    case 'enum':
+      return { fieldType: 'enum', choices };
+  }
+}
+
+export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEditorProps) {
+  const isEdit = editorMode.mode === 'edit';
+
+  const [name, setName] = useState<string>(() => {
+    if (editorMode.mode === 'edit') return editorMode.field.name;
+    return FIELD_TYPE_META[editorMode.type].defaultName;
+  });
+
+  const [fieldType, setFieldType] = useState<FieldType>(() => {
+    if (editorMode.mode === 'edit') return editorMode.field.type;
+    return 'enum';
+  });
+
+  const [required, setRequired] = useState<boolean>(() => {
+    if (editorMode.mode === 'edit') return editorMode.field.required;
+    return true;
+  });
+
+  const [choicesText, setChoicesText] = useState<string>(() => {
+    if (
+      editorMode.mode === 'edit' &&
+      editorMode.field.config.fieldType === 'enum'
+    ) {
+      return editorMode.field.config.choices.join('\n');
+    }
+    return '';
+  });
+
+  function handleTypeChange(type: FieldType) {
+    if (type !== 'enum') {
+      setChoicesText('');
+    }
+    setFieldType(type);
+  }
+
+  function handleSave() {
+    if (!name.trim()) return;
+
+    let parsedChoices: string[] = [];
+    if (fieldType === 'enum') {
+      parsedChoices = choicesText
+        .split('\n')
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0);
+      if (parsedChoices.length === 0) return;
+    }
+
+    onSave(fieldType, name.trim(), buildConfig(fieldType, parsedChoices), required);
+  }
+
+  const titleText = isEdit ? 'Edit column' : 'New list column';
+
+  return (
+    <Dialog.Root open onOpenChange={(o) => { if (!o) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-[rgb(11_18_32/0.4)] backdrop-blur-sm z-50" />
+        <Dialog.Content className="fixed inset-0 grid place-items-center z-50 p-5">
+          <div className="bg-white rounded-2xl p-5 w-[460px] max-w-full shadow-[0_12px_48px_rgb(11_18_32/0.18)]">
+            {/* Header */}
+            <div className="flex items-start justify-between mb-4">
+              <Dialog.Title className="text-base font-semibold text-ink">
+                {titleText}
+              </Dialog.Title>
+              <button
+                onClick={onClose}
+                aria-label="Close"
+                className="p-1 rounded-lg text-ink-soft hover:text-ink hover:bg-surface-raised transition-colors"
+              >
+                <X size={14} />
+              </button>
+            </div>
+
+            {/* Form */}
+            <div className="flex flex-col gap-4">
+              {/* Name input */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-ink-soft" htmlFor="field-name">
+                  Name
+                </label>
+                <input
+                  id="field-name"
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="border border-surface-sunk rounded-lg px-2.5 py-2 text-sm font-[inherit] outline-none focus:border-brand focus:ring-1 focus:ring-brand bg-white w-full"
+                />
+              </div>
+
+              {/* Type pill grid */}
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-ink-soft">Type</span>
+                <div className="grid grid-cols-3 gap-2">
+                  {FIELD_TYPES.map((type) => {
+                    const meta = FIELD_TYPE_META[type];
+                    const Icon = meta.icon;
+                    const isActive = fieldType === type;
+                    return (
+                      <button
+                        key={type}
+                        onClick={() => handleTypeChange(type)}
+                        className={[
+                          'flex items-center gap-1.5 text-xs font-medium border rounded-[10px] px-2 py-2 cursor-pointer font-[inherit]',
+                          isActive
+                            ? 'bg-[rgb(31_111_235/0.10)] text-brand border-brand'
+                            : 'bg-white text-ink border-surface-sunk',
+                        ].join(' ')}
+                      >
+                        <Icon size={13} />
+                        {meta.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Choices textarea (enum only) */}
+              {fieldType === 'enum' && (
+                <div className="flex flex-col gap-1.5">
+                  <label className="text-xs font-medium text-ink-soft" htmlFor="field-choices">
+                    Choices (one per line)
+                  </label>
+                  <textarea
+                    id="field-choices"
+                    value={choicesText}
+                    onChange={(e) => setChoicesText(e.target.value)}
+                    placeholder={'Apples\nBananas\nOranges'}
+                    className="border border-surface-sunk rounded-lg px-2.5 py-2 text-sm font-[inherit] outline-none focus:border-brand focus:ring-1 focus:ring-brand bg-white w-full min-h-[80px] resize-y"
+                  />
+                </div>
+              )}
+
+              {/* Required checkbox */}
+              <label className="flex items-center gap-2 cursor-pointer text-sm text-ink">
+                <input
+                  type="checkbox"
+                  checked={required}
+                  onChange={(e) => setRequired(e.target.checked)}
+                  className="rounded"
+                />
+                Required for every slot
+              </label>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between mt-5">
+              <div>
+                {isEdit && onDelete && (
+                  <button
+                    onClick={onDelete}
+                    className="text-sm text-danger font-medium hover:opacity-70"
+                  >
+                    Remove column
+                  </button>
+                )}
+              </div>
+              <button
+                onClick={handleSave}
+                className="bg-brand text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-brand/90 transition-colors"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/build-grid/FieldPicker.tsx
+++ b/src/components/build-grid/FieldPicker.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { FIELD_TYPE_META } from './fieldTypes';
+import { FIELD_TYPES } from '@/schemas/slot-fields';
+import type { FieldType } from '@/schemas/slot-fields';
+
+type FieldPickerProps = {
+  onPick: (type: Exclude<FieldType, 'enum'>) => void;
+  onPickEnum: () => void;
+  onClose: () => void;
+};
+
+export function FieldPicker({ onPick, onPickEnum, onClose }: FieldPickerProps) {
+  return (
+    <Dialog.Root open onOpenChange={(o) => { if (!o) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-[rgb(11_18_32/0.4)] backdrop-blur-sm z-50" />
+        <Dialog.Content className="fixed inset-0 grid place-items-center z-50 p-5">
+          <div className="bg-white rounded-2xl p-5 w-[460px] max-w-full shadow-[0_12px_48px_rgb(11_18_32/0.18)]">
+            <div className="flex items-start justify-between mb-1">
+              <Dialog.Title className="text-base font-semibold text-ink">
+                What does this column track?
+              </Dialog.Title>
+              <button
+                onClick={onClose}
+                aria-label="Close"
+                className="p-1 rounded-lg text-ink-soft hover:text-ink hover:bg-surface-raised transition-colors"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <Dialog.Description className="text-sm text-ink-muted mb-3.5">
+              Pick a type — we&apos;ll set the right input.
+            </Dialog.Description>
+            <div className="grid grid-cols-3 gap-2">
+              {FIELD_TYPES.map((type) => {
+                const meta = FIELD_TYPE_META[type];
+                const Icon = meta.icon;
+                return (
+                  <button
+                    key={type}
+                    onClick={() => {
+                      if (type === 'enum') {
+                        onPickEnum();
+                      } else {
+                        onPick(type as Exclude<FieldType, 'enum'>);
+                      }
+                    }}
+                    className="bg-white border border-surface-sunk rounded-xl p-3 flex flex-col items-start gap-1.5 cursor-pointer text-left font-[inherit] hover:border-brand hover:bg-surface-raised transition-colors"
+                  >
+                    <Icon size={18} className="text-brand" />
+                    <span className="text-sm font-semibold text-ink">{meta.label}</span>
+                    <span className="text-xs text-ink-soft">{meta.placeholder}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -9,7 +9,7 @@ import type { GridField, GridRow } from './useGridState';
 interface GridBodyProps {
   fields: GridField[];
   rows: GridRow[];
-  previewRowIdx: number;
+  highlightedRowIdx: number;
   onSelectRow: (idx: number) => void;
   onEditCell: (rowId: string, fieldRef: string, value: string) => void;
   onSetCapacity: (rowId: string, capacity: number | null) => void;
@@ -21,7 +21,7 @@ interface GridBodyProps {
 export function GridBody({
   fields,
   rows,
-  previewRowIdx,
+  highlightedRowIdx,
   onSelectRow,
   onEditCell,
   onSetCapacity,
@@ -39,7 +39,7 @@ export function GridBody({
             display: 'grid',
             gridTemplateColumns: buildColsTemplate(fields),
             borderBottom: '1px solid #eef1f5',
-            background: i === previewRowIdx ? 'rgb(31 111 235 / 0.04)' : 'transparent',
+            background: i === highlightedRowIdx ? 'rgb(31 111 235 / 0.04)' : 'transparent',
             cursor: 'pointer',
           }}
           className="group transition-colors hover:bg-brand/5"
@@ -66,7 +66,10 @@ export function GridBody({
 
           {/* Capacity cell — 90px */}
           <div className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]">
-            <CapacityCell rowId={row.id} capacity={row.capacity} onChange={onSetCapacity} />
+            <CapacityCell
+              capacity={row.capacity}
+              onChange={(v) => onSetCapacity(row.id, v)}
+            />
           </div>
 
           {/* Trailing actions — 60px (visible on group-hover) */}
@@ -77,6 +80,7 @@ export function GridBody({
                 onMoveRowUp(row.id);
               }}
               title="Move up"
+              aria-label="Move row up"
               className="p-1 rounded text-ink-soft hover:text-ink hover:bg-surface-raised"
             >
               <ChevronUp size={12} />
@@ -87,6 +91,7 @@ export function GridBody({
                 onMoveRowDown(row.id);
               }}
               title="Move down"
+              aria-label="Move row down"
               className="p-1 rounded text-ink-soft hover:text-ink hover:bg-surface-raised"
             >
               <ChevronDown size={12} />
@@ -97,6 +102,7 @@ export function GridBody({
                 onDeleteRow(row.id);
               }}
               title="Remove row"
+              aria-label="Remove row"
               className="p-1 rounded text-ink-soft hover:text-danger hover:bg-surface-raised"
             >
               <X size={12} />

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { ChevronUp, ChevronDown, X } from 'lucide-react';
+import { buildColsTemplate } from './columnSizing';
+import { CellInput } from './CellInput';
+import { CapacityCell } from './CapacityCell';
+import type { GridField, GridRow } from './useGridState';
+
+interface GridBodyProps {
+  fields: GridField[];
+  rows: GridRow[];
+  previewRowIdx: number;
+  onSelectRow: (idx: number) => void;
+  onEditCell: (rowId: string, fieldRef: string, value: string) => void;
+  onSetCapacity: (rowId: string, capacity: number | null) => void;
+  onDeleteRow: (rowId: string) => void;
+  onMoveRowUp: (rowId: string) => void;
+  onMoveRowDown: (rowId: string) => void;
+}
+
+export function GridBody({
+  fields,
+  rows,
+  previewRowIdx,
+  onSelectRow,
+  onEditCell,
+  onSetCapacity,
+  onDeleteRow,
+  onMoveRowUp,
+  onMoveRowDown,
+}: GridBodyProps) {
+  return (
+    <div>
+      {rows.map((row, i) => (
+        <div
+          key={row.id}
+          onClick={() => onSelectRow(i)}
+          style={{
+            display: 'grid',
+            gridTemplateColumns: buildColsTemplate(fields),
+            borderBottom: '1px solid #eef1f5',
+            background: i === previewRowIdx ? 'rgb(31 111 235 / 0.04)' : 'transparent',
+            cursor: 'pointer',
+          }}
+          className="group transition-colors hover:bg-brand/5"
+        >
+          {/* Row index — 38px */}
+          <div className="flex items-center justify-center px-2 border-r border-surface-sunk">
+            <span className="text-[11px] text-ink-soft font-mono">{i + 1}</span>
+          </div>
+
+          {/* Field cells */}
+          {fields.map((f) => (
+            <div
+              key={f.id}
+              className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]"
+            >
+              <CellInput
+                field={f}
+                value={row.values[f.ref] ?? ''}
+                onChange={(v) => onEditCell(row.id, f.ref, v)}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </div>
+          ))}
+
+          {/* Capacity cell — 90px */}
+          <div className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]">
+            <CapacityCell rowId={row.id} capacity={row.capacity} onChange={onSetCapacity} />
+          </div>
+
+          {/* Trailing actions — 60px (visible on group-hover) */}
+          <div className="flex items-center justify-end gap-0.5 px-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onMoveRowUp(row.id);
+              }}
+              title="Move up"
+              className="p-1 rounded text-ink-soft hover:text-ink hover:bg-surface-raised"
+            >
+              <ChevronUp size={12} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onMoveRowDown(row.id);
+              }}
+              title="Move down"
+              className="p-1 rounded text-ink-soft hover:text-ink hover:bg-surface-raised"
+            >
+              <ChevronDown size={12} />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteRow(row.id);
+              }}
+              title="Remove row"
+              className="p-1 rounded text-ink-soft hover:text-danger hover:bg-surface-raised"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -73,7 +73,7 @@ export function GridBody({
           </div>
 
           {/* Trailing actions — 60px (visible on group-hover) */}
-          <div className="flex items-center justify-end gap-0.5 px-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <div className="flex items-center justify-end opacity-0 group-hover:opacity-100 transition-opacity">
             <button
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -8,7 +8,7 @@ import type { GridField } from './useGridState';
 
 interface GridHeaderProps {
   fields: GridField[];
-  onEditField: (fieldId: string) => void;
+  onEditField: (field: GridField) => void;
   onAddField: () => void;
   onResize: (fieldId: string, width: number) => void;
   onResetWidth: (fieldId: string) => void;
@@ -46,7 +46,7 @@ export function GridHeader({
             className="flex items-center border-r border-surface-sunk"
           >
             <button
-              onClick={() => onEditField(f.id)}
+              onClick={() => onEditField(f)}
               className="flex flex-1 items-center gap-1.5 px-2 py-2 text-left min-w-0 overflow-hidden text-ellipsis"
             >
               <Icon size={12} className="text-brand flex-shrink-0" />
@@ -56,9 +56,9 @@ export function GridHeader({
             </button>
             <ResizeHandle
               field={f}
-              isFirst={i === 0}
-              onResize={onResize}
-              onReset={onResetWidth}
+              fieldIndex={i}
+              onResize={(width) => onResize(f.id, width)}
+              onReset={() => onResetWidth(f.id)}
             />
           </div>
         );
@@ -74,6 +74,7 @@ export function GridHeader({
         <button
           onClick={onAddField}
           title="Add column"
+          aria-label="Add column"
           className="text-brand hover:text-brand/80 p-1 rounded"
         >
           <Plus size={13} />

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Plus, ChevronDown } from 'lucide-react';
+import { buildColsTemplate } from './columnSizing';
+import { fieldTypeMeta } from './fieldTypes';
+import { ResizeHandle } from './ResizeHandle';
+import type { GridField } from './useGridState';
+
+interface GridHeaderProps {
+  fields: GridField[];
+  onEditField: (fieldId: string) => void;
+  onAddField: () => void;
+  onResize: (fieldId: string, width: number) => void;
+  onResetWidth: (fieldId: string) => void;
+}
+
+export function GridHeader({
+  fields,
+  onEditField,
+  onAddField,
+  onResize,
+  onResetWidth,
+}: GridHeaderProps) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: buildColsTemplate(fields),
+        borderBottom: '1px solid #eef1f5',
+      }}
+      className="bg-surface-raised"
+    >
+      {/* Leading # column — 38px */}
+      <div className="flex items-center justify-center px-2 py-2 border-r border-surface-sunk">
+        <span className="text-[11px] text-ink-soft font-mono">#</span>
+      </div>
+
+      {/* Field columns */}
+      {fields.map((f, i) => {
+        const meta = fieldTypeMeta(f.type);
+        const Icon = meta.icon;
+        return (
+          <div
+            key={f.id}
+            style={{ position: 'relative' }}
+            className="flex items-center border-r border-surface-sunk"
+          >
+            <button
+              onClick={() => onEditField(f.id)}
+              className="flex flex-1 items-center gap-1.5 px-2 py-2 text-left min-w-0 overflow-hidden text-ellipsis"
+            >
+              <Icon size={12} className="text-brand flex-shrink-0" />
+              <span className="text-[13px] font-medium text-ink truncate">{f.name}</span>
+              {f.required && <span className="text-danger text-[11px]">*</span>}
+              <ChevronDown size={11} className="text-ink-soft ml-auto flex-shrink-0" />
+            </button>
+            <ResizeHandle
+              field={f}
+              isFirst={i === 0}
+              onResize={onResize}
+              onReset={onResetWidth}
+            />
+          </div>
+        );
+      })}
+
+      {/* Trailing Capacity header — 90px */}
+      <div className="flex items-center justify-center px-2 py-2 border-r border-surface-sunk">
+        <span className="text-[11px] text-ink-soft">Cap.</span>
+      </div>
+
+      {/* Trailing + button — 60px */}
+      <div className="flex items-center justify-center">
+        <button
+          onClick={onAddField}
+          title="Add column"
+          className="text-brand hover:text-brand/80 p-1 rounded"
+        >
+          <Plus size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -66,7 +66,7 @@ export function GridHeader({
 
       {/* Trailing Capacity header — 90px */}
       <div className="flex items-center justify-center px-2 py-2 border-r border-surface-sunk">
-        <span className="text-[11px] text-ink-soft">Cap.</span>
+        <span className="text-[13px] font-medium text-ink truncate">Cap.</span>
       </div>
 
       {/* Trailing + button — 60px */}

--- a/src/components/build-grid/ResizeHandle.tsx
+++ b/src/components/build-grid/ResizeHandle.tsx
@@ -6,53 +6,46 @@ import type { GridField } from './useGridState';
 
 interface ResizeHandleProps {
   field: GridField;
-  isFirst: boolean;
-  onResize: (fieldId: string, width: number) => void;
-  onReset: (fieldId: string) => void;
+  fieldIndex: number;
+  onResize: (width: number) => void;
+  onReset: () => void;
 }
 
-export function ResizeHandle({ field, isFirst, onResize, onReset }: ResizeHandleProps) {
+export function ResizeHandle({ field, fieldIndex, onResize, onReset }: ResizeHandleProps) {
   const [dragging, setDragging] = useState(false);
   const [hover, setHover] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [startWidth, setStartWidth] = useState(0);
 
-  function startDrag(e: React.PointerEvent) {
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
-    e.stopPropagation();
-
-    const startX = e.clientX;
-    const startW = widthFor(field, isFirst);
-
+    e.currentTarget.setPointerCapture(e.pointerId);
     setDragging(true);
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
+    setStartX(e.clientX);
+    setStartWidth(widthFor(field, fieldIndex));
+  };
 
-    function onPointerMove(moveEvent: PointerEvent) {
-      const delta = moveEvent.clientX - startX;
-      const next = Math.min(MAX_W, Math.max(MIN_W, startW + delta));
-      onResize(field.id, next);
-    }
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragging) return;
+    const next = Math.min(MAX_W, Math.max(MIN_W, startWidth + e.clientX - startX));
+    onResize(next);
+  };
 
-    function onPointerUp() {
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      setDragging(false);
-      window.removeEventListener('pointermove', onPointerMove);
-      window.removeEventListener('pointerup', onPointerUp);
-    }
-
-    window.addEventListener('pointermove', onPointerMove);
-    window.addEventListener('pointerup', onPointerUp);
-  }
+  const handlePointerUp = () => {
+    setDragging(false);
+  };
 
   function resetWidth(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
-    onReset(field.id);
+    onReset();
   }
 
   return (
     <div
-      onPointerDown={startDrag}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
       onDoubleClick={resetWidth}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}

--- a/src/components/build-grid/ResizeHandle.tsx
+++ b/src/components/build-grid/ResizeHandle.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState } from 'react';
+import { MIN_W, MAX_W, widthFor } from './columnSizing';
+import type { GridField } from './useGridState';
+
+interface ResizeHandleProps {
+  field: GridField;
+  isFirst: boolean;
+  onResize: (fieldId: string, width: number) => void;
+  onReset: (fieldId: string) => void;
+}
+
+export function ResizeHandle({ field, isFirst, onResize, onReset }: ResizeHandleProps) {
+  const [dragging, setDragging] = useState(false);
+  const [hover, setHover] = useState(false);
+
+  function startDrag(e: React.PointerEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const startX = e.clientX;
+    const startW = widthFor(field, isFirst);
+
+    setDragging(true);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    function onPointerMove(moveEvent: PointerEvent) {
+      const delta = moveEvent.clientX - startX;
+      const next = Math.min(MAX_W, Math.max(MIN_W, startW + delta));
+      onResize(field.id, next);
+    }
+
+    function onPointerUp() {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      setDragging(false);
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', onPointerUp);
+    }
+
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+  }
+
+  function resetWidth(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    onReset(field.id);
+  }
+
+  return (
+    <div
+      onPointerDown={startDrag}
+      onDoubleClick={resetWidth}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: -3,
+        bottom: 0,
+        width: 6,
+        cursor: 'col-resize',
+        zIndex: 5,
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 6,
+          bottom: 6,
+          left: 2,
+          width: 2,
+          borderRadius: 2,
+          background: dragging ? '#1f6feb' : hover ? '#dbe7ff' : 'transparent',
+          transition: 'background 0.12s',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/build-grid/ResizeHandle.tsx
+++ b/src/components/build-grid/ResizeHandle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { MIN_W, MAX_W, widthFor } from './columnSizing';
 import type { GridField } from './useGridState';
 
@@ -14,24 +14,29 @@ interface ResizeHandleProps {
 export function ResizeHandle({ field, fieldIndex, onResize, onReset }: ResizeHandleProps) {
   const [dragging, setDragging] = useState(false);
   const [hover, setHover] = useState(false);
-  const [startX, setStartX] = useState(0);
-  const [startWidth, setStartWidth] = useState(0);
+  const drag = useRef({ active: false, startX: 0, startWidth: 0 });
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = {
+      active: true,
+      startX: e.clientX,
+      startWidth:
+        e.currentTarget.parentElement?.getBoundingClientRect().width ??
+        widthFor(field, fieldIndex),
+    };
     setDragging(true);
-    setStartX(e.clientX);
-    setStartWidth(widthFor(field, fieldIndex));
   };
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!dragging) return;
-    const next = Math.min(MAX_W, Math.max(MIN_W, startWidth + e.clientX - startX));
+    if (!drag.current.active) return;
+    const next = Math.min(MAX_W, Math.max(MIN_W, drag.current.startWidth + e.clientX - drag.current.startX));
     onResize(next);
   };
 
   const handlePointerUp = () => {
+    drag.current.active = false;
     setDragging(false);
   };
 

--- a/src/components/build-grid/SaveStatus.tsx
+++ b/src/components/build-grid/SaveStatus.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Check, AlertCircle } from 'lucide-react';
+import { Spinner } from '@/components/ui/spinner';
+import type { SaveStatus } from './useGridState';
+
+type SaveStatusProps = {
+  status: SaveStatus;
+};
+
+export function SaveStatus({ status }: SaveStatusProps) {
+
+  if (status === 'idle') return null;
+
+  if (status === 'saving') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-ink-soft">
+        <Spinner className="size-3 border-[1.5px]" />
+        Saving…
+      </span>
+    );
+  }
+
+  if (status === 'saved') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-ink-soft">
+        <Check size={12} />
+        Saved
+      </span>
+    );
+  }
+
+  // error
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-danger">
+      <AlertCircle size={12} />
+      Save failed
+    </span>
+  );
+}

--- a/src/components/build-grid/ScrollableTable.tsx
+++ b/src/components/build-grid/ScrollableTable.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+interface ScrollableTableProps {
+  totalWidth: number;
+  children: React.ReactNode;
+}
+
+export function ScrollableTable({ totalWidth, children }: ScrollableTableProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [scrollState, setScrollState] = useState({ left: 0, max: 0 });
+  const lastRef = useRef({ left: 0, max: 0 });
+
+  const onScroll = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const next = { left: el.scrollLeft, max: el.scrollWidth - el.clientWidth };
+    const last = lastRef.current;
+    if (Math.abs(next.left - last.left) < 1 && Math.abs(next.max - last.max) < 1) return;
+    lastRef.current = next;
+    setScrollState(next);
+  }, []);
+
+  useEffect(() => {
+    onScroll();
+    if (!ref.current) return;
+    let raf = 0;
+    const ro = new ResizeObserver(() => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(onScroll);
+    });
+    ro.observe(ref.current);
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [totalWidth, onScroll]);
+
+  const showLeft = scrollState.left > 4;
+  const showRight = scrollState.max - scrollState.left > 4;
+
+  return (
+    <div style={{ position: 'relative' }}>
+      {/* Left fade */}
+      {showLeft && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            width: 24,
+            pointerEvents: 'none',
+            background: 'linear-gradient(to right, rgb(11 18 32 / 0.08), transparent)',
+            zIndex: 10,
+          }}
+        />
+      )}
+
+      {/* Right fade */}
+      {showRight && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            width: 24,
+            pointerEvents: 'none',
+            background: 'linear-gradient(to left, rgb(11 18 32 / 0.08), transparent)',
+            zIndex: 10,
+          }}
+        />
+      )}
+
+      {/* Scrollable inner container */}
+      <div
+        ref={ref}
+        onScroll={onScroll}
+        style={{ overflowX: 'auto', overflowY: 'visible' }}
+      >
+        {/* Content container — stretches to totalWidth minimum */}
+        <div style={{ minWidth: totalWidth, width: '100%' }}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Eye } from 'lucide-react';
+import { summarizeSlot } from '@/lib/slot-summary';
+import type { GridField, GridRow } from './useGridState';
+
+type SideRailProps = {
+  fields: GridField[];
+  rows: GridRow[];
+  previewRowIdx: number;
+  onSelectRow: (idx: number) => void;
+};
+
+export function SideRail({ fields, rows, previewRowIdx, onSelectRow }: SideRailProps) {
+  // summarizeSlot expects SlotFieldDefinition[] which has `label` not `name`
+  const fieldDefs = fields.map((f) => ({
+    id: f.id,
+    ref: f.ref,
+    label: f.name,
+    fieldType: f.type,
+    required: f.required,
+    sortOrder: f.sortOrder,
+    config: f.config,
+  }));
+
+  return (
+    <div className="sticky top-5 flex flex-col gap-2.5">
+      {/* Caption row */}
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-semibold text-brand tracking-wide">
+          <Eye size={12} className="text-brand" />
+          LIVE PREVIEW
+        </span>
+        <span className="text-xs text-ink-soft">
+          Row {previewRowIdx + 1} of {rows.length}
+        </span>
+      </div>
+
+      {/* Phone frame */}
+      <div className="bg-[#0b1220] rounded-[28px] p-2 shadow-[0_8px_32px_rgb(11_18_32/0.12)]">
+        {/* Screen */}
+        <div className="bg-surface-raised rounded-[22px] overflow-hidden h-[540px] flex flex-col">
+          {/* Status bar */}
+          <div className="h-7 bg-white flex items-center justify-between px-4 text-[10px] font-semibold text-ink flex-shrink-0">
+            <span>9:41</span>
+            <span>••• Wi-Fi 100%</span>
+          </div>
+
+          {/* Page content */}
+          <div className="flex-1 overflow-y-auto p-3.5 flex flex-col gap-2">
+            {/* Title */}
+            <div className="text-sm font-bold tracking-tight text-ink leading-snug">
+              Sign-up Preview
+            </div>
+
+            {/* Divider */}
+            <div className="h-px bg-surface-sunk my-1" />
+
+            {/* Slot cards */}
+            {rows.map((row, i) => {
+              const summary = summarizeSlot(fieldDefs, row.values as Record<string, unknown>);
+              const isActive = i === previewRowIdx;
+              return (
+                <button
+                  key={row.id}
+                  onClick={() => onSelectRow(i)}
+                  className={[
+                    'border rounded-[10px] p-2 w-full text-left font-[inherit] flex items-center justify-between gap-2 transition-all duration-100 cursor-pointer',
+                    isActive
+                      ? 'bg-white border-brand shadow-[0_0_0_2px_#dbe7ff]'
+                      : 'bg-transparent border-surface-sunk',
+                  ].join(' ')}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[12px] font-medium text-ink truncate">
+                      {summary || 'Untitled slot'}
+                    </div>
+                    <div className="text-[10px] text-ink-soft mt-0.5">
+                      0{row.capacity != null ? `/${row.capacity}` : ''} signed up
+                    </div>
+                  </div>
+                  <div
+                    className={[
+                      'text-[10px] font-medium px-2.5 py-0.5 rounded-full border flex-shrink-0',
+                      isActive
+                        ? 'bg-brand text-white border-brand'
+                        : 'bg-white text-ink border-surface-sunk',
+                    ].join(' ')}
+                  >
+                    Sign up
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/build-grid/Toolbar.tsx
+++ b/src/components/build-grid/Toolbar.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Plus, ChevronDown, Smartphone, X } from 'lucide-react';
+import { SaveStatus } from './SaveStatus';
+import type { GridField, GridRow, SaveStatus as SaveStatusType } from './useGridState';
+
+type ToolbarProps = {
+  fields: GridField[];
+  rows: GridRow[];
+  groupByFieldRef: string | null;
+  onGroupByChange: (ref: string | null) => void;
+  showPreview: boolean;
+  onTogglePreview: () => void;
+  saveStatus: SaveStatusType;
+  onAddField: () => void;
+};
+
+export function Toolbar({
+  fields,
+  rows,
+  groupByFieldRef,
+  onGroupByChange,
+  showPreview,
+  onTogglePreview,
+  saveStatus,
+  onAddField,
+}: ToolbarProps) {
+  const [groupByOpen, setGroupByOpen] = useState(false);
+  const groupByRef = useRef<HTMLDivElement>(null);
+
+  const groupableFields = fields.filter((f) => f.type === 'date' || f.type === 'text');
+  const activeField = groupByFieldRef
+    ? fields.find((f) => f.ref === groupByFieldRef)
+    : null;
+
+  useEffect(() => {
+    if (!groupByOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (groupByRef.current && !groupByRef.current.contains(e.target as Node)) {
+        setGroupByOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [groupByOpen]);
+
+  return (
+    <div className="flex items-center gap-2 px-3.5 py-2.5 border-b border-surface-sunk bg-surface-raised">
+      {/* Add column button */}
+      <button
+        onClick={onAddField}
+        aria-label="Add column"
+        className="flex items-center gap-1 text-sm text-ink-muted font-medium hover:text-ink"
+      >
+        <Plus size={13} />
+        Add column
+      </button>
+
+      {/* Divider */}
+      <div className="w-px h-4.5 bg-surface-sunk mx-1" />
+
+      {/* Group by label */}
+      <span className="text-xs text-ink-soft">Group by</span>
+
+      {/* Group by pill */}
+      <div ref={groupByRef} className="relative">
+        {activeField ? (
+          <div className="inline-flex items-center border rounded-full bg-[rgb(31_111_235/0.10)] border-brand-soft">
+            <button
+              onClick={() => setGroupByOpen((o) => !o)}
+              className="inline-flex items-center gap-1.5 pl-2.5 pr-1 py-1 text-xs font-medium text-brand bg-transparent border-none cursor-pointer font-[inherit]"
+              aria-label={`Group by ${activeField.name} — click to change`}
+            >
+              {activeField.name}
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onGroupByChange(null);
+                setGroupByOpen(false);
+              }}
+              className="inline-flex items-center pr-2 py-1 text-brand bg-transparent border-none cursor-pointer"
+              aria-label="Clear group by"
+            >
+              <X size={10} />
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setGroupByOpen((o) => !o)}
+            className="flex items-center gap-1 text-xs font-medium border rounded-full px-2.5 py-1 bg-white text-ink-muted border-surface-sunk"
+          >
+            None
+            <ChevronDown size={11} />
+          </button>
+        )}
+
+        {groupByOpen && (
+          <div className="absolute top-full left-0 mt-1 z-50 bg-white border border-surface-sunk rounded-lg shadow-md py-1 min-w-[140px]">
+            <button
+              onClick={() => {
+                onGroupByChange(null);
+                setGroupByOpen(false);
+              }}
+              className="w-full text-left px-3 py-1.5 text-xs text-ink-muted hover:bg-surface-raised"
+            >
+              None
+            </button>
+            {groupableFields.map((f) => (
+              <button
+                key={f.ref}
+                onClick={() => {
+                  onGroupByChange(f.ref);
+                  setGroupByOpen(false);
+                }}
+                className="w-full text-left px-3 py-1.5 text-xs text-ink hover:bg-surface-raised"
+              >
+                {f.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Stats */}
+      <span className="text-xs text-ink-soft">
+        {fields.length} fields · {rows.length} slots
+      </span>
+
+      {/* Divider */}
+      <div className="w-px h-4.5 bg-surface-sunk mx-1" />
+
+      {/* Save status */}
+      <SaveStatus status={saveStatus} />
+
+      {/* Live preview toggle */}
+      <button
+        onClick={onTogglePreview}
+        aria-label={showPreview ? 'Hide live preview' : 'Show live preview'}
+        className={[
+          'flex items-center gap-1.5 text-xs font-medium border rounded-full px-2.5 py-1',
+          showPreview
+            ? 'bg-[rgb(31_111_235/0.10)] text-brand border-brand-soft'
+            : 'bg-white text-ink-muted border-surface-sunk',
+        ].join(' ')}
+      >
+        <Smartphone size={12} />
+        Live preview
+      </button>
+    </div>
+  );
+}

--- a/src/components/build-grid/columnSizing.test.ts
+++ b/src/components/build-grid/columnSizing.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { COL_SIZING, MIN_W, MAX_W, sizingFor, buildColsTemplate, totalGridWidth } from './columnSizing';
+
+describe('sizingFor', () => {
+  it('returns fixed sizing for date type', () => {
+    expect(sizingFor({ type: 'date' }, false)).toEqual({ mode: 'fixed', px: 150 });
+  });
+
+  it('returns fixed sizing for time type', () => {
+    expect(sizingFor({ type: 'time' }, false)).toEqual({ mode: 'fixed', px: 110 });
+  });
+
+  it('returns fixed sizing for number type', () => {
+    expect(sizingFor({ type: 'number' }, false)).toEqual({ mode: 'fixed', px: 110 });
+  });
+
+  it('returns fixed sizing for enum type', () => {
+    expect(sizingFor({ type: 'enum' }, false)).toEqual({ mode: 'fixed', px: 150 });
+  });
+
+  it('returns flex sizing for text type (not first)', () => {
+    expect(sizingFor({ type: 'text' }, false)).toEqual({ mode: 'flex', min: 140, weight: 1.5 });
+  });
+
+  it('returns flex sizing for text type as first field with +0.5 weight bonus', () => {
+    expect(sizingFor({ type: 'text' }, true)).toEqual({ mode: 'flex', min: 140, weight: 2.0 });
+  });
+
+  it('returns fixed sizing when explicit width is set (overrides type)', () => {
+    expect(sizingFor({ type: 'text', width: 200 }, false)).toEqual({ mode: 'fixed', px: 200 });
+  });
+
+  it('clamps explicit width to MIN_W (60) if below', () => {
+    expect(sizingFor({ type: 'text', width: 30 }, false)).toEqual({ mode: 'fixed', px: MIN_W });
+  });
+
+  it('clamps explicit width to MAX_W (600) if above', () => {
+    expect(sizingFor({ type: 'date', width: 800 }, false)).toEqual({ mode: 'fixed', px: MAX_W });
+  });
+
+  it('uses width exactly at MIN_W boundary', () => {
+    expect(sizingFor({ type: 'text', width: 60 }, false)).toEqual({ mode: 'fixed', px: 60 });
+  });
+
+  it('uses width exactly at MAX_W boundary', () => {
+    expect(sizingFor({ type: 'text', width: 600 }, false)).toEqual({ mode: 'fixed', px: 600 });
+  });
+});
+
+describe('buildColsTemplate', () => {
+  it('returns fixed header/footer with no fields', () => {
+    expect(buildColsTemplate([])).toBe('38px 90px 60px');
+  });
+
+  it('inserts fixed px track for a date field', () => {
+    expect(buildColsTemplate([{ type: 'date' }])).toBe('38px 150px 90px 60px');
+  });
+
+  it('inserts minmax track for a text field (first text gets +0.5 bonus)', () => {
+    expect(buildColsTemplate([{ type: 'text' }])).toBe('38px minmax(140px, 2fr) 90px 60px');
+  });
+
+  it('handles two text fields: first is 2fr, second is 1.5fr', () => {
+    expect(buildColsTemplate([{ type: 'text' }, { type: 'text' }])).toBe(
+      '38px minmax(140px, 2fr) minmax(140px, 1.5fr) 90px 60px',
+    );
+  });
+
+  it('handles mixed fixed and flex fields', () => {
+    expect(buildColsTemplate([{ type: 'date' }, { type: 'text' }])).toBe(
+      '38px 150px minmax(140px, 1.5fr) 90px 60px',
+    );
+  });
+
+  it('uses custom width override as fixed track', () => {
+    expect(buildColsTemplate([{ type: 'text', width: 220 }])).toBe('38px 220px 90px 60px');
+  });
+});
+
+describe('totalGridWidth', () => {
+  it('returns 188 for no fields (38 + 90 + 60)', () => {
+    expect(totalGridWidth([])).toBe(188);
+  });
+
+  it('returns 338 for one date field (188 + 150)', () => {
+    expect(totalGridWidth([{ type: 'date' }])).toBe(338);
+  });
+
+  it('returns 328 for one text field (188 + 140)', () => {
+    expect(totalGridWidth([{ type: 'text' }])).toBe(328);
+  });
+
+  it('sums min widths for multiple fields', () => {
+    // date (150) + text (140) = 290 + 188 = 478
+    expect(totalGridWidth([{ type: 'date' }, { type: 'text' }])).toBe(478);
+  });
+});
+
+describe('COL_SIZING constants', () => {
+  it('exports correct defaults', () => {
+    expect(COL_SIZING.text).toEqual({ mode: 'flex', min: 140, weight: 1.5 });
+    expect(COL_SIZING.date).toEqual({ mode: 'fixed', px: 150 });
+    expect(COL_SIZING.time).toEqual({ mode: 'fixed', px: 110 });
+    expect(COL_SIZING.number).toEqual({ mode: 'fixed', px: 110 });
+    expect(COL_SIZING.enum).toEqual({ mode: 'fixed', px: 150 });
+  });
+
+  it('exports MIN_W as 60', () => {
+    expect(MIN_W).toBe(60);
+  });
+
+  it('exports MAX_W as 600', () => {
+    expect(MAX_W).toBe(600);
+  });
+});

--- a/src/components/build-grid/columnSizing.test.ts
+++ b/src/components/build-grid/columnSizing.test.ts
@@ -98,28 +98,28 @@ describe('totalGridWidth', () => {
 
 describe('widthFor', () => {
   it('returns fixed px for a date field', () => {
-    expect(widthFor({ type: 'date' }, false)).toBe(150);
+    expect(widthFor({ type: 'date' }, 1)).toBe(150);
   });
 
   it('returns flex min for a text field (not first)', () => {
-    expect(widthFor({ type: 'text' }, false)).toBe(140);
+    expect(widthFor({ type: 'text' }, 1)).toBe(140);
   });
 
   it('returns flex min for a text field (first, bonus does not affect min)', () => {
-    // isFirst adds weight bonus but does not change the min; widthFor returns min for flex
-    expect(widthFor({ type: 'text' }, true)).toBe(140);
+    // fieldIndex === 0 adds weight bonus but does not change the min; widthFor returns min for flex
+    expect(widthFor({ type: 'text' }, 0)).toBe(140);
   });
 
   it('returns the explicit width when set', () => {
-    expect(widthFor({ type: 'text', width: 220 }, false)).toBe(220);
+    expect(widthFor({ type: 'text', width: 220 }, 1)).toBe(220);
   });
 
   it('returns clamped MIN_W when explicit width is below minimum', () => {
-    expect(widthFor({ type: 'text', width: 20 }, false)).toBe(MIN_W);
+    expect(widthFor({ type: 'text', width: 20 }, 1)).toBe(MIN_W);
   });
 
   it('returns clamped MAX_W when explicit width is above maximum', () => {
-    expect(widthFor({ type: 'date', width: 900 }, false)).toBe(MAX_W);
+    expect(widthFor({ type: 'date', width: 900 }, 1)).toBe(MAX_W);
   });
 });
 

--- a/src/components/build-grid/columnSizing.test.ts
+++ b/src/components/build-grid/columnSizing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { COL_SIZING, MIN_W, MAX_W, sizingFor, buildColsTemplate, totalGridWidth } from './columnSizing';
+import { COL_SIZING, MIN_W, MAX_W, sizingFor, buildColsTemplate, totalGridWidth, widthFor } from './columnSizing';
 
 describe('sizingFor', () => {
   it('returns fixed sizing for date type', () => {
@@ -93,6 +93,33 @@ describe('totalGridWidth', () => {
   it('sums min widths for multiple fields', () => {
     // date (150) + text (140) = 290 + 188 = 478
     expect(totalGridWidth([{ type: 'date' }, { type: 'text' }])).toBe(478);
+  });
+});
+
+describe('widthFor', () => {
+  it('returns fixed px for a date field', () => {
+    expect(widthFor({ type: 'date' }, false)).toBe(150);
+  });
+
+  it('returns flex min for a text field (not first)', () => {
+    expect(widthFor({ type: 'text' }, false)).toBe(140);
+  });
+
+  it('returns flex min for a text field (first, bonus does not affect min)', () => {
+    // isFirst adds weight bonus but does not change the min; widthFor returns min for flex
+    expect(widthFor({ type: 'text' }, true)).toBe(140);
+  });
+
+  it('returns the explicit width when set', () => {
+    expect(widthFor({ type: 'text', width: 220 }, false)).toBe(220);
+  });
+
+  it('returns clamped MIN_W when explicit width is below minimum', () => {
+    expect(widthFor({ type: 'text', width: 20 }, false)).toBe(MIN_W);
+  });
+
+  it('returns clamped MAX_W when explicit width is above maximum', () => {
+    expect(widthFor({ type: 'date', width: 900 }, false)).toBe(MAX_W);
   });
 });
 

--- a/src/components/build-grid/columnSizing.ts
+++ b/src/components/build-grid/columnSizing.ts
@@ -69,6 +69,15 @@ export function buildColsTemplate(fields: SizableField[]): string {
 }
 
 /**
+ * Returns the effective pixel width for a field, resolving flex min or fixed px.
+ * Used by ResizeHandle to determine the starting width before a drag.
+ */
+export function widthFor(field: SizableField, isFirst: boolean): number {
+  const s = sizingFor(field, isFirst);
+  return s.mode === 'fixed' ? s.px : s.min;
+}
+
+/**
  * Returns the sum of minimum column widths for the full grid.
  *
  * = 38 (index) + 90 (capacity) + 60 (actions) + Σ each field's min/fixed width

--- a/src/components/build-grid/columnSizing.ts
+++ b/src/components/build-grid/columnSizing.ts
@@ -1,0 +1,83 @@
+// Column sizing model for the build grid.
+// Keep this module pure — no React, no imports from schemas.
+
+export type FieldSizing =
+  | { mode: 'flex'; min: number; weight: number }
+  | { mode: 'fixed'; px: number };
+
+// A minimal field interface for sizing (only what's needed).
+export interface SizableField {
+  type: string;
+  width?: number;
+}
+
+export const MIN_W = 60;
+export const MAX_W = 600;
+
+export const COL_SIZING: Record<string, FieldSizing> = {
+  text: { mode: 'flex', min: 140, weight: 1.5 },
+  date: { mode: 'fixed', px: 150 },
+  time: { mode: 'fixed', px: 110 },
+  number: { mode: 'fixed', px: 110 },
+  enum: { mode: 'fixed', px: 150 },
+};
+
+/**
+ * Returns the sizing descriptor for a single field.
+ *
+ * Priority:
+ * 1. If `field.width` is set → fixed mode with px clamped to [MIN_W, MAX_W].
+ * 2. Otherwise → lookup COL_SIZING[field.type]; for flex types add +0.5 weight
+ *    bonus when `isFirst` is true (first flex column gets extra weight).
+ */
+export function sizingFor(field: SizableField, isFirst: boolean): FieldSizing {
+  if (field.width !== undefined) {
+    return { mode: 'fixed', px: Math.min(MAX_W, Math.max(MIN_W, field.width)) };
+  }
+
+  const base = COL_SIZING[field.type] ?? COL_SIZING['text']!;
+
+  if (base.mode === 'flex' && isFirst) {
+    return { mode: 'flex', min: base.min, weight: base.weight + 0.5 };
+  }
+
+  return base;
+}
+
+/**
+ * Builds a CSS `grid-template-columns` string for the build grid.
+ *
+ * Layout: 38px <field tracks…> 90px 60px
+ * - 38px = leading row-index column
+ * - 90px = trailing Capacity column (fixed)
+ * - 60px = trailing actions column (fixed)
+ * - fixed fields → "${px}px"
+ * - flex fields  → "minmax(${min}px, ${weight}fr)"
+ *
+ * The +0.5 weight bonus is given only when the field is at index 0 in the
+ * fields array (i.e. it is the first field overall, not just the first flex).
+ */
+export function buildColsTemplate(fields: SizableField[]): string {
+  const tracks = fields.map((f, idx) => {
+    const isFirst = idx === 0;
+    const s = sizingFor(f, isFirst);
+    if (s.mode === 'fixed') return `${s.px}px`;
+    return `minmax(${s.min}px, ${s.weight}fr)`;
+  });
+
+  return ['38px', ...tracks, '90px', '60px'].join(' ');
+}
+
+/**
+ * Returns the sum of minimum column widths for the full grid.
+ *
+ * = 38 (index) + 90 (capacity) + 60 (actions) + Σ each field's min/fixed width
+ */
+export function totalGridWidth(fields: SizableField[]): number {
+  const FIXED_COLS = 38 + 90 + 60;
+  const fieldsWidth = fields.reduce((sum, f) => {
+    const s = sizingFor(f, false); // isFirst doesn't affect width for totalGridWidth
+    return sum + (s.mode === 'fixed' ? s.px : s.min);
+  }, 0);
+  return FIXED_COLS + fieldsWidth;
+}

--- a/src/components/build-grid/columnSizing.ts
+++ b/src/components/build-grid/columnSizing.ts
@@ -72,8 +72,8 @@ export function buildColsTemplate(fields: SizableField[]): string {
  * Returns the effective pixel width for a field, resolving flex min or fixed px.
  * Used by ResizeHandle to determine the starting width before a drag.
  */
-export function widthFor(field: SizableField, isFirst: boolean): number {
-  const s = sizingFor(field, isFirst);
+export function widthFor(field: SizableField, fieldIndex: number): number {
+  const s = sizingFor(field, fieldIndex === 0);
   return s.mode === 'fixed' ? s.px : s.min;
 }
 

--- a/src/components/build-grid/fieldTypes.ts
+++ b/src/components/build-grid/fieldTypes.ts
@@ -1,0 +1,49 @@
+import { Type, Calendar, Clock, Hash, List } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { FieldType } from '@/schemas/slot-fields';
+
+export interface FieldTypeMeta {
+  icon: LucideIcon;
+  label: string;
+  placeholder: string;
+  /** Default column name shown when the user adds this field type. */
+  defaultName: string;
+}
+
+export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
+  text: {
+    icon: Type,
+    label: 'Short text',
+    placeholder: 'e.g. vs Hawks',
+    defaultName: 'Name',
+  },
+  date: {
+    icon: Calendar,
+    label: 'Date',
+    placeholder: 'Date',
+    defaultName: 'Date',
+  },
+  time: {
+    icon: Clock,
+    label: 'Time',
+    placeholder: 'Time',
+    defaultName: 'Time',
+  },
+  number: {
+    icon: Hash,
+    label: 'Number',
+    placeholder: '0',
+    defaultName: 'Quantity',
+  },
+  enum: {
+    icon: List,
+    label: 'List',
+    placeholder: 'Choose…',
+    defaultName: 'Choice',
+  },
+};
+
+/** Returns metadata for a field type; falls back to `text` for unknown types. */
+export function fieldTypeMeta(type: FieldType): FieldTypeMeta {
+  return FIELD_TYPE_META[type] ?? FIELD_TYPE_META.text;
+}

--- a/src/components/build-grid/index.ts
+++ b/src/components/build-grid/index.ts
@@ -1,0 +1,1 @@
+export { BuildGrid } from './BuildGrid';

--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect } from 'vitest';
+import { gridReducer } from './useGridState';
+import type { GridState, GridField, GridRow } from './useGridState';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeField = (overrides: Partial<GridField> = {}): GridField => ({
+  id: 'field-1',
+  ref: 'name',
+  name: 'Name',
+  type: 'text',
+  required: true,
+  config: { fieldType: 'text', maxLength: 200 },
+  sortOrder: 0,
+  ...overrides,
+});
+
+const makeRow = (overrides: Partial<GridRow> = {}): GridRow => ({
+  id: 'row-1',
+  capacity: null,
+  sortOrder: 0,
+  values: {},
+  ...overrides,
+});
+
+const makeState = (overrides: Partial<GridState> = {}): GridState => ({
+  fields: [],
+  rows: [],
+  groupByFieldRef: null,
+  previewRowIdx: 0,
+  showPreview: false,
+  saveStatus: 'idle',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// SET_FIELD_WIDTH
+// ---------------------------------------------------------------------------
+
+describe('gridReducer SET_FIELD_WIDTH', () => {
+  it('sets width on the correct field', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta' });
+    const state = makeState({ fields: [field1, field2] });
+
+    const next = gridReducer(state, { type: 'SET_FIELD_WIDTH', fieldId: 'f1', width: 300 });
+
+    expect(next.fields[0]?.width).toBe(300);
+    expect(next.fields[1]?.width).toBeUndefined();
+  });
+
+  it('does not mutate other fields', () => {
+    const field1 = makeField({ id: 'f1' });
+    const field2 = makeField({ id: 'f2', name: 'Other', ref: 'other' });
+    const state = makeState({ fields: [field1, field2] });
+
+    const next = gridReducer(state, { type: 'SET_FIELD_WIDTH', fieldId: 'f1', width: 200 });
+
+    expect(next.fields[1]).toEqual(field2);
+  });
+
+  it('clears width when undefined is passed', () => {
+    const field = makeField({ id: 'f1', width: 300 });
+    const state = makeState({ fields: [field] });
+
+    const next = gridReducer(state, { type: 'SET_FIELD_WIDTH', fieldId: 'f1', width: undefined });
+
+    expect(next.fields[0]?.width).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPTIMISTIC_ADD_ROW
+// ---------------------------------------------------------------------------
+
+describe('gridReducer OPTIMISTIC_ADD_ROW', () => {
+  it('appends the new row to the end of rows', () => {
+    const row1 = makeRow({ id: 'r1' });
+    const row2 = makeRow({ id: 'r2' });
+    const state = makeState({ rows: [row1] });
+
+    const next = gridReducer(state, { type: 'OPTIMISTIC_ADD_ROW', row: row2 });
+
+    expect(next.rows).toHaveLength(2);
+    expect(next.rows[1]).toEqual(row2);
+  });
+
+  it('does not mutate existing rows', () => {
+    const row1 = makeRow({ id: 'r1' });
+    const state = makeState({ rows: [row1] });
+
+    const next = gridReducer(state, {
+      type: 'OPTIMISTIC_ADD_ROW',
+      row: makeRow({ id: 'r2' }),
+    });
+
+    expect(next.rows[0]).toEqual(row1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPTIMISTIC_REMOVE_ROW
+// ---------------------------------------------------------------------------
+
+describe('gridReducer OPTIMISTIC_REMOVE_ROW', () => {
+  it('removes the correct row', () => {
+    const row1 = makeRow({ id: 'r1' });
+    const row2 = makeRow({ id: 'r2' });
+    const state = makeState({ rows: [row1, row2] });
+
+    const next = gridReducer(state, { type: 'OPTIMISTIC_REMOVE_ROW', rowId: 'r1' });
+
+    expect(next.rows).toHaveLength(1);
+    expect(next.rows[0]?.id).toBe('r2');
+  });
+
+  it('leaves other rows unchanged', () => {
+    const row1 = makeRow({ id: 'r1', capacity: 5 });
+    const row2 = makeRow({ id: 'r2', capacity: 10 });
+    const state = makeState({ rows: [row1, row2] });
+
+    const next = gridReducer(state, { type: 'OPTIMISTIC_REMOVE_ROW', rowId: 'r1' });
+
+    expect(next.rows[0]).toEqual(row2);
+  });
+
+  it('returns empty rows when last row removed', () => {
+    const row1 = makeRow({ id: 'r1' });
+    const state = makeState({ rows: [row1] });
+
+    const next = gridReducer(state, { type: 'OPTIMISTIC_REMOVE_ROW', rowId: 'r1' });
+
+    expect(next.rows).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPTIMISTIC_EDIT_CELL
+// ---------------------------------------------------------------------------
+
+describe('gridReducer OPTIMISTIC_EDIT_CELL', () => {
+  it('updates the correct cell value', () => {
+    const row = makeRow({ id: 'r1', values: { name: 'Alice', date: '2026-01-01' } });
+    const state = makeState({ rows: [row] });
+
+    const next = gridReducer(state, {
+      type: 'OPTIMISTIC_EDIT_CELL',
+      rowId: 'r1',
+      fieldRef: 'name',
+      value: 'Bob',
+    });
+
+    expect(next.rows[0]?.values['name']).toBe('Bob');
+    expect(next.rows[0]?.values['date']).toBe('2026-01-01');
+  });
+
+  it('does not mutate other rows', () => {
+    const row1 = makeRow({ id: 'r1', values: { name: 'Alice' } });
+    const row2 = makeRow({ id: 'r2', values: { name: 'Carol' } });
+    const state = makeState({ rows: [row1, row2] });
+
+    const next = gridReducer(state, {
+      type: 'OPTIMISTIC_EDIT_CELL',
+      rowId: 'r1',
+      fieldRef: 'name',
+      value: 'Bob',
+    });
+
+    expect(next.rows[1]?.values['name']).toBe('Carol');
+  });
+
+  it('adds a new field ref to existing values if not present', () => {
+    const row = makeRow({ id: 'r1', values: { name: 'Alice' } });
+    const state = makeState({ rows: [row] });
+
+    const next = gridReducer(state, {
+      type: 'OPTIMISTIC_EDIT_CELL',
+      rowId: 'r1',
+      fieldRef: 'role',
+      value: 'Captain',
+    });
+
+    expect(next.rows[0]?.values['role']).toBe('Captain');
+    expect(next.rows[0]?.values['name']).toBe('Alice');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPTIMISTIC_SET_CAPACITY
+// ---------------------------------------------------------------------------
+
+describe('gridReducer OPTIMISTIC_SET_CAPACITY', () => {
+  it('updates capacity for the correct row', () => {
+    const row1 = makeRow({ id: 'r1', capacity: null });
+    const row2 = makeRow({ id: 'r2', capacity: 5 });
+    const state = makeState({ rows: [row1, row2] });
+
+    const next = gridReducer(state, { type: 'OPTIMISTIC_SET_CAPACITY', rowId: 'r1', capacity: 10 });
+
+    expect(next.rows[0]?.capacity).toBe(10);
+    expect(next.rows[1]?.capacity).toBe(5);
+  });
+
+  it('sets capacity to null', () => {
+    const row = makeRow({ id: 'r1', capacity: 10 });
+    const state = makeState({ rows: [row] });
+
+    const next = gridReducer(state, { type: 'OPTIMISTIC_SET_CAPACITY', rowId: 'r1', capacity: null });
+
+    expect(next.rows[0]?.capacity).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SET_SAVE_STATUS
+// ---------------------------------------------------------------------------
+
+describe('gridReducer SET_SAVE_STATUS', () => {
+  it('updates saveStatus to saving', () => {
+    const state = makeState({ saveStatus: 'idle' });
+    const next = gridReducer(state, { type: 'SET_SAVE_STATUS', status: 'saving' });
+    expect(next.saveStatus).toBe('saving');
+  });
+
+  it('updates saveStatus to saved', () => {
+    const state = makeState({ saveStatus: 'saving' });
+    const next = gridReducer(state, { type: 'SET_SAVE_STATUS', status: 'saved' });
+    expect(next.saveStatus).toBe('saved');
+  });
+
+  it('updates saveStatus to error', () => {
+    const state = makeState({ saveStatus: 'saving' });
+    const next = gridReducer(state, { type: 'SET_SAVE_STATUS', status: 'error' });
+    expect(next.saveStatus).toBe('error');
+  });
+
+  it('updates saveStatus back to idle', () => {
+    const state = makeState({ saveStatus: 'saved' });
+    const next = gridReducer(state, { type: 'SET_SAVE_STATUS', status: 'idle' });
+    expect(next.saveStatus).toBe('idle');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SET_SHOW_PREVIEW
+// ---------------------------------------------------------------------------
+
+describe('gridReducer SET_SHOW_PREVIEW', () => {
+  it('sets showPreview to true', () => {
+    const state = makeState({ showPreview: false });
+    const next = gridReducer(state, { type: 'SET_SHOW_PREVIEW', show: true });
+    expect(next.showPreview).toBe(true);
+  });
+
+  it('sets showPreview to false', () => {
+    const state = makeState({ showPreview: true });
+    const next = gridReducer(state, { type: 'SET_SHOW_PREVIEW', show: false });
+    expect(next.showPreview).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SET_GROUP_BY
+// ---------------------------------------------------------------------------
+
+describe('gridReducer SET_GROUP_BY', () => {
+  it('sets groupByFieldRef to a ref string', () => {
+    const state = makeState({ groupByFieldRef: null });
+    const next = gridReducer(state, { type: 'SET_GROUP_BY', ref: 'date' });
+    expect(next.groupByFieldRef).toBe('date');
+  });
+
+  it('clears groupByFieldRef to null', () => {
+    const state = makeState({ groupByFieldRef: 'date' });
+    const next = gridReducer(state, { type: 'SET_GROUP_BY', ref: null });
+    expect(next.groupByFieldRef).toBeNull();
+  });
+});

--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -278,3 +278,132 @@ describe('gridReducer SET_GROUP_BY', () => {
     expect(next.groupByFieldRef).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// APPEND_FIELD
+// ---------------------------------------------------------------------------
+
+describe('gridReducer APPEND_FIELD', () => {
+  it('appends the new field to the end of fields', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta' });
+    const state = makeState({ fields: [field1] });
+
+    const next = gridReducer(state, { type: 'APPEND_FIELD', field: field2 });
+
+    expect(next.fields).toHaveLength(2);
+    expect(next.fields[1]).toEqual(field2);
+  });
+
+  it('does not mutate existing fields', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta' });
+    const state = makeState({ fields: [field1] });
+
+    const next = gridReducer(state, { type: 'APPEND_FIELD', field: field2 });
+
+    expect(next.fields[0]).toEqual(field1);
+  });
+
+  it('works when fields is empty', () => {
+    const field = makeField({ id: 'f1', ref: 'alpha' });
+    const state = makeState({ fields: [] });
+
+    const next = gridReducer(state, { type: 'APPEND_FIELD', field });
+
+    expect(next.fields).toHaveLength(1);
+    expect(next.fields[0]).toEqual(field);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REPLACE_FIELD
+// ---------------------------------------------------------------------------
+
+describe('gridReducer REPLACE_FIELD', () => {
+  it('replaces the matching field by id', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha', name: 'Alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta', name: 'Beta' });
+    const updatedField1 = makeField({ id: 'f1', ref: 'alpha', name: 'Alpha Updated' });
+    const state = makeState({ fields: [field1, field2] });
+
+    const next = gridReducer(state, { type: 'REPLACE_FIELD', field: updatedField1 });
+
+    expect(next.fields[0]?.name).toBe('Alpha Updated');
+    expect(next.fields[1]).toEqual(field2);
+  });
+
+  it('does not change fields if id is not found', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const ghost = makeField({ id: 'f99', ref: 'ghost', name: 'Ghost' });
+    const state = makeState({ fields: [field1] });
+
+    const next = gridReducer(state, { type: 'REPLACE_FIELD', field: ghost });
+
+    expect(next.fields).toHaveLength(1);
+    expect(next.fields[0]).toEqual(field1);
+  });
+
+  it('does not mutate other fields', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta', name: 'Beta' });
+    const updatedField1 = makeField({ id: 'f1', ref: 'alpha', name: 'Alpha Updated' });
+    const state = makeState({ fields: [field1, field2] });
+
+    const next = gridReducer(state, { type: 'REPLACE_FIELD', field: updatedField1 });
+
+    expect(next.fields[1]).toEqual(field2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE_FIELD
+// ---------------------------------------------------------------------------
+
+describe('gridReducer DELETE_FIELD', () => {
+  it('removes the field with the given id from fields', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta' });
+    const state = makeState({ fields: [field1, field2] });
+
+    const next = gridReducer(state, { type: 'DELETE_FIELD', fieldId: 'f1', fieldRef: 'alpha' });
+
+    expect(next.fields).toHaveLength(1);
+    expect(next.fields[0]?.id).toBe('f2');
+  });
+
+  it('strips the fieldRef from all rows values', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const row1 = makeRow({ id: 'r1', values: { alpha: 'hello', beta: 'world' } });
+    const row2 = makeRow({ id: 'r2', values: { alpha: 'foo', beta: 'bar' } });
+    const state = makeState({ fields: [field1], rows: [row1, row2] });
+
+    const next = gridReducer(state, { type: 'DELETE_FIELD', fieldId: 'f1', fieldRef: 'alpha' });
+
+    expect(next.rows[0]?.values).toEqual({ beta: 'world' });
+    expect(next.rows[1]?.values).toEqual({ beta: 'bar' });
+  });
+
+  it('does not affect rows that do not have the fieldRef', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const row1 = makeRow({ id: 'r1', values: { beta: 'world' } });
+    const state = makeState({ fields: [field1], rows: [row1] });
+
+    const next = gridReducer(state, { type: 'DELETE_FIELD', fieldId: 'f1', fieldRef: 'alpha' });
+
+    expect(next.rows[0]?.values).toEqual({ beta: 'world' });
+  });
+
+  it('atomically removes field and strips rows in one action', () => {
+    const field1 = makeField({ id: 'f1', ref: 'alpha' });
+    const field2 = makeField({ id: 'f2', ref: 'beta' });
+    const row1 = makeRow({ id: 'r1', values: { alpha: 'a', beta: 'b' } });
+    const state = makeState({ fields: [field1, field2], rows: [row1] });
+
+    const next = gridReducer(state, { type: 'DELETE_FIELD', fieldId: 'f1', fieldRef: 'alpha' });
+
+    expect(next.fields).toHaveLength(1);
+    expect(next.fields[0]?.id).toBe('f2');
+    expect(next.rows[0]?.values).toEqual({ beta: 'b' });
+  });
+});

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -49,7 +49,10 @@ export type GridAction =
   | { type: 'OPTIMISTIC_ADD_ROW'; row: GridRow }
   | { type: 'OPTIMISTIC_REMOVE_ROW'; rowId: string }
   | { type: 'OPTIMISTIC_EDIT_CELL'; rowId: string; fieldRef: string; value: string }
-  | { type: 'OPTIMISTIC_SET_CAPACITY'; rowId: string; capacity: number | null };
+  | { type: 'OPTIMISTIC_SET_CAPACITY'; rowId: string; capacity: number | null }
+  | { type: 'APPEND_FIELD'; field: GridField }
+  | { type: 'REPLACE_FIELD'; field: GridField }
+  | { type: 'DELETE_FIELD'; fieldId: string; fieldRef: string };
 
 // ---------------------------------------------------------------------------
 // Reducer (exported for testing)
@@ -105,6 +108,25 @@ export function gridReducer(state: GridState, action: GridAction): GridState {
         rows: state.rows.map((r) =>
           r.id === action.rowId ? { ...r, capacity: action.capacity } : r,
         ),
+      };
+
+    case 'APPEND_FIELD':
+      return { ...state, fields: [...state.fields, action.field] };
+
+    case 'REPLACE_FIELD':
+      return {
+        ...state,
+        fields: state.fields.map((f) => (f.id === action.field.id ? action.field : f)),
+      };
+
+    case 'DELETE_FIELD':
+      return {
+        ...state,
+        fields: state.fields.filter((f) => f.id !== action.fieldId),
+        rows: state.rows.map((r) => {
+          const { [action.fieldRef]: _, ...rest } = r.values;
+          return { ...r, values: rest };
+        }),
       };
 
     default:
@@ -209,13 +231,13 @@ export function useGridState(
         if (!res.ok) throw new Error(await res.text());
         const envelope = (await res.json()) as { data: SlotFieldDefinition };
         const field = toGridFields([envelope.data])[0]!;
-        dispatch({ type: 'SET_FIELDS', fields: [...state.fields, field] });
+        dispatch({ type: 'APPEND_FIELD', field });
         markSaved();
       } catch {
         markError();
       }
     },
-    [signupId, state.fields],
+    [signupId],
   );
 
   const updateField = useCallback(
@@ -239,47 +261,33 @@ export function useGridState(
         if (!res.ok) throw new Error(await res.text());
         const envelope = (await res.json()) as { data: SlotFieldDefinition };
         const updated = toGridFields([envelope.data])[0]!;
-        dispatch({
-          type: 'SET_FIELDS',
-          fields: state.fields.map((f) => (f.id === fieldId ? updated : f)),
-        });
+        dispatch({ type: 'REPLACE_FIELD', field: updated });
         markSaved();
       } catch {
         markError();
       }
     },
-    [signupId, state.fields],
+    [signupId],
   );
 
   const deleteField = useCallback(
     async (fieldId: string): Promise<void> => {
       const field = state.fields.find((f) => f.id === fieldId);
       if (!field) return;
+      const fieldRef = field.ref;
       markSaving();
       try {
         const res = await fetch(`/api/signups/${signupId}/fields/${fieldId}`, {
           method: 'DELETE',
         });
         if (!res.ok) throw new Error(await res.text());
-        dispatch({
-          type: 'SET_FIELDS',
-          fields: state.fields.filter((f) => f.id !== fieldId),
-        });
-        // Remove the field's values from all rows
-        const fieldRef = field.ref;
-        dispatch({
-          type: 'SET_ROWS',
-          rows: state.rows.map((r) => {
-            const { [fieldRef]: _removed, ...rest } = r.values;
-            return { ...r, values: rest };
-          }),
-        });
+        dispatch({ type: 'DELETE_FIELD', fieldId, fieldRef });
         markSaved();
       } catch {
         markError();
       }
     },
-    [signupId, state.fields, state.rows],
+    [signupId, state.fields],
   );
 
   const moveFieldUp = useCallback(

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -192,6 +192,8 @@ export function useGridState(
   // Per-slot debounce entries: key = `${rowId}:${fieldRef}` or `${rowId}:capacity`
   type DebounceEntry = { timeoutId: ReturnType<typeof setTimeout>; saveFn: () => Promise<void> };
   const timersRef = useRef<Map<string, DebounceEntry>>(new Map());
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   // ---------------------------------------------------------------------------
   // Save status helpers
@@ -522,12 +524,14 @@ export function useGridState(
       dispatch({ type: 'OPTIMISTIC_EDIT_CELL', rowId, fieldRef, value });
       const key = `${rowId}:${fieldRef}`;
       flushTimer(key, async () => {
+        const row = stateRef.current.rows.find((r) => r.id === rowId);
+        if (!row) return;
         markSaving();
         try {
           const res = await fetch(`/api/slots/${rowId}`, {
             method: 'PATCH',
             headers: JSON_HEADERS,
-            body: JSON.stringify({ values: { [fieldRef]: value } }),
+            body: JSON.stringify({ values: row.values }),
           });
           if (!res.ok) throw new Error(await res.text());
           markSaved();

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -1,0 +1,619 @@
+import { useReducer, useRef, useEffect, useCallback } from 'react';
+import type { SlotFieldDefinition, SlotFieldConfig, FieldType } from '@/schemas/slot-fields';
+
+// ---------------------------------------------------------------------------
+// State types
+// ---------------------------------------------------------------------------
+
+export type GridField = {
+  id: string;
+  ref: string;
+  name: string; // field label
+  type: FieldType;
+  required: boolean;
+  config: SlotFieldConfig;
+  sortOrder: number;
+  width?: number; // session-only resize override; not sent to API
+};
+
+export type GridRow = {
+  id: string;
+  capacity: number | null;
+  sortOrder: number;
+  values: Record<string, string>; // fieldRef → string value
+};
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export type GridState = {
+  fields: GridField[];
+  rows: GridRow[];
+  groupByFieldRef: string | null;
+  previewRowIdx: number;
+  showPreview: boolean;
+  saveStatus: SaveStatus;
+};
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export type GridAction =
+  | { type: 'SET_FIELDS'; fields: GridField[] }
+  | { type: 'SET_ROWS'; rows: GridRow[] }
+  | { type: 'SET_FIELD_WIDTH'; fieldId: string; width: number | undefined }
+  | { type: 'SET_PREVIEW_ROW'; idx: number }
+  | { type: 'SET_SHOW_PREVIEW'; show: boolean }
+  | { type: 'SET_GROUP_BY'; ref: string | null }
+  | { type: 'SET_SAVE_STATUS'; status: SaveStatus }
+  | { type: 'OPTIMISTIC_ADD_ROW'; row: GridRow }
+  | { type: 'OPTIMISTIC_REMOVE_ROW'; rowId: string }
+  | { type: 'OPTIMISTIC_EDIT_CELL'; rowId: string; fieldRef: string; value: string }
+  | { type: 'OPTIMISTIC_SET_CAPACITY'; rowId: string; capacity: number | null };
+
+// ---------------------------------------------------------------------------
+// Reducer (exported for testing)
+// ---------------------------------------------------------------------------
+
+export function gridReducer(state: GridState, action: GridAction): GridState {
+  switch (action.type) {
+    case 'SET_FIELDS':
+      return { ...state, fields: action.fields };
+
+    case 'SET_ROWS':
+      return { ...state, rows: action.rows };
+
+    case 'SET_FIELD_WIDTH':
+      return {
+        ...state,
+        fields: state.fields.map((f) =>
+          f.id === action.fieldId ? { ...f, width: action.width } : f,
+        ),
+      };
+
+    case 'SET_PREVIEW_ROW':
+      return { ...state, previewRowIdx: action.idx };
+
+    case 'SET_SHOW_PREVIEW':
+      return { ...state, showPreview: action.show };
+
+    case 'SET_GROUP_BY':
+      return { ...state, groupByFieldRef: action.ref };
+
+    case 'SET_SAVE_STATUS':
+      return { ...state, saveStatus: action.status };
+
+    case 'OPTIMISTIC_ADD_ROW':
+      return { ...state, rows: [...state.rows, action.row] };
+
+    case 'OPTIMISTIC_REMOVE_ROW':
+      return { ...state, rows: state.rows.filter((r) => r.id !== action.rowId) };
+
+    case 'OPTIMISTIC_EDIT_CELL':
+      return {
+        ...state,
+        rows: state.rows.map((r) =>
+          r.id === action.rowId
+            ? { ...r, values: { ...r.values, [action.fieldRef]: action.value } }
+            : r,
+        ),
+      };
+
+    case 'OPTIMISTIC_SET_CAPACITY':
+      return {
+        ...state,
+        rows: state.rows.map((r) =>
+          r.id === action.rowId ? { ...r, capacity: action.capacity } : r,
+        ),
+      };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level constants (stable, no need to be inside the hook)
+// ---------------------------------------------------------------------------
+
+const DEBOUNCE_MS = 800;
+const SAVED_CLEAR_MS = 3000;
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toGridFields(fields: SlotFieldDefinition[]): GridField[] {
+  return fields.map((f) => ({
+    id: f.id,
+    ref: f.ref,
+    name: f.label,
+    type: f.fieldType,
+    required: f.required,
+    config: f.config,
+    sortOrder: f.sortOrder,
+  }));
+}
+
+function toStringValues(values: Record<string, unknown>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(values)) {
+    result[k] = v === null || v === undefined ? '' : String(v);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useGridState(
+  signupId: string,
+  initialFields: SlotFieldDefinition[],
+  initialRows: Array<{ id: string; capacity: number | null; sortOrder?: number; values: Record<string, unknown> }>,
+) {
+  const [state, dispatch] = useReducer(gridReducer, undefined, () => ({
+    fields: toGridFields(initialFields),
+    rows: initialRows.map((r, i) => ({
+      id: r.id,
+      capacity: r.capacity,
+      sortOrder: r.sortOrder ?? i,
+      values: toStringValues(r.values),
+    })),
+    groupByFieldRef: null,
+    previewRowIdx: 0,
+    showPreview: false,
+    saveStatus: 'idle' as SaveStatus,
+  }));
+
+  // Per-slot debounce entries: key = `${rowId}:${fieldRef}` or `${rowId}:capacity`
+  type DebounceEntry = { timeoutId: ReturnType<typeof setTimeout>; saveFn: () => Promise<void> };
+  const timersRef = useRef<Map<string, DebounceEntry>>(new Map());
+
+  // ---------------------------------------------------------------------------
+  // Save status helpers
+  // ---------------------------------------------------------------------------
+
+  function markSaving() {
+    dispatch({ type: 'SET_SAVE_STATUS', status: 'saving' });
+  }
+
+  function markSaved() {
+    dispatch({ type: 'SET_SAVE_STATUS', status: 'saved' });
+    setTimeout(() => dispatch({ type: 'SET_SAVE_STATUS', status: 'idle' }), SAVED_CLEAR_MS);
+  }
+
+  function markError() {
+    dispatch({ type: 'SET_SAVE_STATUS', status: 'error' });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Field mutations
+  // ---------------------------------------------------------------------------
+
+  const addField = useCallback(
+    async (
+      type: FieldType,
+      name: string,
+      config: SlotFieldConfig,
+      required: boolean,
+    ): Promise<void> => {
+      markSaving();
+      try {
+        const res = await fetch(`/api/signups/${signupId}/fields`, {
+          method: 'POST',
+          headers: JSON_HEADERS,
+          body: JSON.stringify({ label: name, fieldType: type, config, required }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const envelope = (await res.json()) as { data: SlotFieldDefinition };
+        const field = toGridFields([envelope.data])[0]!;
+        dispatch({ type: 'SET_FIELDS', fields: [...state.fields, field] });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [signupId, state.fields],
+  );
+
+  const updateField = useCallback(
+    async (
+      fieldId: string,
+      patch: { name?: string; type?: FieldType; required?: boolean; config?: SlotFieldConfig },
+    ): Promise<void> => {
+      markSaving();
+      try {
+        const body: Record<string, unknown> = {};
+        if (patch.name !== undefined) body['label'] = patch.name;
+        if (patch.type !== undefined) body['fieldType'] = patch.type;
+        if (patch.required !== undefined) body['required'] = patch.required;
+        if (patch.config !== undefined) body['config'] = patch.config;
+
+        const res = await fetch(`/api/signups/${signupId}/fields/${fieldId}`, {
+          method: 'PATCH',
+          headers: JSON_HEADERS,
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const envelope = (await res.json()) as { data: SlotFieldDefinition };
+        const updated = toGridFields([envelope.data])[0]!;
+        dispatch({
+          type: 'SET_FIELDS',
+          fields: state.fields.map((f) => (f.id === fieldId ? updated : f)),
+        });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [signupId, state.fields],
+  );
+
+  const deleteField = useCallback(
+    async (fieldId: string): Promise<void> => {
+      const field = state.fields.find((f) => f.id === fieldId);
+      if (!field) return;
+      markSaving();
+      try {
+        const res = await fetch(`/api/signups/${signupId}/fields/${fieldId}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) throw new Error(await res.text());
+        dispatch({
+          type: 'SET_FIELDS',
+          fields: state.fields.filter((f) => f.id !== fieldId),
+        });
+        // Remove the field's values from all rows
+        const fieldRef = field.ref;
+        dispatch({
+          type: 'SET_ROWS',
+          rows: state.rows.map((r) => {
+            const { [fieldRef]: _removed, ...rest } = r.values;
+            return { ...r, values: rest };
+          }),
+        });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [signupId, state.fields, state.rows],
+  );
+
+  const moveFieldUp = useCallback(
+    async (fieldId: string): Promise<void> => {
+      const idx = state.fields.findIndex((f) => f.id === fieldId);
+      if (idx <= 0) return;
+      const above = state.fields[idx - 1]!;
+      const current = state.fields[idx]!;
+      const newAboveSortOrder = current.sortOrder;
+      const newCurrentSortOrder = above.sortOrder;
+
+      markSaving();
+      try {
+        await Promise.all([
+          fetch(`/api/signups/${signupId}/fields/${above.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newAboveSortOrder }),
+          }),
+          fetch(`/api/signups/${signupId}/fields/${current.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newCurrentSortOrder }),
+          }),
+        ]);
+        const updatedFields = state.fields.map((f) => {
+          if (f.id === above.id) return { ...f, sortOrder: newAboveSortOrder };
+          if (f.id === current.id) return { ...f, sortOrder: newCurrentSortOrder };
+          return f;
+        });
+        dispatch({
+          type: 'SET_FIELDS',
+          fields: [...updatedFields].sort((a, b) => a.sortOrder - b.sortOrder),
+        });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [signupId, state.fields],
+  );
+
+  const moveFieldDown = useCallback(
+    async (fieldId: string): Promise<void> => {
+      const idx = state.fields.findIndex((f) => f.id === fieldId);
+      if (idx < 0 || idx >= state.fields.length - 1) return;
+      const current = state.fields[idx]!;
+      const below = state.fields[idx + 1]!;
+      const newCurrentSortOrder = below.sortOrder;
+      const newBelowSortOrder = current.sortOrder;
+
+      markSaving();
+      try {
+        await Promise.all([
+          fetch(`/api/signups/${signupId}/fields/${current.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newCurrentSortOrder }),
+          }),
+          fetch(`/api/signups/${signupId}/fields/${below.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newBelowSortOrder }),
+          }),
+        ]);
+        const updatedFields = state.fields.map((f) => {
+          if (f.id === current.id) return { ...f, sortOrder: newCurrentSortOrder };
+          if (f.id === below.id) return { ...f, sortOrder: newBelowSortOrder };
+          return f;
+        });
+        dispatch({
+          type: 'SET_FIELDS',
+          fields: [...updatedFields].sort((a, b) => a.sortOrder - b.sortOrder),
+        });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [signupId, state.fields],
+  );
+
+  const setFieldWidth = useCallback(
+    (fieldId: string, width: number | undefined): void => {
+      dispatch({ type: 'SET_FIELD_WIDTH', fieldId, width });
+    },
+    [],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Row mutations
+  // ---------------------------------------------------------------------------
+
+  const addRow = useCallback(async (): Promise<void> => {
+    markSaving();
+    try {
+      const res = await fetch(`/api/signups/${signupId}/slots`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ values: {}, capacity: 1 }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const envelope = (await res.json()) as {
+        data: { id: string; capacity: number | null; sortOrder: number; values: Record<string, unknown> };
+      };
+      const slot = envelope.data;
+      dispatch({
+        type: 'OPTIMISTIC_ADD_ROW',
+        row: {
+          id: slot.id,
+          capacity: slot.capacity,
+          sortOrder: slot.sortOrder,
+          values: toStringValues(slot.values ?? {}),
+        },
+      });
+      markSaved();
+    } catch {
+      markError();
+    }
+  }, [signupId]);
+
+  const deleteRow = useCallback(async (rowId: string): Promise<void> => {
+    markSaving();
+    try {
+      const res = await fetch(`/api/slots/${rowId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(await res.text());
+      dispatch({ type: 'OPTIMISTIC_REMOVE_ROW', rowId });
+      markSaved();
+    } catch {
+      markError();
+    }
+    // markSaving/Saved/Error are stable (inline fns, not deps); rowId is a param
+  }, []);
+
+  const moveRowUp = useCallback(
+    async (rowId: string): Promise<void> => {
+      const idx = state.rows.findIndex((r) => r.id === rowId);
+      if (idx <= 0) return;
+      const above = state.rows[idx - 1]!;
+      const current = state.rows[idx]!;
+      const newAboveSortOrder = current.sortOrder;
+      const newCurrentSortOrder = above.sortOrder;
+
+      markSaving();
+      try {
+        await Promise.all([
+          fetch(`/api/slots/${above.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newAboveSortOrder }),
+          }),
+          fetch(`/api/slots/${current.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newCurrentSortOrder }),
+          }),
+        ]);
+        const updatedRows = state.rows.map((r) => {
+          if (r.id === above.id) return { ...r, sortOrder: newAboveSortOrder };
+          if (r.id === current.id) return { ...r, sortOrder: newCurrentSortOrder };
+          return r;
+        });
+        dispatch({
+          type: 'SET_ROWS',
+          rows: [...updatedRows].sort((a, b) => a.sortOrder - b.sortOrder),
+        });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [state.rows],
+  );
+
+  const moveRowDown = useCallback(
+    async (rowId: string): Promise<void> => {
+      const idx = state.rows.findIndex((r) => r.id === rowId);
+      if (idx < 0 || idx >= state.rows.length - 1) return;
+      const current = state.rows[idx]!;
+      const below = state.rows[idx + 1]!;
+      const newCurrentSortOrder = below.sortOrder;
+      const newBelowSortOrder = current.sortOrder;
+
+      markSaving();
+      try {
+        await Promise.all([
+          fetch(`/api/slots/${current.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newCurrentSortOrder }),
+          }),
+          fetch(`/api/slots/${below.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: newBelowSortOrder }),
+          }),
+        ]);
+        const updatedRows = state.rows.map((r) => {
+          if (r.id === current.id) return { ...r, sortOrder: newCurrentSortOrder };
+          if (r.id === below.id) return { ...r, sortOrder: newBelowSortOrder };
+          return r;
+        });
+        dispatch({
+          type: 'SET_ROWS',
+          rows: [...updatedRows].sort((a, b) => a.sortOrder - b.sortOrder),
+        });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [state.rows],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Cell / capacity debounced saves
+  // ---------------------------------------------------------------------------
+
+  const flushTimer = useCallback((key: string, saveFn: () => Promise<void>) => {
+    const timers = timersRef.current;
+    const existing = timers.get(key);
+    if (existing !== undefined) clearTimeout(existing.timeoutId);
+    const timeoutId = setTimeout(() => {
+      timers.delete(key);
+      void saveFn();
+    }, DEBOUNCE_MS);
+    timers.set(key, { timeoutId, saveFn });
+  }, []);
+
+  const editCell = useCallback(
+    (rowId: string, fieldRef: string, value: string): void => {
+      dispatch({ type: 'OPTIMISTIC_EDIT_CELL', rowId, fieldRef, value });
+      const key = `${rowId}:${fieldRef}`;
+      flushTimer(key, async () => {
+        markSaving();
+        try {
+          const res = await fetch(`/api/slots/${rowId}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ values: { [fieldRef]: value } }),
+          });
+          if (!res.ok) throw new Error(await res.text());
+          markSaved();
+        } catch {
+          markError();
+        }
+      });
+    },
+    [flushTimer],
+  );
+
+  const setCapacity = useCallback(
+    (rowId: string, capacity: number | null): void => {
+      dispatch({ type: 'OPTIMISTIC_SET_CAPACITY', rowId, capacity });
+      const key = `${rowId}:capacity`;
+      flushTimer(key, async () => {
+        markSaving();
+        try {
+          const res = await fetch(`/api/slots/${rowId}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ capacity }),
+          });
+          if (!res.ok) throw new Error(await res.text());
+          markSaved();
+        } catch {
+          markError();
+        }
+      });
+    },
+    [flushTimer],
+  );
+
+  // Flush all pending saves on unmount — call each pending saveFn immediately,
+  // then cancel the timer so it doesn't double-fire.
+  // Capture timersRef.current in a variable so the cleanup uses the same Map
+  // reference that was set at effect-run time (avoids the exhaustive-deps warning).
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const [, { timeoutId, saveFn }] of timers) {
+        clearTimeout(timeoutId);
+        void saveFn();
+      }
+    };
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // UI state
+  // ---------------------------------------------------------------------------
+
+  const setPreviewRow = useCallback((idx: number): void => {
+    dispatch({ type: 'SET_PREVIEW_ROW', idx });
+  }, []);
+
+  const setShowPreview = useCallback((show: boolean): void => {
+    dispatch({ type: 'SET_SHOW_PREVIEW', show });
+  }, []);
+
+  const setGroupBy = useCallback(
+    async (ref: string | null): Promise<void> => {
+      markSaving();
+      try {
+        const res = await fetch(`/api/signups/${signupId}`, {
+          method: 'PATCH',
+          headers: JSON_HEADERS,
+          body: JSON.stringify({ settings: { groupByFieldRefs: ref ? [ref] : [] } }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        dispatch({ type: 'SET_GROUP_BY', ref });
+        markSaved();
+      } catch {
+        markError();
+      }
+    },
+    [signupId],
+  );
+
+  return {
+    state,
+    addField,
+    updateField,
+    deleteField,
+    moveFieldUp,
+    moveFieldDown,
+    setFieldWidth,
+    addRow,
+    deleteRow,
+    moveRowUp,
+    moveRowDown,
+    editCell,
+    setCapacity,
+    setPreviewRow,
+    setShowPreview,
+    setGroupBy,
+  };
+}

--- a/src/components/signup/TabsNav.tsx
+++ b/src/components/signup/TabsNav.tsx
@@ -7,15 +7,13 @@ import { useEffect, useRef } from 'react';
 interface TabsNavProps {
   signupId: string;
   counts: {
-    fields: number;
-    slots: number;
+    build: number;
     responses: number;
   };
 }
 
 const TABS = [
-  { id: 'fields', label: 'Fields' },
-  { id: 'slots', label: 'Slots' },
+  { id: 'build', label: 'Build' },
   { id: 'responses', label: 'Responses' },
   { id: 'settings', label: 'Settings' },
 ] as const;
@@ -29,7 +27,7 @@ export function TabsNav({ signupId, counts }: TabsNavProps) {
   const activeTab: TabId = (() => {
     const segment = pathname.split('/').pop() ?? '';
     const match = TABS.find((t) => t.id === segment);
-    return match ? match.id : 'fields';
+    return match ? match.id : 'build';
   })();
 
   useEffect(() => {
@@ -45,13 +43,11 @@ export function TabsNav({ signupId, counts }: TabsNavProps) {
       {TABS.map((t) => {
         const active = t.id === activeTab;
         const count =
-          t.id === 'fields'
-            ? counts.fields
-            : t.id === 'slots'
-              ? counts.slots
-              : t.id === 'responses'
-                ? counts.responses
-                : null;
+          t.id === 'build'
+            ? counts.build
+            : t.id === 'responses'
+              ? counts.responses
+              : null;
         return (
           <Link
             key={t.id}

--- a/src/lib/slot-summary.ts
+++ b/src/lib/slot-summary.ts
@@ -1,0 +1,18 @@
+import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+
+/**
+ * Produces a human-readable summary string for a slot's field values.
+ * Skips null/undefined/empty values; joins present ones with " · ".
+ */
+export function summarizeSlot(
+  fields: SlotFieldDefinition[],
+  values: Record<string, unknown>,
+): string {
+  const parts: string[] = [];
+  for (const f of fields) {
+    const v = values[f.ref];
+    if (v === undefined || v === null || v === '') continue;
+    parts.push(`${f.label}: ${String(v)}`);
+  }
+  return parts.join(' · ');
+}

--- a/src/services/slot-fields.test.ts
+++ b/src/services/slot-fields.test.ts
@@ -121,6 +121,17 @@ describe('validateSlotValues', () => {
     expect(r1.ok).toBe(false);
     expect(r2.ok).toBe(false);
   });
+
+  it('allows missing required field when enforceRequired is false', () => {
+    const r = validateSlotValues([def({})], {}, { enforceRequired: false });
+    expect(r.ok).toBe(true);
+  });
+
+  it('still rejects wrong type when enforceRequired is false', () => {
+    const r = validateSlotValues([def({})], { date: 'not-a-date' }, { enforceRequired: false });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('invalid_input');
+  });
 });
 
 describe('findReminderFields', () => {

--- a/src/services/slot-fields.ts
+++ b/src/services/slot-fields.ts
@@ -249,6 +249,22 @@ export async function updateField(
     );
   }
 
+  if (data.required === true && !existing.required) {
+    const missing = slotRows.filter((row) => {
+      const v = (row.values as Record<string, unknown>)?.[existing.ref];
+      return v === undefined || v === null || v === '';
+    });
+    if (missing.length > 0) {
+      return err(
+        serviceError(
+          'conflict',
+          `cannot make field required while ${missing.length} slot(s) have no value for "${existing.ref}"`,
+          { field: 'required', details: { slotIds: missing.slice(0, 20).map((r) => r.id), count: missing.length } },
+        ),
+      );
+    }
+  }
+
   const updated = await db.transaction(async (tx) => {
     const [row] = await tx
       .update(slotFields)

--- a/src/services/slot-fields.ts
+++ b/src/services/slot-fields.ts
@@ -234,10 +234,11 @@ export async function updateField(
     config: (data.config ?? (existing.config as SlotFieldConfig)) as SlotFieldConfig,
   };
 
+  const typeCheckDef = { ...nextDef, required: false };
   const offending: string[] = [];
   for (const row of slotRows) {
     const values = (row.values as Record<string, unknown>) ?? {};
-    const r = validateOneValue(nextDef, values[existing.ref]);
+    const r = validateOneValue(typeCheckDef, values[existing.ref]);
     if (!r.ok) offending.push(row.id);
   }
   if (offending.length > 0) {
@@ -377,6 +378,7 @@ export async function listFields(
 export function validateSlotValues(
   fields: SlotFieldDefinition[],
   values: Record<string, unknown>,
+  { enforceRequired = true }: { enforceRequired?: boolean } = {},
 ): Result<void, ServiceError> {
   const knownRefs = new Set(fields.map((f) => f.ref));
   for (const ref of Object.keys(values)) {
@@ -389,7 +391,10 @@ export function validateSlotValues(
     }
   }
   for (const field of fields) {
-    const r = validateOneValue(field, values[field.ref]);
+    const r = validateOneValue(
+      enforceRequired ? field : { ...field, required: false },
+      values[field.ref],
+    );
     if (!r.ok) return r;
   }
   return ok(undefined);

--- a/src/services/slots.ts
+++ b/src/services/slots.ts
@@ -46,7 +46,7 @@ export async function addSlot(
   requireWorkspaceWrite(actor, signupRow.workspaceId);
 
   const fields = await listFieldsForSignup(db, signupId);
-  const valid = validateSlotValues(fields, data.values);
+  const valid = validateSlotValues(fields, data.values, { enforceRequired: false });
   if (!valid.ok) return valid;
 
   const settings = (signupRow.settings as SignupSettingsLike) ?? {};
@@ -103,7 +103,7 @@ export async function addSlotsBulk(
 
   const fields = await listFieldsForSignup(db, signupId);
   for (const r of data.rows) {
-    const valid = validateSlotValues(fields, r.values);
+    const valid = validateSlotValues(fields, r.values, { enforceRequired: false });
     if (!valid.ok) return valid;
   }
 
@@ -190,7 +190,7 @@ export async function updateSlot(
       .then((r) => r[0]);
     if (!signupRow) return err(serviceError('not_found', 'signup not found'));
     const fields = await listFieldsForSignup(db, slotRow.signupId);
-    const valid = validateSlotValues(fields, data.values);
+    const valid = validateSlotValues(fields, data.values, { enforceRequired: false });
     if (!valid.ok) return valid;
     const settings = (signupRow.settings as SignupSettingsLike) ?? {};
     nextSlotAt = extractSlotAt(settings, fields, data.values);


### PR DESCRIPTION
## Summary

- **slot-fields**: `updateField` now rejects flipping `required: false → true` when any existing slot lacks a value for that field ref — matches the guard already present in `addField`, fixes the failing CI test
- **ResizeHandle**: move drag state (`startX`, `startWidth`) into a `useRef` so `pointerMove` never reads stale values from a closure
- **useGridState editCell**: send the full post-optimistic `row.values` on `PATCH` instead of only the single changed key, preventing other fields from being silently blanked

## Test plan

- [x] `pnpm test:db` — 64/64 pass (was 63/64 before this fix)
- [ ] Manual: resize a column, verify smooth drag without jumps
- [ ] Manual: edit a cell, verify adjacent cells are not cleared on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)