### PR TITLE
Fix slot capacity validation to check total quantity instead of count

### DIFF
--- a/src/db/schema/commitments.ts
+++ b/src/db/schema/commitments.ts
@@ -33,7 +33,7 @@ export const commitments = pgTable(
      * (slot_id, position) is the database-level capacity enforcement.
      * Cancelled commitments keep their position (position is a write-time claim,
      * not a live slot), so cancellations don't reopen positions — the service
-     * layer counts active commitments against capacity instead.
+     * layer sums active commitment quantities against capacity instead.
      */
     position: integer('position').notNull(),
     status: text('status').notNull().default('confirmed'),

--- a/src/services/slots.db.test.ts
+++ b/src/services/slots.db.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, type Db } from '@/db/client';
+import { workspaceMembers } from '@/db/schema/members';
+import { organizers } from '@/db/schema/organizers';
+import { workspaces } from '@/db/schema/workspaces';
+import { makeId } from '@/lib/ids';
+import type { Actor } from '@/lib/policy';
+import { commitToSlot } from '@/services/commitments';
+import { createSignup, publishSignup } from '@/services/signups';
+import { addSlot, updateSlot } from '@/services/slots';
+
+interface Fixture {
+  db: Db;
+  workspaceId: string;
+  organizerId: string;
+  actor: Actor;
+}
+
+async function setupWorkspace(): Promise<Fixture> {
+  const db = getDb();
+  const organizerId = makeId('org');
+  const workspaceId = makeId('ws');
+  const memberId = makeId('mem');
+  const slug = `test-${workspaceId.slice(-8).toLowerCase()}`;
+  const email = `${slug}@example.test`;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(organizers).values({ id: organizerId, email, name: 'Test Org' });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      slug,
+      name: 'Test Workspace',
+      type: 'personal',
+      plan: 'free',
+    });
+    await tx.insert(workspaceMembers).values({
+      id: memberId,
+      workspaceId,
+      organizerId,
+      role: 'owner',
+      status: 'active',
+    });
+  });
+
+  const actor: Actor = {
+    kind: 'organizer',
+    id: organizerId,
+    email,
+    workspaceIds: [workspaceId],
+    workspaceRoles: { [workspaceId]: 'owner' },
+  };
+
+  return { db, workspaceId, organizerId, actor };
+}
+
+async function teardownWorkspace(db: Db, workspaceId: string, organizerId: string): Promise<void> {
+  await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+  await db.delete(organizers).where(eq(organizers.id, organizerId));
+}
+
+async function makeOpenSignupWithSlot(fx: Fixture, title: string, capacity: number) {
+  const created = await createSignup(fx.db, fx.actor, fx.workspaceId, {
+    title,
+    description: '',
+    tags: [],
+    visibility: 'unlisted' as const,
+    settings: {},
+  });
+  if (!created.ok) throw new Error(`createSignup failed: ${created.error.message}`);
+
+  const slot = await addSlot(fx.db, fx.actor, created.value.id, {
+    values: {},
+    capacity,
+  });
+  if (!slot.ok) throw new Error(`addSlot failed: ${slot.error.message}`);
+
+  const pub = await publishSignup(fx.db, fx.actor, created.value.id);
+  if (!pub.ok) throw new Error(`publishSignup failed: ${pub.error.message}`);
+
+  return { signupId: created.value.id, slotId: slot.value.id };
+}
+
+describe('updateSlot capacity validation (db)', () => {
+  let fx: Fixture;
+
+  beforeAll(async () => {
+    fx = await setupWorkspace();
+  });
+
+  afterAll(async () => {
+    await teardownWorkspace(fx.db, fx.workspaceId, fx.organizerId);
+  });
+
+  it('rejects lowering capacity below total committed quantity', async () => {
+    const { slotId } = await makeOpenSignupWithSlot(fx, 'Capacity quantity test', 5);
+
+    // One commitment with quantity=3 → total quantity in use is 3.
+    const committed = await commitToSlot(fx.db, slotId, {
+      name: 'Alice',
+      email: 'alice-qty@example.test',
+      quantity: 3,
+    });
+    if (!committed.ok) throw new Error(`commitToSlot failed: ${committed.error.message}`);
+
+    // Lowering to 2 should be rejected because sum(quantity)=3 > 2.
+    const result = await updateSlot(fx.db, fx.actor, slotId, { capacity: 2 });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('conflict');
+    expect(result.error.message).toContain('active quantity (3)');
+  });
+
+  it('allows lowering capacity to exactly the total committed quantity', async () => {
+    const { slotId } = await makeOpenSignupWithSlot(fx, 'Capacity exact match test', 5);
+
+    const committed = await commitToSlot(fx.db, slotId, {
+      name: 'Bob',
+      email: 'bob-qty@example.test',
+      quantity: 3,
+    });
+    if (!committed.ok) throw new Error(`commitToSlot failed: ${committed.error.message}`);
+
+    // Lowering to exactly 3 should succeed (3 is not > 3).
+    const result = await updateSlot(fx.db, fx.actor, slotId, { capacity: 3 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.capacity).toBe(3);
+  });
+});

--- a/src/services/slots.ts
+++ b/src/services/slots.ts
@@ -159,8 +159,8 @@ export async function updateSlot(
   requireWorkspaceWrite(actor, slotRow.workspaceId);
 
   if (data.capacity !== undefined && data.capacity !== null) {
-    const countRows = await db
-      .select({ count: sql<number>`count(*)::int` })
+    const sumRows = await db
+      .select({ sum: sql<number>`coalesce(sum(${commitments.quantity}), 0)::int` })
       .from(commitments)
       .where(
         and(
@@ -168,10 +168,10 @@ export async function updateSlot(
           or(eq(commitments.status, 'confirmed'), eq(commitments.status, 'tentative')),
         ),
       );
-    const count = countRows[0]?.count ?? 0;
-    if (count > data.capacity) {
+    const usedQty = sumRows[0]?.sum ?? 0;
+    if (usedQty > data.capacity) {
       return err(
-        serviceError('conflict', `capacity (${data.capacity}) is less than active count (${count})`, {
+        serviceError('conflict', `capacity (${data.capacity}) is less than active quantity (${usedQty})`, {
           field: 'capacity',
           received: data.capacity,
           suggestion: 'cancel some commitments before lowering capacity',


### PR DESCRIPTION
## Summary
Updated the slot capacity validation logic to correctly check the sum of commitment quantities rather than just counting the number of commitments. This ensures capacity constraints are properly enforced based on actual resource usage.

## Key Changes
- Changed the database query from counting commitments to summing their quantities
- Updated variable names from `countRows`/`count` to `sumRows`/`usedQty` for clarity
- Modified the SQL query to use `sum(commitments.quantity)` with `coalesce` to handle null values
- Updated error message to reflect "active quantity" instead of "active count"

## Implementation Details
- The query now calculates the total quantity of confirmed and tentative commitments for a slot
- Uses `coalesce(sum(...), 0)` to safely handle cases where no commitments exist
- The validation still prevents capacity from being lowered below the total quantity of active commitments
- Error messaging is now more accurate in describing what constraint was violated

https://claude.ai/code/session_01RoZdfMiHqhWBpwhRqzMMRW