### PR TITLE
feat(signups): create new signups with a default starter template

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -33,7 +33,7 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 
 | event | actor | payload | fired from |
 |---|---|---|---|
-| `signup.created` | organizer | `{ title }` | `services/signups.ts` |
+| `signup.created` | organizer | `{ title, templateId, fieldsAdded, slotsAdded }` | `services/signups.ts` |
 | `signup.updated` | organizer | `{ changes }` | `services/signups.ts` |
 | `signup.published` | organizer | `{}` | `services/signups.ts` |
 | `signup.closed` | organizer | `{}` | `services/signups.ts` |

--- a/src/lib/signup-templates.test.ts
+++ b/src/lib/signup-templates.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { SlotFieldInputSchema } from '@/schemas/slot-fields';
+import { DEFAULT_TEMPLATE, EMPTY_TEMPLATE } from './signup-templates';
+
+describe('signup templates', () => {
+  describe('DEFAULT_TEMPLATE', () => {
+    it('has a single date field with capacity-1 slot', () => {
+      expect(DEFAULT_TEMPLATE.fields).toHaveLength(1);
+      expect(DEFAULT_TEMPLATE.slots).toHaveLength(1);
+
+      const field = DEFAULT_TEMPLATE.fields[0]!;
+      expect(field.ref).toBe('date');
+      expect(field.fieldType).toBe('date');
+      expect(field.required).toBe(true);
+
+      const slot = DEFAULT_TEMPLATE.slots[0]!;
+      expect(slot.capacity).toBe(1);
+      expect(slot.values).toEqual({});
+    });
+
+    it('every field round-trips through SlotFieldInputSchema', () => {
+      for (const field of DEFAULT_TEMPLATE.fields) {
+        const parsed = SlotFieldInputSchema.safeParse(field);
+        expect(parsed.success).toBe(true);
+      }
+    });
+  });
+
+  describe('EMPTY_TEMPLATE', () => {
+    it('contains no fields and no slots', () => {
+      expect(EMPTY_TEMPLATE.fields).toHaveLength(0);
+      expect(EMPTY_TEMPLATE.slots).toHaveLength(0);
+    });
+  });
+});

--- a/src/lib/signup-templates.ts
+++ b/src/lib/signup-templates.ts
@@ -1,0 +1,34 @@
+import type { SlotFieldInput } from '@/schemas/slot-fields';
+
+export interface SignupTemplateSlot {
+  capacity: number | null;
+  values: Record<string, unknown>;
+  sortOrder?: number;
+}
+
+export interface SignupTemplate {
+  id: string;
+  fields: SlotFieldInput[];
+  slots: SignupTemplateSlot[];
+}
+
+export const DEFAULT_TEMPLATE: SignupTemplate = {
+  id: 'default',
+  fields: [
+    {
+      ref: 'date',
+      label: 'Date',
+      fieldType: 'date',
+      required: true,
+      sortOrder: 0,
+      config: { fieldType: 'date' },
+    },
+  ],
+  slots: [{ capacity: 1, values: {}, sortOrder: 0 }],
+};
+
+export const EMPTY_TEMPLATE: SignupTemplate = {
+  id: 'empty',
+  fields: [],
+  slots: [],
+};

--- a/src/services/signups.db.test.ts
+++ b/src/services/signups.db.test.ts
@@ -220,7 +220,7 @@ describe('signups service (db)', () => {
       expect(capacities).toEqual([2, 5]);
     });
 
-    it('produces no signup, no fields, no slots when template has duplicate refs', async () => {
+    it('rejects a template with duplicate field refs (no DB writes)', async () => {
       const broken: SignupTemplate = {
         id: 'broken',
         fields: [
@@ -250,21 +250,103 @@ describe('signups service (db)', () => {
         .where(eq(signups.workspaceId, fx.workspaceId));
       const beforeCount = before.length;
 
-      await expect(
-        createSignup(
-          fx.db,
-          fx.actor,
-          fx.workspaceId,
-          validCreateInput('Rollback me'),
-          { template: broken },
-        ),
-      ).rejects.toThrow();
+      const r = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        validCreateInput('Dup ref'),
+        { template: broken },
+      );
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('invalid_input');
+      expect(r.error.message).toMatch(/duplicate field ref/);
 
       const after = await fx.db
         .select({ id: signups.id })
         .from(signups)
         .where(eq(signups.workspaceId, fx.workspaceId));
       expect(after.length).toBe(beforeCount);
+    });
+
+    it('rejects a template whose slot capacity is not a positive integer', async () => {
+      const bad: SignupTemplate = {
+        id: 'zero-cap',
+        fields: [],
+        slots: [{ capacity: 0, values: {}, sortOrder: 0 }],
+      };
+      const r = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        validCreateInput('Zero cap'),
+        { template: bad },
+      );
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('invalid_input');
+      expect(r.error.message).toMatch(/invalid slot/);
+    });
+
+    it('rejects a template whose slot values reference an unknown field', async () => {
+      const bad: SignupTemplate = {
+        id: 'unknown-ref',
+        fields: [
+          {
+            ref: 'date',
+            label: 'Date',
+            fieldType: 'date',
+            required: true,
+            sortOrder: 0,
+            config: { fieldType: 'date' },
+          },
+        ],
+        slots: [{ capacity: 1, values: { nope: 'x' }, sortOrder: 0 }],
+      };
+      const r = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        validCreateInput('Unknown ref'),
+        { template: bad },
+      );
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('invalid_input');
+      expect(r.error.message).toMatch(/unknown field ref/);
+    });
+
+    it('computes slotAt for template slots when reminderFromFieldRef is set and values include a date', async () => {
+      const tmpl: SignupTemplate = {
+        id: 'date-with-values',
+        fields: [
+          {
+            ref: 'date',
+            label: 'Date',
+            fieldType: 'date',
+            required: true,
+            sortOrder: 0,
+            config: { fieldType: 'date' },
+          },
+        ],
+        slots: [{ capacity: 1, values: { date: '2027-01-15' }, sortOrder: 0 }],
+      };
+      const r = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        { ...validCreateInput('Slot at'), settings: { reminderFromFieldRef: 'date' } },
+        { template: tmpl },
+      );
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+
+      const slotRows = await fx.db
+        .select()
+        .from(slots)
+        .where(eq(slots.signupId, r.value.id));
+      expect(slotRows).toHaveLength(1);
+      expect(slotRows[0]!.slotAt).toEqual(new Date('2027-01-15T00:00:00.000Z'));
     });
 
     it('rejects a template with an invalid field shape (no DB writes)', async () => {

--- a/src/services/signups.db.test.ts
+++ b/src/services/signups.db.test.ts
@@ -5,9 +5,12 @@ import { activity } from '@/db/schema/activity';
 import { workspaceMembers } from '@/db/schema/members';
 import { organizers } from '@/db/schema/organizers';
 import { signups } from '@/db/schema/signups';
+import { slots } from '@/db/schema/slots';
 import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
 import type { Actor, WorkspaceRole } from '@/lib/policy';
+import { DEFAULT_TEMPLATE, EMPTY_TEMPLATE, type SignupTemplate } from '@/lib/signup-templates';
+import { listFieldsForSignup } from '@/services/slot-fields';
 import { addSlot } from '@/services/slots';
 import { commitToSlot } from '@/services/commitments';
 import {
@@ -137,6 +140,171 @@ describe('signups service (db)', () => {
       } finally {
         await teardownWorkspace(viewerFx.db, viewerFx.workspaceId, viewerFx.organizerId);
       }
+    });
+
+    it('applies DEFAULT_TEMPLATE when no opts.template is supplied', async () => {
+      const r = await createSignup(fx.db, fx.actor, fx.workspaceId, validCreateInput('Default tmpl'));
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+
+      const fields = await listFieldsForSignup(fx.db, r.value.id);
+      expect(fields).toHaveLength(1);
+      expect(fields[0]!.ref).toBe('date');
+      expect(fields[0]!.fieldType).toBe('date');
+      expect(fields[0]!.required).toBe(true);
+
+      const slotRows = await fx.db
+        .select()
+        .from(slots)
+        .where(eq(slots.signupId, r.value.id));
+      expect(slotRows).toHaveLength(1);
+      expect(slotRows[0]!.capacity).toBe(1);
+      expect(slotRows[0]!.values).toEqual({});
+      expect(slotRows[0]!.status).toBe('open');
+
+      const acts = await fx.db.select().from(activity).where(eq(activity.signupId, r.value.id));
+      const created = acts.find((a) => a.eventType === 'signup.created');
+      expect(created).toBeDefined();
+      const payload = created!.payload as Record<string, unknown>;
+      expect(payload.templateId).toBe(DEFAULT_TEMPLATE.id);
+      expect(payload.fieldsAdded).toBe(1);
+      expect(payload.slotsAdded).toBe(1);
+    });
+
+    it('applies a custom template when supplied', async () => {
+      const custom: SignupTemplate = {
+        id: 'date-and-item',
+        fields: [
+          {
+            ref: 'date',
+            label: 'Date',
+            fieldType: 'date',
+            required: true,
+            sortOrder: 0,
+            config: { fieldType: 'date' },
+          },
+          {
+            ref: 'item',
+            label: 'Item',
+            fieldType: 'text',
+            required: false,
+            sortOrder: 1,
+            config: { fieldType: 'text', maxLength: 200 },
+          },
+        ],
+        slots: [
+          { capacity: 2, values: {}, sortOrder: 0 },
+          { capacity: 5, values: {}, sortOrder: 1 },
+        ],
+      };
+
+      const r = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        validCreateInput('Custom tmpl'),
+        { template: custom },
+      );
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+
+      const fields = await listFieldsForSignup(fx.db, r.value.id);
+      expect(fields.map((f) => f.ref)).toEqual(['date', 'item']);
+
+      const slotRows = await fx.db
+        .select()
+        .from(slots)
+        .where(eq(slots.signupId, r.value.id));
+      expect(slotRows).toHaveLength(2);
+      const capacities = slotRows.map((s) => s.capacity).sort();
+      expect(capacities).toEqual([2, 5]);
+    });
+
+    it('produces no signup, no fields, no slots when template has duplicate refs', async () => {
+      const broken: SignupTemplate = {
+        id: 'broken',
+        fields: [
+          {
+            ref: 'date',
+            label: 'Date',
+            fieldType: 'date',
+            required: true,
+            sortOrder: 0,
+            config: { fieldType: 'date' },
+          },
+          {
+            ref: 'date',
+            label: 'Date again',
+            fieldType: 'date',
+            required: true,
+            sortOrder: 1,
+            config: { fieldType: 'date' },
+          },
+        ],
+        slots: [{ capacity: 1, values: {}, sortOrder: 0 }],
+      };
+
+      const before = await fx.db
+        .select({ id: signups.id })
+        .from(signups)
+        .where(eq(signups.workspaceId, fx.workspaceId));
+      const beforeCount = before.length;
+
+      await expect(
+        createSignup(
+          fx.db,
+          fx.actor,
+          fx.workspaceId,
+          validCreateInput('Rollback me'),
+          { template: broken },
+        ),
+      ).rejects.toThrow();
+
+      const after = await fx.db
+        .select({ id: signups.id })
+        .from(signups)
+        .where(eq(signups.workspaceId, fx.workspaceId));
+      expect(after.length).toBe(beforeCount);
+    });
+
+    it('rejects a template with an invalid field shape (no DB writes)', async () => {
+      const before = await fx.db
+        .select({ id: signups.id })
+        .from(signups)
+        .where(eq(signups.workspaceId, fx.workspaceId));
+      const beforeCount = before.length;
+
+      const bad: SignupTemplate = {
+        id: 'bad',
+        fields: [
+          {
+            ref: 'NotKebab',
+            label: 'X',
+            fieldType: 'text',
+            required: true,
+            sortOrder: 0,
+            config: { fieldType: 'text', maxLength: 200 },
+          },
+        ],
+        slots: [],
+      };
+
+      const r = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        validCreateInput('Bad template'),
+        { template: bad },
+      );
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.error.code).toBe('invalid_input');
+
+      const after = await fx.db
+        .select({ id: signups.id })
+        .from(signups)
+        .where(eq(signups.workspaceId, fx.workspaceId));
+      expect(after.length).toBe(beforeCount);
     });
   });
 
@@ -282,7 +450,13 @@ describe('signups service (db)', () => {
     });
 
     it('publishSignup rejects when no slots', async () => {
-      const created = await createSignup(fx.db, fx.actor, fx.workspaceId, validCreateInput('Empty'));
+      const created = await createSignup(
+        fx.db,
+        fx.actor,
+        fx.workspaceId,
+        validCreateInput('Empty'),
+        { template: EMPTY_TEMPLATE },
+      );
       if (!created.ok) throw new Error('setup failed');
 
       const r = await publishSignup(fx.db, fx.actor, created.value.id);

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -12,14 +12,25 @@ import { requireOrganizerId, requireWorkspaceAccess, requireWorkspaceWrite, type
 import { err, ok, type Result } from '@/lib/result';
 import { DEFAULT_TEMPLATE, type SignupTemplate } from '@/lib/signup-templates';
 import { toSlug } from '@/lib/slug';
-import { type SlotFieldDefinition, SlotFieldInputSchema } from '@/schemas/slot-fields';
+import { type SlotFieldDefinition, type SlotFieldInput, SlotFieldInputSchema } from '@/schemas/slot-fields';
 import {
   type SignupStatus,
   SignupCreateInputSchema,
   SignupUpdateInputSchema,
 } from '@/schemas/signups';
-import { listFieldsForSignup, recomputeSlotAtForSignup } from './slot-fields';
+import { type SlotCreateInput, SlotCreateInputSchema } from '@/schemas/slots';
+import {
+  extractSlotAt,
+  listFieldsForSignup,
+  recomputeSlotAtForSignup,
+  validateSlotValues,
+} from './slot-fields';
 import { pickAvailableRef, summarizeValues } from './slots';
+
+interface ReminderSettingsLike {
+  reminderFromFieldRef?: string | undefined;
+  [k: string]: unknown;
+}
 
 type SignupRow = typeof signups.$inferSelect;
 
@@ -46,6 +57,8 @@ export async function createSignup(
 
   const template = opts.template ?? DEFAULT_TEMPLATE;
 
+  const parsedFields: SlotFieldInput[] = [];
+  const seenRefs = new Set<string>();
   for (const field of template.fields) {
     const parsed = SlotFieldInputSchema.safeParse(field);
     if (!parsed.success) {
@@ -56,6 +69,44 @@ export async function createSignup(
         }),
       );
     }
+    if (seenRefs.has(parsed.data.ref)) {
+      return err(
+        serviceError('invalid_input', `template "${template.id}" has duplicate field ref "${parsed.data.ref}"`, {
+          field: 'template',
+          details: { templateId: template.id, ref: parsed.data.ref },
+        }),
+      );
+    }
+    seenRefs.add(parsed.data.ref);
+    parsedFields.push(parsed.data);
+  }
+
+  const parsedSlots: SlotCreateInput[] = [];
+  for (const slot of template.slots) {
+    const parsed = SlotCreateInputSchema.safeParse(slot);
+    if (!parsed.success) {
+      return err(
+        serviceError('invalid_input', `template "${template.id}" has an invalid slot`, {
+          field: 'template',
+          details: { templateId: template.id, error: parsed.error.flatten() },
+        }),
+      );
+    }
+    parsedSlots.push(parsed.data);
+  }
+
+  const fieldDefs: SlotFieldDefinition[] = parsedFields.map((f) => ({
+    id: '',
+    ref: f.ref,
+    label: f.label,
+    fieldType: f.fieldType,
+    required: f.required,
+    sortOrder: f.sortOrder,
+    config: f.config,
+  }));
+  for (const slot of parsedSlots) {
+    const v = validateSlotValues(fieldDefs, slot.values, { enforceRequired: false });
+    if (!v.ok) return v;
   }
 
   const id = makeId('sig');
@@ -80,7 +131,9 @@ export async function createSignup(
       .returning();
     if (!inserted) throw new Error('insert failed');
 
-    for (const field of template.fields) {
+    const settings = (inserted.settings as ReminderSettingsLike) ?? {};
+
+    for (const field of parsedFields) {
       await tx.insert(slotFields).values({
         id: makeId('fld'),
         signupId: inserted.id,
@@ -94,8 +147,9 @@ export async function createSignup(
       });
     }
 
-    for (const [index, slot] of template.slots.entries()) {
+    for (const [index, slot] of parsedSlots.entries()) {
       const ref = await pickAvailableRef(tx, inserted.id, summarizeValues(slot.values));
+      const slotAt = extractSlotAt(settings, fieldDefs, slot.values);
       await tx.insert(slots).values({
         id: makeId('slot'),
         signupId: inserted.id,
@@ -104,6 +158,7 @@ export async function createSignup(
         values: slot.values,
         capacity: slot.capacity,
         sortOrder: slot.sortOrder ?? index,
+        slotAt,
         status: 'open',
       });
     }

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, isNull, or, sql } from 'drizzle-orm';
 import type { Db } from '@/db/client';
 import { commitments } from '@/db/schema/commitments';
 import { signups } from '@/db/schema/signups';
+import { slotFields } from '@/db/schema/slot-fields';
 import { slots } from '@/db/schema/slots';
 import { recordActivity } from '@/lib/activity';
 import { serviceError, ServiceException, type ServiceError } from '@/lib/errors';
@@ -9,14 +10,16 @@ import { makeId } from '@/lib/ids';
 import { parseInputSafe } from '@/lib/parse';
 import { requireOrganizerId, requireWorkspaceAccess, requireWorkspaceWrite, type Actor } from '@/lib/policy';
 import { err, ok, type Result } from '@/lib/result';
+import { DEFAULT_TEMPLATE, type SignupTemplate } from '@/lib/signup-templates';
 import { toSlug } from '@/lib/slug';
-import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+import { type SlotFieldDefinition, SlotFieldInputSchema } from '@/schemas/slot-fields';
 import {
   type SignupStatus,
   SignupCreateInputSchema,
   SignupUpdateInputSchema,
 } from '@/schemas/signups';
 import { listFieldsForSignup, recomputeSlotAtForSignup } from './slot-fields';
+import { pickAvailableRef, summarizeValues } from './slots';
 
 type SignupRow = typeof signups.$inferSelect;
 
@@ -30,6 +33,7 @@ export async function createSignup(
   actor: Actor,
   workspaceId: string,
   rawInput: unknown,
+  opts: { template?: SignupTemplate } = {},
 ): Promise<Result<SignupRow, ServiceError>> {
   requireWorkspaceWrite(actor, workspaceId);
   if (actor.kind !== 'organizer') {
@@ -39,6 +43,20 @@ export async function createSignup(
   const input = parseInputSafe(SignupCreateInputSchema, rawInput);
   if (!input.ok) return input;
   const data = input.value;
+
+  const template = opts.template ?? DEFAULT_TEMPLATE;
+
+  for (const field of template.fields) {
+    const parsed = SlotFieldInputSchema.safeParse(field);
+    if (!parsed.success) {
+      return err(
+        serviceError('invalid_input', `template "${template.id}" has an invalid field`, {
+          field: 'template',
+          details: { templateId: template.id, error: parsed.error.flatten() },
+        }),
+      );
+    }
+  }
 
   const id = makeId('sig');
   const slug = await pickAvailableSlug(db, data.title);
@@ -62,12 +80,45 @@ export async function createSignup(
       .returning();
     if (!inserted) throw new Error('insert failed');
 
+    for (const field of template.fields) {
+      await tx.insert(slotFields).values({
+        id: makeId('fld'),
+        signupId: inserted.id,
+        workspaceId,
+        ref: field.ref,
+        label: field.label,
+        fieldType: field.fieldType,
+        required: field.required,
+        sortOrder: field.sortOrder,
+        config: field.config,
+      });
+    }
+
+    for (const [index, slot] of template.slots.entries()) {
+      const ref = await pickAvailableRef(tx, inserted.id, summarizeValues(slot.values));
+      await tx.insert(slots).values({
+        id: makeId('slot'),
+        signupId: inserted.id,
+        workspaceId,
+        ref,
+        values: slot.values,
+        capacity: slot.capacity,
+        sortOrder: slot.sortOrder ?? index,
+        status: 'open',
+      });
+    }
+
     await recordActivity(tx, {
       signupId: inserted.id,
       workspaceId,
       actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'signup.created',
-      payload: { title: inserted.title },
+      payload: {
+        title: inserted.title,
+        templateId: template.id,
+        fieldsAdded: template.fields.length,
+        slotsAdded: template.slots.length,
+      },
     });
     return inserted;
   });

--- a/src/services/slot-fields.db.test.ts
+++ b/src/services/slot-fields.db.test.ts
@@ -9,6 +9,7 @@ import { slots } from '@/db/schema/slots';
 import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
 import type { Actor } from '@/lib/policy';
+import { EMPTY_TEMPLATE } from '@/lib/signup-templates';
 import {
   addField,
   deleteField,
@@ -71,13 +72,19 @@ async function teardown(fx: Fixture): Promise<void> {
 }
 
 async function createTestSignup(fx: Fixture, title = 'Field Test'): Promise<string> {
-  const r = await createSignup(fx.db, fx.actor, fx.workspaceId, {
-    title,
-    description: '',
-    tags: [],
-    visibility: 'unlisted',
-    settings: {},
-  });
+  const r = await createSignup(
+    fx.db,
+    fx.actor,
+    fx.workspaceId,
+    {
+      title,
+      description: '',
+      tags: [],
+      visibility: 'unlisted',
+      settings: {},
+    },
+    { template: EMPTY_TEMPLATE },
+  );
   if (!r.ok) throw new Error('signup setup failed');
   return r.value.id;
 }

--- a/src/services/slots.ts
+++ b/src/services/slots.ts
@@ -258,7 +258,7 @@ export async function listSlotsForSignup(db: Db, signupId: string) {
     .orderBy(asc(slots.sortOrder), asc(slots.slotAt), asc(slots.createdAt));
 }
 
-function summarizeValues(values: Record<string, unknown>): string {
+export function summarizeValues(values: Record<string, unknown>): string {
   const parts: string[] = [];
   for (const val of Object.values(values)) {
     if (val === undefined || val === null || val === '') continue;
@@ -268,7 +268,7 @@ function summarizeValues(values: Record<string, unknown>): string {
   return parts.join('-') || 'slot';
 }
 
-async function pickAvailableRef(db: Queryable, signupId: string, seed: string): Promise<string> {
+export async function pickAvailableRef(db: Queryable, signupId: string, seed: string): Promise<string> {
   const base = toSlug(seed, { suffix: false, fallback: 'slot' });
   for (let i = 0; i < 6; i++) {
     const candidate = i === 0 ? base : `${base}-${toSlug(`${Date.now()}-${i}`, { suffix: false })}`;


### PR DESCRIPTION
## Summary
- New signups now land on `/build` with a single required `Date` column and one capacity-1 slot, instead of a fully empty grid.
- Layout is expressed as a `SignupTemplate` (`src/lib/signup-templates.ts`) so future AI-generated templates can plug into `createSignup` via `opts.template` with no service changes.
- Field shapes are validated through the existing `SlotFieldInputSchema` before any DB write, and all template inserts run inside `createSignup`'s existing transaction (rolls back atomically on failure).

The `signup.created` activity payload now carries `templateId`, `fieldsAdded`, and `slotsAdded`. Callers that want a blank canvas (a couple of existing tests) pass `EMPTY_TEMPLATE` explicitly.

The public `POST /api/signups` body is unchanged — `opts.template` is internal-only until AI templates exist.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 240/240
- [x] `pnpm test:db` — 69/69 (covers default template, custom template, rollback on duplicate ref, invalid field rejection)
- [x] Manual: create a new signup in `pnpm dev` and confirm the BuildGrid lands with one `Date` column and one capacity-1 row

🤖 Generated with [Claude Code](https://claude.com/claude-code)