### PR TITLE
feat(build-grid): reorder columns via header chevron menu

### DIFF
--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -59,6 +59,7 @@ export function BuildGrid({ signupId, initialFields, initialSlots, initialSettin
     addField,
     updateField,
     deleteField,
+    moveField,
     setFieldWidth,
     addRow,
     deleteRow,
@@ -107,6 +108,8 @@ export function BuildGrid({ signupId, initialFields, initialSlots, initialSettin
               fields={state.fields}
               onEditField={(field) => setEditingField(field)}
               onAddField={() => setShowFieldPicker(true)}
+              onDeleteField={(fieldId) => { void deleteField(fieldId); }}
+              onMoveField={(fieldId, toIdx) => { void moveField(fieldId, toIdx); }}
               onResize={(fieldId, width) => setFieldWidth(fieldId, width)}
               onResetWidth={(fieldId) => setFieldWidth(fieldId, undefined)}
             />

--- a/src/components/build-grid/ColumnHeaderMenu.tsx
+++ b/src/components/build-grid/ColumnHeaderMenu.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useState, type RefObject } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Pencil,
+  ArrowLeft,
+  ArrowRight,
+  ArrowLeftToLine,
+  ArrowRightToLine,
+  Trash2,
+  type LucideIcon,
+} from 'lucide-react';
+
+const MENU_WIDTH = 240;
+const MENU_GAP = 4;
+
+type ColumnHeaderMenuProps = {
+  anchorRef: RefObject<HTMLElement | null>;
+  isFirst: boolean;
+  isLast: boolean;
+  onEdit: () => void;
+  onMoveLeft: () => void;
+  onMoveRight: () => void;
+  onMoveStart: () => void;
+  onMoveEnd: () => void;
+  onDelete: () => void;
+};
+
+export function ColumnHeaderMenu({
+  anchorRef,
+  isFirst,
+  isLast,
+  onEdit,
+  onMoveLeft,
+  onMoveRight,
+  onMoveStart,
+  onMoveEnd,
+  onDelete,
+}: ColumnHeaderMenuProps) {
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useLayoutEffect(() => {
+    const update = () => {
+      const el = anchorRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      // Right-align the menu with the column's right edge (where the chevron sits).
+      const desiredLeft = rect.right - MENU_WIDTH;
+      const left = Math.max(8, Math.min(desiredLeft, window.innerWidth - MENU_WIDTH - 8));
+      setPosition({ top: rect.bottom + MENU_GAP, left });
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [anchorRef]);
+
+  if (!mounted || position === null) return null;
+
+  return createPortal(
+    <div
+      role="menu"
+      data-column-header-menu
+      style={{ position: 'fixed', top: position.top, left: position.left, width: MENU_WIDTH }}
+      className="z-50 rounded-xl border border-surface-sunk bg-white py-1 shadow-card"
+    >
+      <MenuItem icon={Pencil} label="Edit field…" onClick={onEdit} />
+      <Divider />
+      <SectionLabel>Reorder</SectionLabel>
+      <MenuItem icon={ArrowLeft} label="Move left" onClick={onMoveLeft} disabled={isFirst} />
+      <MenuItem icon={ArrowRight} label="Move right" onClick={onMoveRight} disabled={isLast} />
+      <MenuItem
+        icon={ArrowLeftToLine}
+        label="Move to start"
+        onClick={onMoveStart}
+        disabled={isFirst}
+      />
+      <MenuItem
+        icon={ArrowRightToLine}
+        label="Move to end"
+        onClick={onMoveEnd}
+        disabled={isLast}
+      />
+      <Divider />
+      <MenuItem icon={Trash2} label="Delete column" onClick={onDelete} danger />
+    </div>,
+    document.body,
+  );
+}
+
+type MenuItemProps = {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+};
+
+function MenuItem({ icon: Icon, label, onClick, disabled, danger }: MenuItemProps) {
+  const textClass = disabled
+    ? 'text-ink-soft/70'
+    : danger
+      ? 'text-danger'
+      : 'text-ink';
+  const iconClass = disabled ? 'text-ink-soft/70' : danger ? 'text-danger' : 'text-ink-muted';
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[13px] ${textClass} ${
+        disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-surface-raised'
+      }`}
+    >
+      <Icon size={14} className={iconClass} />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-ink-soft">
+      {children}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className="my-1 h-px bg-surface-sunk" />;
+}

--- a/src/components/build-grid/ColumnHeaderMenu.tsx
+++ b/src/components/build-grid/ColumnHeaderMenu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useState, type RefObject } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Pencil,
@@ -14,6 +14,9 @@ import {
 
 const MENU_WIDTH = 240;
 const MENU_GAP = 4;
+// 6 items × 28px + 22px section label + 2 × 9px dividers + 8px py-1 ≈ 216px.
+// 24px headroom for safety. Bump if items are added.
+const MENU_HEIGHT_ESTIMATE = 240;
 
 type ColumnHeaderMenuProps = {
   anchorRef: RefObject<HTMLElement | null>;
@@ -26,6 +29,11 @@ type ColumnHeaderMenuProps = {
   onMoveEnd: () => void;
   onDelete: () => void;
 };
+
+type MenuEntry =
+  | { kind: 'item'; label: string; icon: LucideIcon; onClick: () => void; disabled: boolean; danger?: boolean }
+  | { kind: 'divider' }
+  | { kind: 'section'; label: string };
 
 export function ColumnHeaderMenu({
   anchorRef,
@@ -45,6 +53,42 @@ export function ColumnHeaderMenu({
     setMounted(true);
   }, []);
 
+  const entries = useMemo<MenuEntry[]>(
+    () => [
+      { kind: 'item', label: 'Edit field…', icon: Pencil, onClick: onEdit, disabled: false },
+      { kind: 'divider' },
+      { kind: 'section', label: 'Reorder' },
+      { kind: 'item', label: 'Move left', icon: ArrowLeft, onClick: onMoveLeft, disabled: isFirst },
+      { kind: 'item', label: 'Move right', icon: ArrowRight, onClick: onMoveRight, disabled: isLast },
+      { kind: 'item', label: 'Move to start', icon: ArrowLeftToLine, onClick: onMoveStart, disabled: isFirst },
+      { kind: 'item', label: 'Move to end', icon: ArrowRightToLine, onClick: onMoveEnd, disabled: isLast },
+      { kind: 'divider' },
+      { kind: 'item', label: 'Delete column', icon: Trash2, onClick: onDelete, disabled: false, danger: true },
+    ],
+    [isFirst, isLast, onEdit, onMoveLeft, onMoveRight, onMoveStart, onMoveEnd, onDelete],
+  );
+
+  // Indexes (within `entries`) of items that can receive focus.
+  const enabledItemIndexes = useMemo(
+    () =>
+      entries
+        .map((e, i) => ({ e, i }))
+        .filter(({ e }) => e.kind === 'item' && !e.disabled)
+        .map(({ i }) => i),
+    [entries],
+  );
+
+  const [focusedIndex, setFocusedIndex] = useState<number>(() => enabledItemIndexes[0] ?? 0);
+
+  // Reset focus to first enabled item when the enabled set changes.
+  useEffect(() => {
+    if (!enabledItemIndexes.includes(focusedIndex)) {
+      setFocusedIndex(enabledItemIndexes[0] ?? 0);
+    }
+  }, [enabledItemIndexes, focusedIndex]);
+
+  const itemRefs = useRef(new Map<number, HTMLButtonElement>());
+
   useLayoutEffect(() => {
     const update = () => {
       const el = anchorRef.current;
@@ -53,7 +97,12 @@ export function ColumnHeaderMenu({
       // Right-align the menu with the column's right edge (where the chevron sits).
       const desiredLeft = rect.right - MENU_WIDTH;
       const left = Math.max(8, Math.min(desiredLeft, window.innerWidth - MENU_WIDTH - 8));
-      setPosition({ top: rect.bottom + MENU_GAP, left });
+      // Flip above the chevron when there isn't room below.
+      const willOverflow = rect.bottom + MENU_HEIGHT_ESTIMATE + 8 > window.innerHeight;
+      const top = willOverflow
+        ? Math.max(8, rect.top - MENU_HEIGHT_ESTIMATE - MENU_GAP)
+        : rect.bottom + MENU_GAP;
+      setPosition({ top, left });
     };
     update();
     window.addEventListener('resize', update);
@@ -64,34 +113,72 @@ export function ColumnHeaderMenu({
     };
   }, [anchorRef]);
 
+  // Focus the active menu item once the menu is mounted and positioned.
+  useLayoutEffect(() => {
+    if (!mounted || position === null) return;
+    itemRefs.current.get(focusedIndex)?.focus();
+  }, [mounted, position, focusedIndex]);
+
+  const moveFocus = (delta: 1 | -1) => {
+    if (enabledItemIndexes.length === 0) return;
+    const at = enabledItemIndexes.indexOf(focusedIndex);
+    const next =
+      at === -1
+        ? enabledItemIndexes[0]!
+        : enabledItemIndexes[(at + delta + enabledItemIndexes.length) % enabledItemIndexes.length]!;
+    setFocusedIndex(next);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveFocus(1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveFocus(-1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      const first = enabledItemIndexes[0];
+      if (first !== undefined) setFocusedIndex(first);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      const last = enabledItemIndexes[enabledItemIndexes.length - 1];
+      if (last !== undefined) setFocusedIndex(last);
+    }
+  };
+
   if (!mounted || position === null) return null;
 
   return createPortal(
     <div
       role="menu"
       data-column-header-menu
+      onKeyDown={onKeyDown}
       style={{ position: 'fixed', top: position.top, left: position.left, width: MENU_WIDTH }}
       className="z-50 rounded-xl border border-surface-sunk bg-white py-1 shadow-card"
     >
-      <MenuItem icon={Pencil} label="Edit field…" onClick={onEdit} />
-      <Divider />
-      <SectionLabel>Reorder</SectionLabel>
-      <MenuItem icon={ArrowLeft} label="Move left" onClick={onMoveLeft} disabled={isFirst} />
-      <MenuItem icon={ArrowRight} label="Move right" onClick={onMoveRight} disabled={isLast} />
-      <MenuItem
-        icon={ArrowLeftToLine}
-        label="Move to start"
-        onClick={onMoveStart}
-        disabled={isFirst}
-      />
-      <MenuItem
-        icon={ArrowRightToLine}
-        label="Move to end"
-        onClick={onMoveEnd}
-        disabled={isLast}
-      />
-      <Divider />
-      <MenuItem icon={Trash2} label="Delete column" onClick={onDelete} danger />
+      {entries.map((entry, i) => {
+        if (entry.kind === 'divider') return <Divider key={`d-${i}`} />;
+        if (entry.kind === 'section') return <SectionLabel key={`s-${i}`}>{entry.label}</SectionLabel>;
+        return (
+          <MenuItem
+            key={entry.label}
+            icon={entry.icon}
+            label={entry.label}
+            onClick={entry.onClick}
+            disabled={entry.disabled}
+            danger={entry.danger}
+            tabIndex={focusedIndex === i ? 0 : -1}
+            onMouseEnter={() => {
+              if (!entry.disabled) setFocusedIndex(i);
+            }}
+            innerRef={(el) => {
+              if (el) itemRefs.current.set(i, el);
+              else itemRefs.current.delete(i);
+            }}
+          />
+        );
+      })}
     </div>,
     document.body,
   );
@@ -103,9 +190,12 @@ type MenuItemProps = {
   onClick: () => void;
   disabled?: boolean;
   danger?: boolean;
+  tabIndex: number;
+  onMouseEnter: () => void;
+  innerRef: (el: HTMLButtonElement | null) => void;
 };
 
-function MenuItem({ icon: Icon, label, onClick, disabled, danger }: MenuItemProps) {
+function MenuItem({ icon: Icon, label, onClick, disabled, danger, tabIndex, onMouseEnter, innerRef }: MenuItemProps) {
   const textClass = disabled
     ? 'text-ink-soft/70'
     : danger
@@ -114,9 +204,12 @@ function MenuItem({ icon: Icon, label, onClick, disabled, danger }: MenuItemProp
   const iconClass = disabled ? 'text-ink-soft/70' : danger ? 'text-danger' : 'text-ink-muted';
   return (
     <button
+      ref={innerRef}
       type="button"
       role="menuitem"
+      tabIndex={tabIndex}
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
       disabled={disabled}
       className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[13px] ${textClass} ${
         disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-surface-raised'

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Plus, ChevronDown } from 'lucide-react';
 import { buildColsTemplate } from './columnSizing';
+import { ColumnHeaderMenu } from './ColumnHeaderMenu';
 import { fieldTypeMeta } from './fieldTypes';
 import { ResizeHandle } from './ResizeHandle';
 import type { GridField } from './useGridState';
@@ -10,17 +12,74 @@ interface GridHeaderProps {
   fields: GridField[];
   onEditField: (field: GridField) => void;
   onAddField: () => void;
+  onDeleteField: (fieldId: string) => void;
+  onMoveField: (fieldId: string, toIdx: number) => void;
   onResize: (fieldId: string, width: number) => void;
   onResetWidth: (fieldId: string) => void;
 }
+
+const FLASH_MS = 700;
 
 export function GridHeader({
   fields,
   onEditField,
   onAddField,
+  onDeleteField,
+  onMoveField,
   onResize,
   onResetWidth,
 }: GridHeaderProps) {
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [justMovedId, setJustMovedId] = useState<string | null>(null);
+  const buttonRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const setButtonRef = useCallback((id: string) => (el: HTMLButtonElement | null) => {
+    if (el) buttonRefs.current.set(id, el);
+    else buttonRefs.current.delete(id);
+  }, []);
+
+  // Close on outside click + Esc while a menu is open. The menu lives in a
+  // portal under document.body, so we identify it via [data-column-header-menu]
+  // rather than DOM-tree containment.
+  useEffect(() => {
+    if (openMenuId === null) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('[data-column-header-button]')) return;
+      if (target.closest('[data-column-header-menu]')) return;
+      setOpenMenuId(null);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenMenuId(null);
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [openMenuId]);
+
+  // Clear flash highlight after a short delay.
+  useEffect(() => {
+    if (justMovedId === null) return;
+    const id = setTimeout(() => setJustMovedId(null), FLASH_MS);
+    return () => clearTimeout(id);
+  }, [justMovedId]);
+
+  const move = (fieldId: string, toIdx: number) => {
+    onMoveField(fieldId, toIdx);
+    setJustMovedId(fieldId);
+    setOpenMenuId(null);
+  };
+
+  const anchorRefFor = (id: string) => ({
+    get current() {
+      return buttonRefs.current.get(id) ?? null;
+    },
+  });
+
   return (
     <div
       style={{
@@ -39,20 +98,39 @@ export function GridHeader({
       {fields.map((f, i) => {
         const meta = fieldTypeMeta(f.type);
         const Icon = meta.icon;
+        const isOpen = openMenuId === f.id;
+        const isFlashing = justMovedId === f.id;
+        const headerBg = isOpen
+          ? 'bg-brand-soft'
+          : isFlashing
+            ? 'bg-brand-soft/60'
+            : '';
         return (
           <div
             key={f.id}
             style={{ position: 'relative' }}
-            className="flex items-center border-r border-surface-sunk"
+            className={`flex items-center border-r border-surface-sunk transition-colors ${headerBg}`}
           >
             <button
-              onClick={() => onEditField(f)}
+              ref={setButtonRef(f.id)}
+              type="button"
+              data-column-header-button
+              onClick={() => setOpenMenuId((cur) => (cur === f.id ? null : f.id))}
+              aria-haspopup="menu"
+              aria-expanded={isOpen}
               className="flex flex-1 items-center gap-1.5 px-2 py-2 text-left min-w-0 overflow-hidden text-ellipsis"
             >
               <Icon size={12} className="text-brand flex-shrink-0" />
               <span className="text-[13px] font-medium text-ink truncate">{f.name}</span>
               {f.required && <span className="text-danger text-[11px]">*</span>}
-              <ChevronDown size={11} className="text-ink-soft ml-auto flex-shrink-0" />
+              <span
+                aria-hidden
+                className={`ml-auto flex flex-shrink-0 items-center justify-center rounded px-1 py-0.5 ${
+                  isOpen ? 'bg-brand/15 text-brand' : 'text-ink-soft'
+                }`}
+              >
+                <ChevronDown size={11} />
+              </span>
             </button>
             <ResizeHandle
               field={f}
@@ -60,6 +138,25 @@ export function GridHeader({
               onResize={(width) => onResize(f.id, width)}
               onReset={() => onResetWidth(f.id)}
             />
+            {isOpen && (
+              <ColumnHeaderMenu
+                anchorRef={anchorRefFor(f.id)}
+                isFirst={i === 0}
+                isLast={i === fields.length - 1}
+                onEdit={() => {
+                  setOpenMenuId(null);
+                  onEditField(f);
+                }}
+                onMoveLeft={() => move(f.id, i - 1)}
+                onMoveRight={() => move(f.id, i + 1)}
+                onMoveStart={() => move(f.id, 0)}
+                onMoveEnd={() => move(f.id, fields.length - 1)}
+                onDelete={() => {
+                  setOpenMenuId(null);
+                  onDeleteField(f.id);
+                }}
+              />
+            )}
           </div>
         );
       })}

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, ChevronDown } from 'lucide-react';
 import { buildColsTemplate } from './columnSizing';
 import { ColumnHeaderMenu } from './ColumnHeaderMenu';
@@ -38,28 +38,35 @@ export function GridHeader({
     else buttonRefs.current.delete(id);
   }, []);
 
+  const closeMenu = useCallback(() => {
+    setOpenMenuId((prev) => {
+      if (prev) buttonRefs.current.get(prev)?.focus();
+      return null;
+    });
+  }, []);
+
   // Close on outside click + Esc while a menu is open. The menu lives in a
   // portal under document.body, so we identify it via [data-column-header-menu]
-  // rather than DOM-tree containment.
+  // rather than DOM-tree containment. `pointerdown` covers mouse, touch, and pen.
   useEffect(() => {
     if (openMenuId === null) return;
-    const onDown = (e: MouseEvent) => {
+    const onDown = (e: PointerEvent) => {
       const target = e.target as HTMLElement | null;
       if (!target) return;
       if (target.closest('[data-column-header-button]')) return;
       if (target.closest('[data-column-header-menu]')) return;
-      setOpenMenuId(null);
+      closeMenu();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpenMenuId(null);
+      if (e.key === 'Escape') closeMenu();
     };
-    document.addEventListener('mousedown', onDown);
+    document.addEventListener('pointerdown', onDown);
     document.addEventListener('keydown', onKey);
     return () => {
-      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('pointerdown', onDown);
       document.removeEventListener('keydown', onKey);
     };
-  }, [openMenuId]);
+  }, [openMenuId, closeMenu]);
 
   // Clear flash highlight after a short delay.
   useEffect(() => {
@@ -71,14 +78,20 @@ export function GridHeader({
   const move = (fieldId: string, toIdx: number) => {
     onMoveField(fieldId, toIdx);
     setJustMovedId(fieldId);
-    setOpenMenuId(null);
+    closeMenu();
   };
 
-  const anchorRefFor = (id: string) => ({
-    get current() {
-      return buttonRefs.current.get(id) ?? null;
-    },
-  });
+  // Anchor ref is stable per `openMenuId` — only one menu is open at a time, so
+  // we don't need a per-field ref. Rebuilding only on `openMenuId` change keeps
+  // the menu's resize/scroll listeners attached exactly once per open.
+  const anchorRef = useMemo(
+    () => ({
+      get current() {
+        return openMenuId ? buttonRefs.current.get(openMenuId) ?? null : null;
+      },
+    }),
+    [openMenuId],
+  );
 
   return (
     <div
@@ -140,11 +153,11 @@ export function GridHeader({
             />
             {isOpen && (
               <ColumnHeaderMenu
-                anchorRef={anchorRefFor(f.id)}
+                anchorRef={anchorRef}
                 isFirst={i === 0}
                 isLast={i === fields.length - 1}
                 onEdit={() => {
-                  setOpenMenuId(null);
+                  closeMenu();
                   onEditField(f);
                 }}
                 onMoveLeft={() => move(f.id, i - 1)}
@@ -152,7 +165,7 @@ export function GridHeader({
                 onMoveStart={() => move(f.id, 0)}
                 onMoveEnd={() => move(f.id, fields.length - 1)}
                 onDelete={() => {
-                  setOpenMenuId(null);
+                  closeMenu();
                   onDeleteField(f.id);
                 }}
               />

--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -313,6 +313,42 @@ describe('gridReducer SET_GROUP_BY', () => {
 });
 
 // ---------------------------------------------------------------------------
+// SET_FIELDS (used by moveField to apply a re-sequenced order)
+// ---------------------------------------------------------------------------
+
+describe('gridReducer SET_FIELDS', () => {
+  it('replaces the fields array in order', () => {
+    const a = makeField({ id: 'a', ref: 'a', sortOrder: 0 });
+    const b = makeField({ id: 'b', ref: 'b', sortOrder: 1 });
+    const c = makeField({ id: 'c', ref: 'c', sortOrder: 2 });
+    const state = makeState({ fields: [a, b, c] });
+
+    const next = gridReducer(state, {
+      type: 'SET_FIELDS',
+      fields: [
+        { ...c, sortOrder: 0 },
+        { ...a, sortOrder: 1 },
+        { ...b, sortOrder: 2 },
+      ],
+    });
+
+    expect(next.fields.map((f) => f.id)).toEqual(['c', 'a', 'b']);
+    expect(next.fields.map((f) => f.sortOrder)).toEqual([0, 1, 2]);
+  });
+
+  it('does not touch rows when fields are reordered', () => {
+    const a = makeField({ id: 'a', ref: 'a' });
+    const b = makeField({ id: 'b', ref: 'b' });
+    const row = makeRow({ id: 'r1', values: { a: '1', b: '2' } });
+    const state = makeState({ fields: [a, b], rows: [row] });
+
+    const next = gridReducer(state, { type: 'SET_FIELDS', fields: [b, a] });
+
+    expect(next.rows).toEqual([row]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // APPEND_FIELD
 // ---------------------------------------------------------------------------
 

--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { gridReducer } from './useGridState';
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { gridReducer, useGridState } from './useGridState';
 import type { GridState, GridField, GridRow } from './useGridState';
+import type { SlotFieldDefinition } from '@/schemas/slot-fields';
+import type { SignupSettings } from '@/schemas/signups';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -474,5 +478,173 @@ describe('gridReducer DELETE_FIELD', () => {
     expect(next.fields).toHaveLength(1);
     expect(next.fields[0]?.id).toBe('f2');
     expect(next.rows[0]?.values).toEqual({ beta: 'b' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useGridState moveField (renderHook + mocked fetch)
+// ---------------------------------------------------------------------------
+
+const makeApiField = (overrides: Partial<SlotFieldDefinition> = {}): SlotFieldDefinition => ({
+  id: 'f1',
+  ref: 'alpha',
+  label: 'Alpha',
+  fieldType: 'text',
+  required: false,
+  sortOrder: 0,
+  config: { fieldType: 'text', maxLength: 200 },
+  ...overrides,
+});
+
+const defaultSettings: SignupSettings = {
+  requireEmail: true,
+  allowNotes: true,
+  showWhoSignedUp: true,
+  lockoutHoursBeforeSlot: 0,
+  sendReminders: true,
+  groupByFieldRefs: [],
+};
+
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  const status = init.status ?? (init.ok === false ? 500 : 200);
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function fieldIdFromUrl(url: string): string | undefined {
+  return url.match(/\/fields\/([^/]+)$/)?.[1];
+}
+
+function renderGrid(initialFields: SlotFieldDefinition[]) {
+  return renderHook(() => useGridState('sig_test', initialFields, [], defaultSettings));
+}
+
+describe('useGridState moveField', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reorders fields and PATCHes each changed field with its new sortOrder', async () => {
+    const a = makeApiField({ id: 'a', ref: 'a', label: 'A', sortOrder: 0 });
+    const b = makeApiField({ id: 'b', ref: 'b', label: 'B', sortOrder: 1 });
+    const c = makeApiField({ id: 'c', ref: 'c', label: 'C', sortOrder: 2 });
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: {} }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGrid([a, b, c]);
+    await act(async () => {
+      await result.current.moveField('c', 0);
+    });
+
+    expect(result.current.state.fields.map((f) => f.id)).toEqual(['c', 'a', 'b']);
+    expect(result.current.state.fields.map((f) => f.sortOrder)).toEqual([0, 1, 2]);
+
+    // Inspect PATCH bodies by id, not call count.
+    const sentPatches = new Map<string, number>();
+    for (const call of fetchMock.mock.calls) {
+      const url = String(call[0]);
+      const init = call[1] as RequestInit | undefined;
+      if (init?.method !== 'PATCH') continue;
+      const id = fieldIdFromUrl(url);
+      const body = JSON.parse(String(init.body)) as { sortOrder: number };
+      if (id !== undefined) sentPatches.set(id, body.sortOrder);
+    }
+    expect(sentPatches.get('c')).toBe(0);
+    expect(sentPatches.get('a')).toBe(1);
+    expect(sentPatches.get('b')).toBe(2);
+    expect(result.current.state.saveStatus).toBe('saved');
+  });
+
+  it('refetches server truth on PATCH failure and preserves session widths', async () => {
+    const a = makeApiField({ id: 'a', ref: 'a', label: 'A', sortOrder: 0 });
+    const b = makeApiField({ id: 'b', ref: 'b', label: 'B', sortOrder: 1 });
+    const c = makeApiField({ id: 'c', ref: 'c', label: 'C', sortOrder: 2 });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'PATCH') {
+        const priorPatches = fetchMock.mock.calls.filter(
+          (c) => (c[1] as RequestInit | undefined)?.method === 'PATCH',
+        ).length;
+        // First PATCH succeeds, second fails. Third should not fire.
+        if (priorPatches <= 1) return jsonResponse({ data: {} });
+        return jsonResponse({}, { ok: false });
+      }
+      if (url.endsWith('/fields')) {
+        return jsonResponse({ data: [a, b, c] });
+      }
+      throw new Error(`unexpected fetch ${url} ${init?.method ?? 'GET'}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGrid([a, b, c]);
+
+    // Set a session-only width on field "a" before the failing reorder so we can
+    // verify it survives the refetch.
+    act(() => {
+      result.current.setFieldWidth('a', 321);
+    });
+    expect(result.current.state.fields.find((f) => f.id === 'a')?.width).toBe(321);
+
+    await act(async () => {
+      await result.current.moveField('c', 0);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'PATCH',
+    );
+    const getCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit | undefined)?.method !== 'PATCH',
+    );
+    expect(patchCalls.length).toBe(2); // aborted after the failing second PATCH
+    expect(getCalls.length).toBe(1); // single refetch
+    expect(result.current.state.fields.map((f) => f.id)).toEqual(['a', 'b', 'c']);
+    expect(result.current.state.fields.find((f) => f.id === 'a')?.width).toBe(321);
+    expect(result.current.state.saveStatus).toBe('error');
+  });
+
+  it('falls back to snapshot with sticky error when refetch also fails', async () => {
+    const a = makeApiField({ id: 'a', ref: 'a', label: 'A', sortOrder: 0 });
+    const b = makeApiField({ id: 'b', ref: 'b', label: 'B', sortOrder: 1 });
+
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      return jsonResponse({}, { ok: false });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGrid([a, b]);
+    await act(async () => {
+      await result.current.moveField('b', 0);
+    });
+
+    // The contract is "sticky error, refresh converges them" — the snapshot
+    // is not necessarily server-correct, only that the user sees `error`.
+    expect(result.current.state.fields.map((f) => f.id)).toEqual(['a', 'b']);
+    expect(result.current.state.saveStatus).toBe('error');
+  });
+
+  it('is a no-op when toIdx clamps to fromIdx or fieldId is unknown', async () => {
+    const a = makeApiField({ id: 'a', ref: 'a', label: 'A', sortOrder: 0 });
+    const b = makeApiField({ id: 'b', ref: 'b', label: 'B', sortOrder: 1 });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGrid([a, b]);
+
+    // toIdx -1 clamps to 0; fromIdx of 'a' is 0 — no-op.
+    await act(async () => {
+      await result.current.moveField('a', -1);
+    });
+    // unknown fieldId — no-op.
+    await act(async () => {
+      await result.current.moveField('missing', 0);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.state.fields.map((f) => f.id)).toEqual(['a', 'b']);
   });
 });

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -327,82 +327,39 @@ export function useGridState(
     [signupId, state.fields],
   );
 
-  const moveFieldUp = useCallback(
-    async (fieldId: string): Promise<void> => {
-      const idx = state.fields.findIndex((f) => f.id === fieldId);
-      if (idx <= 0) return;
-      const above = state.fields[idx - 1]!;
-      const current = state.fields[idx]!;
-      const newAboveSortOrder = current.sortOrder;
-      const newCurrentSortOrder = above.sortOrder;
+  const moveField = useCallback(
+    async (fieldId: string, toIdx: number): Promise<void> => {
+      const fields = state.fields;
+      const fromIdx = fields.findIndex((f) => f.id === fieldId);
+      if (fromIdx === -1) return;
+      const clamped = Math.max(0, Math.min(fields.length - 1, toIdx));
+      if (clamped === fromIdx) return;
 
+      const reordered = fields.slice();
+      const [moved] = reordered.splice(fromIdx, 1);
+      if (!moved) return;
+      reordered.splice(clamped, 0, moved);
+      const resequenced = reordered.map((f, i) => ({ ...f, sortOrder: i }));
+
+      // Optimistic update so the UI reorders immediately.
+      dispatch({ type: 'SET_FIELDS', fields: resequenced });
       markSaving();
       try {
-        const [r1, r2] = await Promise.all([
-          fetch(`/api/signups/${signupId}/fields/${above.id}`, {
-            method: 'PATCH',
-            headers: JSON_HEADERS,
-            body: JSON.stringify({ sortOrder: newAboveSortOrder }),
-          }),
-          fetch(`/api/signups/${signupId}/fields/${current.id}`, {
-            method: 'PATCH',
-            headers: JSON_HEADERS,
-            body: JSON.stringify({ sortOrder: newCurrentSortOrder }),
-          }),
-        ]);
-        if (!r1.ok || !r2.ok) throw new Error('reorder failed');
-        const updatedFields = state.fields.map((f) => {
-          if (f.id === above.id) return { ...f, sortOrder: newAboveSortOrder };
-          if (f.id === current.id) return { ...f, sortOrder: newCurrentSortOrder };
-          return f;
-        });
-        dispatch({
-          type: 'SET_FIELDS',
-          fields: [...updatedFields].sort((a, b) => a.sortOrder - b.sortOrder),
-        });
+        const patches = resequenced
+          .filter((f, i) => fields[i]?.id !== f.id || fields[i]?.sortOrder !== f.sortOrder)
+          .map((f) =>
+            fetch(`/api/signups/${signupId}/fields/${f.id}`, {
+              method: 'PATCH',
+              headers: JSON_HEADERS,
+              body: JSON.stringify({ sortOrder: f.sortOrder }),
+            }),
+          );
+        const responses = await Promise.all(patches);
+        if (responses.some((r) => !r.ok)) throw new Error('reorder failed');
         markSaved();
       } catch {
-        markError();
-      }
-    },
-    [signupId, state.fields],
-  );
-
-  const moveFieldDown = useCallback(
-    async (fieldId: string): Promise<void> => {
-      const idx = state.fields.findIndex((f) => f.id === fieldId);
-      if (idx < 0 || idx >= state.fields.length - 1) return;
-      const current = state.fields[idx]!;
-      const below = state.fields[idx + 1]!;
-      const newCurrentSortOrder = below.sortOrder;
-      const newBelowSortOrder = current.sortOrder;
-
-      markSaving();
-      try {
-        const [r1, r2] = await Promise.all([
-          fetch(`/api/signups/${signupId}/fields/${current.id}`, {
-            method: 'PATCH',
-            headers: JSON_HEADERS,
-            body: JSON.stringify({ sortOrder: newCurrentSortOrder }),
-          }),
-          fetch(`/api/signups/${signupId}/fields/${below.id}`, {
-            method: 'PATCH',
-            headers: JSON_HEADERS,
-            body: JSON.stringify({ sortOrder: newBelowSortOrder }),
-          }),
-        ]);
-        if (!r1.ok || !r2.ok) throw new Error('reorder failed');
-        const updatedFields = state.fields.map((f) => {
-          if (f.id === current.id) return { ...f, sortOrder: newCurrentSortOrder };
-          if (f.id === below.id) return { ...f, sortOrder: newBelowSortOrder };
-          return f;
-        });
-        dispatch({
-          type: 'SET_FIELDS',
-          fields: [...updatedFields].sort((a, b) => a.sortOrder - b.sortOrder),
-        });
-        markSaved();
-      } catch {
+        // Roll back to the previous order on failure.
+        dispatch({ type: 'SET_FIELDS', fields });
         markError();
       }
     },
@@ -679,8 +636,7 @@ export function useGridState(
     addField,
     updateField,
     deleteField,
-    moveFieldUp,
-    moveFieldDown,
+    moveField,
     setFieldWidth,
     addRow,
     deleteRow,

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -241,6 +241,10 @@ export function useGridState(
   }
 
   function markError() {
+    if (savedTimerRef.current !== null) {
+      clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = null;
+    }
     dispatch({ type: 'SET_SAVE_STATUS', status: 'error' });
   }
 
@@ -327,15 +331,17 @@ export function useGridState(
     [signupId, state.fields],
   );
 
+  // Concurrent reorders by other organizers can race; this client converges via
+  // refetch on error but the server has no transactional bulk-reorder endpoint.
   const moveField = useCallback(
     async (fieldId: string, toIdx: number): Promise<void> => {
-      const fields = state.fields;
-      const fromIdx = fields.findIndex((f) => f.id === fieldId);
+      const previous = state.fields;
+      const fromIdx = previous.findIndex((f) => f.id === fieldId);
       if (fromIdx === -1) return;
-      const clamped = Math.max(0, Math.min(fields.length - 1, toIdx));
+      const clamped = Math.max(0, Math.min(previous.length - 1, toIdx));
       if (clamped === fromIdx) return;
 
-      const reordered = fields.slice();
+      const reordered = previous.slice();
       const [moved] = reordered.splice(fromIdx, 1);
       if (!moved) return;
       reordered.splice(clamped, 0, moved);
@@ -345,21 +351,38 @@ export function useGridState(
       dispatch({ type: 'SET_FIELDS', fields: resequenced });
       markSaving();
       try {
-        const patches = resequenced
-          .filter((f, i) => fields[i]?.id !== f.id || fields[i]?.sortOrder !== f.sortOrder)
-          .map((f) =>
-            fetch(`/api/signups/${signupId}/fields/${f.id}`, {
-              method: 'PATCH',
-              headers: JSON_HEADERS,
-              body: JSON.stringify({ sortOrder: f.sortOrder }),
-            }),
-          );
-        const responses = await Promise.all(patches);
-        if (responses.some((r) => !r.ok)) throw new Error('reorder failed');
+        const changed = resequenced.filter(
+          (f, i) => previous[i]?.id !== f.id || previous[i]?.sortOrder !== f.sortOrder,
+        );
+        for (const f of changed) {
+          const res = await fetch(`/api/signups/${signupId}/fields/${f.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: f.sortOrder }),
+          });
+          if (!res.ok) throw new Error('reorder failed');
+        }
         markSaved();
       } catch {
-        // Roll back to the previous order on failure.
-        dispatch({ type: 'SET_FIELDS', fields });
+        // Server may hold a partial reorder; converge on server truth via refetch.
+        // `previous` already carries session-only column widths — preserve them on
+        // refresh by id, since `toGridFields` cannot populate `width`.
+        const widthById = new Map(previous.map((f) => [f.id, f.width]));
+        try {
+          const res = await fetch(`/api/signups/${signupId}/fields`);
+          if (res.ok) {
+            const envelope = (await res.json()) as { data: SlotFieldDefinition[] };
+            const refreshed = toGridFields(envelope.data).map((f) => ({
+              ...f,
+              width: widthById.get(f.id),
+            }));
+            dispatch({ type: 'SET_FIELDS', fields: refreshed });
+          } else {
+            dispatch({ type: 'SET_FIELDS', fields: previous });
+          }
+        } catch {
+          dispatch({ type: 'SET_FIELDS', fields: previous });
+        }
         markError();
       }
     },


### PR DESCRIPTION
## Summary
- Adds a column-header dropdown (Edit field, Move left/right/to start/to end, Delete) so organizers can reorder columns on the Build grid. Implements Design B from the `reorder-columns` Claude Design hand-off.
- Edge entries disable on the leftmost/rightmost column; menu closes on outside click or `Esc`; the just-moved column flashes briefly.
- Replaces the unused single-step `moveFieldUp`/`moveFieldDown` helpers with one `moveField(fieldId, toIdx)` that re-sequences `sortOrder` to `0..N-1`, PATCHes only the fields whose order changed, and rolls back on failure.
- Menu renders via `createPortal` and right-aligns with the chevron, so it isn't clipped by the panel's `overflow-hidden` and feels anchored to the trigger.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (259 passed, +2 new SET_FIELDS reducer tests)
- [x] Manual smoke in Chrome on `/app/signups/{id}/build`: open menu, Move right, Move to start, refresh persists order, edge-disabled states render correctly.
- [ ] `pnpm test:db` to confirm no regression on the slot-fields PATCH path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)