### PR TITLE
fix(build-grid): rename "Remove row" to "Remove slot"

### DIFF
--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -101,8 +101,8 @@ export function GridBody({
                 e.stopPropagation();
                 onDeleteRow(row.id);
               }}
-              title="Remove row"
-              aria-label="Remove row"
+              title="Remove slot"
+              aria-label="Remove slot"
               className="p-1 rounded text-ink-soft hover:text-danger hover:bg-surface-raised"
             >
               <X size={12} />


### PR DESCRIPTION
## Summary
- The row delete button showed "Remove row" in its tooltip and aria-label — inconsistent with the product's "slot" terminology.
- Updated both to "Remove slot".

## Test plan
- [ ] Visit `/app/signups/{id}/build`, hover the delete button on a slot row — confirm tooltip reads "Remove slot"

🤖 Generated with [Claude Code](https://claude.com/claude-code)