### PR TITLE
fix(build-grid): rename "fields" to "columns" in toolbar stats

### DIFF
--- a/src/components/build-grid/Toolbar.tsx
+++ b/src/components/build-grid/Toolbar.tsx
@@ -128,7 +128,7 @@ export function Toolbar({
 
       {/* Stats */}
       <span className="text-xs text-ink-soft">
-        {fields.length} fields · {rows.length} slots
+        {fields.length} columns · {rows.length} slots
       </span>
 
       {/* Divider */}


### PR DESCRIPTION
## Summary
- The Build toolbar showed "2 fields · 3 slots" but the rest of the Build page uses "columns" — this aligns the label.

## Test plan
- [ ] Visit `/app/signups/{id}/build` and confirm the toolbar now reads "X columns · Y slots"

🤖 Generated with [Claude Code](https://claude.com/claude-code)