### PR TITLE
Remove isId and parseId functions from ids module

### DIFF
--- a/src/lib/ids.test.ts
+++ b/src/lib/ids.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isId, makeId, parseId } from './ids';
+import { makeId } from './ids';
 
 describe('makeId', () => {
   it('returns prefixed 22-char body', () => {
@@ -18,47 +18,5 @@ describe('makeId', () => {
     const ids = new Set<string>();
     for (let i = 0; i < 1000; i++) ids.add(makeId('slot'));
     expect(ids.size).toBe(1000);
-  });
-});
-
-describe('isId', () => {
-  it('matches correct prefix', () => {
-    const id = makeId('sig');
-    expect(isId('sig', id)).toBe(true);
-  });
-
-  it('rejects wrong prefix', () => {
-    const id = makeId('sig');
-    expect(isId('slot', id)).toBe(false);
-  });
-
-  it('rejects malformed strings', () => {
-    expect(isId('sig', 'sig_short')).toBe(false);
-    expect(isId('sig', 'sig_')).toBe(false);
-    expect(isId('sig', 42)).toBe(false);
-    expect(isId('sig', undefined)).toBe(false);
-  });
-});
-
-describe('parseId', () => {
-  it('parses valid IDs', () => {
-    const id = makeId('slot');
-    const parsed = parseId(id);
-    expect(parsed?.prefix).toBe('slot');
-    expect(parsed?.body).toHaveLength(22);
-  });
-
-  it('returns null for unknown prefixes', () => {
-    expect(parseId('xxx_' + 'A'.repeat(22))).toBeNull();
-  });
-
-  it('returns null when the body contains non-base62 characters', () => {
-    expect(parseId('sig_' + '!'.repeat(22))).toBeNull();
-    expect(parseId('sig_' + '-'.repeat(22))).toBeNull();
-  });
-
-  it('returns null when the body is the wrong length', () => {
-    expect(parseId('sig_' + 'A'.repeat(21))).toBeNull();
-    expect(parseId('sig_' + 'A'.repeat(23))).toBeNull();
   });
 });

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -21,7 +21,6 @@ export type IdPrefix = (typeof ID_PREFIXES)[number];
 
 // ASCII-sorted so lexicographic comparison matches numeric order (required for UUIDv7 sortability).
 const BASE62_ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-const BASE62_BODY_RE = /^[0-9A-Za-z]{22}$/;
 const BASE62 = 62n;
 
 function toBase62(bigint: bigint, padTo: number): string {
@@ -46,18 +45,3 @@ export function makeId<P extends IdPrefix>(prefix: P): `${P}_${string}` {
   return `${prefix}_${body}` as `${P}_${string}`;
 }
 
-export function isId<P extends IdPrefix>(prefix: P, value: unknown): value is `${P}_${string}` {
-  if (typeof value !== 'string') return false;
-  const parsed = parseId(value);
-  return parsed !== null && parsed.prefix === prefix;
-}
-
-export function parseId(value: string): { prefix: IdPrefix; body: string } | null {
-  const idx = value.indexOf('_');
-  if (idx < 0) return null;
-  const prefix = value.slice(0, idx) as IdPrefix;
-  if (!ID_PREFIXES.includes(prefix)) return null;
-  const body = value.slice(idx + 1);
-  if (!BASE62_BODY_RE.test(body)) return null;
-  return { prefix, body };
-}


### PR DESCRIPTION
This PR removes the `isId` and `parseId` utility functions from the ids module along with their corresponding tests.

## Summary
The `isId` and `parseId` functions have been removed from the codebase as they are no longer needed. The `makeId` function remains as the primary ID generation utility.

## Changes
- Removed `isId()` function that validated ID prefixes and format
- Removed `parseId()` function that extracted prefix and body from ID strings
- Removed the `BASE62_BODY_RE` regex pattern used for body validation
- Removed all test cases for `isId` and `parseId` functions
- Updated test imports to only include `makeId`

## Notes
The `makeId` function continues to work as before, generating properly formatted IDs with the required prefix and 22-character base62 body.

https://claude.ai/code/session_016FyNoybkSDwgWL99ggCiHH