### PR TITLE
fix(build-grid): show inline validation errors in FieldEditor

### DIFF
--- a/src/components/build-grid/FieldEditor.tsx
+++ b/src/components/build-grid/FieldEditor.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { FIELD_TYPE_META } from './fieldTypes';
 import { FIELD_TYPES } from '@/schemas/slot-fields';
 import type { FieldType, SlotFieldConfig } from '@/schemas/slot-fields';
 import type { GridField } from './useGridState';
+import { validate } from './fieldEditorValidation';
 
 type FieldEditorMode =
   | { mode: 'edit'; field: GridField }
@@ -33,6 +34,11 @@ function buildConfig(type: FieldType, choices: string[]): SlotFieldConfig {
       return { fieldType: 'enum', choices };
   }
 }
+
+const NAME_INPUT_ID = 'field-name';
+const NAME_ERROR_ID = 'field-name-error';
+const CHOICES_INPUT_ID = 'field-choices';
+const CHOICES_ERROR_ID = 'field-choices-error';
 
 export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEditorProps) {
   const isEdit = editorMode.mode === 'edit';
@@ -62,6 +68,11 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
     return '';
   });
 
+  const [submitted, setSubmitted] = useState(false);
+
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  const choicesInputRef = useRef<HTMLTextAreaElement>(null);
+
   function handleTypeChange(type: FieldType) {
     if (type !== 'enum') {
       setChoicesText('');
@@ -70,25 +81,48 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
   }
 
   function handleSave() {
-    if (!name.trim()) return;
+    setSubmitted(true);
+    const errors = validate(name, fieldType, choicesText);
 
-    let parsedChoices: string[] = [];
-    if (fieldType === 'enum') {
-      parsedChoices = choicesText
-        .split('\n')
-        .map((c) => c.trim())
-        .filter((c) => c.length > 0);
-      if (parsedChoices.length === 0) return;
+    if (errors.name) {
+      nameInputRef.current?.focus();
+      return;
     }
+    if (errors.choices) {
+      choicesInputRef.current?.focus();
+      return;
+    }
+
+    const parsedChoices =
+      fieldType === 'enum'
+        ? choicesText
+            .split('\n')
+            .map((c) => c.trim())
+            .filter((c) => c.length > 0)
+        : [];
 
     onSave(fieldType, name.trim(), buildConfig(fieldType, parsedChoices), required);
   }
 
+  const errors = submitted ? validate(name, fieldType, choicesText) : {};
+  const nameError = errors.name;
+  const choicesErrors = errors.choices;
+
   const titleText = isEdit ? 'Edit column' : 'New column';
-  const canSave =
-    name.trim().length > 0 &&
-    (fieldType !== 'enum' ||
-      choicesText.split('\n').some((c) => c.trim().length > 0));
+
+  const nameInputClasses = [
+    'border rounded-lg px-2.5 py-2 text-sm font-[inherit] outline-none bg-white w-full',
+    nameError
+      ? 'border-danger focus:border-danger focus:ring-1 focus:ring-danger'
+      : 'border-surface-sunk focus:border-brand focus:ring-1 focus:ring-brand',
+  ].join(' ');
+
+  const choicesInputClasses = [
+    'border rounded-lg px-2.5 py-2 text-sm font-[inherit] outline-none bg-white w-full min-h-[80px] resize-y',
+    choicesErrors
+      ? 'border-danger focus:border-danger focus:ring-1 focus:ring-danger'
+      : 'border-surface-sunk focus:border-brand focus:ring-1 focus:ring-brand',
+  ].join(' ');
 
   return (
     <Dialog.Root open onOpenChange={(o) => { if (!o) onClose(); }}>
@@ -114,16 +148,25 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
             <div className="flex flex-col gap-4">
               {/* Name input */}
               <div className="flex flex-col gap-1.5">
-                <label className="text-xs font-medium text-ink-soft" htmlFor="field-name">
-                  Name
+                <label className="text-xs font-medium text-ink-soft" htmlFor={NAME_INPUT_ID}>
+                  Name <span aria-hidden="true" className="text-danger">*</span>
                 </label>
                 <input
-                  id="field-name"
+                  ref={nameInputRef}
+                  id={NAME_INPUT_ID}
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  className="border border-surface-sunk rounded-lg px-2.5 py-2 text-sm font-[inherit] outline-none focus:border-brand focus:ring-1 focus:ring-brand bg-white w-full"
+                  aria-required="true"
+                  aria-invalid={nameError ? true : undefined}
+                  aria-describedby={nameError ? NAME_ERROR_ID : undefined}
+                  className={nameInputClasses}
                 />
+                {nameError && (
+                  <p id={NAME_ERROR_ID} role="alert" className="text-xs text-danger">
+                    {nameError}
+                  </p>
+                )}
               </div>
 
               {/* Type pill grid */}
@@ -156,16 +199,33 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
               {/* Choices textarea (enum only) */}
               {fieldType === 'enum' && (
                 <div className="flex flex-col gap-1.5">
-                  <label className="text-xs font-medium text-ink-soft" htmlFor="field-choices">
-                    Choices (one per line)
+                  <label className="text-xs font-medium text-ink-soft" htmlFor={CHOICES_INPUT_ID}>
+                    Choices (one per line){' '}
+                    <span aria-hidden="true" className="text-danger">*</span>
                   </label>
                   <textarea
-                    id="field-choices"
+                    ref={choicesInputRef}
+                    id={CHOICES_INPUT_ID}
                     value={choicesText}
                     onChange={(e) => setChoicesText(e.target.value)}
                     placeholder={'Apples\nBananas\nOranges'}
-                    className="border border-surface-sunk rounded-lg px-2.5 py-2 text-sm font-[inherit] outline-none focus:border-brand focus:ring-1 focus:ring-brand bg-white w-full min-h-[80px] resize-y"
+                    aria-required="true"
+                    aria-invalid={choicesErrors ? true : undefined}
+                    aria-describedby={choicesErrors ? CHOICES_ERROR_ID : undefined}
+                    className={choicesInputClasses}
                   />
+                  {choicesErrors && (
+                    <ul
+                      id={CHOICES_ERROR_ID}
+                      role="alert"
+                      aria-live="polite"
+                      className="text-xs text-danger flex flex-col gap-0.5"
+                    >
+                      {choicesErrors.map((msg) => (
+                        <li key={msg}>{msg}</li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
               )}
 
@@ -195,8 +255,7 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
               </div>
               <button
                 onClick={handleSave}
-                disabled={!canSave}
-                className="bg-brand text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-brand"
+                className="bg-brand text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-brand/90 transition-colors"
               >
                 Save
               </button>

--- a/src/components/build-grid/FieldEditor.tsx
+++ b/src/components/build-grid/FieldEditor.tsx
@@ -214,18 +214,25 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
                     aria-describedby={choicesErrors ? CHOICES_ERROR_ID : undefined}
                     className={choicesInputClasses}
                   />
-                  {choicesErrors && (
+                  {choicesErrors && choicesErrors.length === 1 ? (
+                    <p
+                      id={CHOICES_ERROR_ID}
+                      role="alert"
+                      className="text-xs text-danger"
+                    >
+                      {choicesErrors[0]}
+                    </p>
+                  ) : choicesErrors ? (
                     <ul
                       id={CHOICES_ERROR_ID}
                       role="alert"
-                      aria-live="polite"
                       className="text-xs text-danger flex flex-col gap-0.5"
                     >
                       {choicesErrors.map((msg) => (
                         <li key={msg}>{msg}</li>
                       ))}
                     </ul>
-                  )}
+                  ) : null}
                 </div>
               )}
 

--- a/src/components/build-grid/FieldEditor.tsx
+++ b/src/components/build-grid/FieldEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { FIELD_TYPE_META } from './fieldTypes';
@@ -35,13 +35,14 @@ function buildConfig(type: FieldType, choices: string[]): SlotFieldConfig {
   }
 }
 
-const NAME_INPUT_ID = 'field-name';
-const NAME_ERROR_ID = 'field-name-error';
-const CHOICES_INPUT_ID = 'field-choices';
-const CHOICES_ERROR_ID = 'field-choices-error';
-
 export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEditorProps) {
   const isEdit = editorMode.mode === 'edit';
+
+  const reactId = useId();
+  const nameInputId = `${reactId}-name`;
+  const nameErrorId = `${reactId}-name-error`;
+  const choicesInputId = `${reactId}-choices`;
+  const choicesErrorId = `${reactId}-choices-error`;
 
   const [name, setName] = useState<string>(() => {
     if (editorMode.mode === 'edit') return editorMode.field.name;
@@ -148,22 +149,22 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
             <div className="flex flex-col gap-4">
               {/* Name input */}
               <div className="flex flex-col gap-1.5">
-                <label className="text-xs font-medium text-ink-soft" htmlFor={NAME_INPUT_ID}>
+                <label className="text-xs font-medium text-ink-soft" htmlFor={nameInputId}>
                   Name <span aria-hidden="true" className="text-danger">*</span>
                 </label>
                 <input
                   ref={nameInputRef}
-                  id={NAME_INPUT_ID}
+                  id={nameInputId}
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   aria-required="true"
                   aria-invalid={nameError ? true : undefined}
-                  aria-describedby={nameError ? NAME_ERROR_ID : undefined}
+                  aria-describedby={nameError ? nameErrorId : undefined}
                   className={nameInputClasses}
                 />
                 {nameError && (
-                  <p id={NAME_ERROR_ID} role="alert" className="text-xs text-danger">
+                  <p id={nameErrorId} role="alert" className="text-xs text-danger">
                     {nameError}
                   </p>
                 )}
@@ -199,24 +200,24 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
               {/* Choices textarea (enum only) */}
               {fieldType === 'enum' && (
                 <div className="flex flex-col gap-1.5">
-                  <label className="text-xs font-medium text-ink-soft" htmlFor={CHOICES_INPUT_ID}>
+                  <label className="text-xs font-medium text-ink-soft" htmlFor={choicesInputId}>
                     Choices (one per line){' '}
                     <span aria-hidden="true" className="text-danger">*</span>
                   </label>
                   <textarea
                     ref={choicesInputRef}
-                    id={CHOICES_INPUT_ID}
+                    id={choicesInputId}
                     value={choicesText}
                     onChange={(e) => setChoicesText(e.target.value)}
                     placeholder={'Apples\nBananas\nOranges'}
                     aria-required="true"
                     aria-invalid={choicesErrors ? true : undefined}
-                    aria-describedby={choicesErrors ? CHOICES_ERROR_ID : undefined}
+                    aria-describedby={choicesErrors ? choicesErrorId : undefined}
                     className={choicesInputClasses}
                   />
                   {choicesErrors && choicesErrors.length === 1 ? (
                     <p
-                      id={CHOICES_ERROR_ID}
+                      id={choicesErrorId}
                       role="alert"
                       className="text-xs text-danger"
                     >
@@ -224,7 +225,7 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
                     </p>
                   ) : choicesErrors ? (
                     <ul
-                      id={CHOICES_ERROR_ID}
+                      id={choicesErrorId}
                       role="alert"
                       className="text-xs text-danger flex flex-col gap-0.5"
                     >

--- a/src/components/build-grid/fieldEditorValidation.test.ts
+++ b/src/components/build-grid/fieldEditorValidation.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { validate } from './fieldEditorValidation';
+
+describe('FieldEditor validate()', () => {
+  describe('name', () => {
+    it('flags empty name', () => {
+      const errors = validate('', 'text', '');
+      expect(errors.name).toBe('Name is required.');
+    });
+
+    it('flags whitespace-only name as empty', () => {
+      const errors = validate('   \t  ', 'text', '');
+      expect(errors.name).toBe('Name is required.');
+    });
+
+    it('flags name longer than 80 chars', () => {
+      const errors = validate('a'.repeat(81), 'text', '');
+      expect(errors.name).toBe('Name must be 80 characters or fewer.');
+    });
+
+    it('measures length after trim', () => {
+      const errors = validate(`   ${'a'.repeat(80)}   `, 'text', '');
+      expect(errors.name).toBeUndefined();
+    });
+
+    it('accepts an 80-char name', () => {
+      const errors = validate('a'.repeat(80), 'text', '');
+      expect(errors.name).toBeUndefined();
+    });
+
+    it('accepts a normal name', () => {
+      const errors = validate('Email', 'text', '');
+      expect(errors.name).toBeUndefined();
+    });
+  });
+
+  describe('choices (enum only)', () => {
+    it('does not check choices for non-enum types', () => {
+      const errors = validate('Email', 'text', '');
+      expect(errors.choices).toBeUndefined();
+    });
+
+    it('flags empty choices for enum', () => {
+      const errors = validate('Size', 'enum', '');
+      expect(errors.choices).toEqual(['Add at least one choice.']);
+    });
+
+    it('treats whitespace-only lines as empty', () => {
+      const errors = validate('Size', 'enum', '   \n\n  \t\n');
+      expect(errors.choices).toEqual(['Add at least one choice.']);
+    });
+
+    it('accepts a single valid choice', () => {
+      const errors = validate('Size', 'enum', 'Small');
+      expect(errors.choices).toBeUndefined();
+    });
+
+    it('ignores blank lines between valid choices', () => {
+      const errors = validate('Size', 'enum', 'Small\n\nMedium\n  \nLarge');
+      expect(errors.choices).toBeUndefined();
+    });
+
+    it('flags a choice over 60 chars with its 1-based locator', () => {
+      const text = ['Short', 'a'.repeat(61), 'Also short'].join('\n');
+      const errors = validate('Size', 'enum', text);
+      expect(errors.choices).toEqual([
+        'Choice 2 must be 60 characters or fewer.',
+      ]);
+    });
+
+    it('numbers choice locators among non-empty lines only', () => {
+      // Blank line between two real choices; the long one is the 2nd non-empty.
+      const text = ['Short', '', 'a'.repeat(61)].join('\n');
+      const errors = validate('Size', 'enum', text);
+      expect(errors.choices).toEqual([
+        'Choice 2 must be 60 characters or fewer.',
+      ]);
+    });
+
+    it('reports every over-long choice in order', () => {
+      const text = ['a'.repeat(61), 'ok', 'b'.repeat(70)].join('\n');
+      const errors = validate('Size', 'enum', text);
+      expect(errors.choices).toEqual([
+        'Choice 1 must be 60 characters or fewer.',
+        'Choice 3 must be 60 characters or fewer.',
+      ]);
+    });
+
+    it('flags more than 20 choices', () => {
+      const text = Array.from({ length: 21 }, (_, i) => `choice-${i}`).join(
+        '\n',
+      );
+      const errors = validate('Size', 'enum', text);
+      expect(errors.choices).toEqual(['At most 20 choices allowed.']);
+    });
+
+    it('reports long-choice and 20-cap errors together', () => {
+      const lines = Array.from({ length: 21 }, (_, i) =>
+        i === 0 ? 'a'.repeat(61) : `choice-${i}`,
+      );
+      const errors = validate('Size', 'enum', lines.join('\n'));
+      expect(errors.choices).toEqual([
+        'Choice 1 must be 60 characters or fewer.',
+        'At most 20 choices allowed.',
+      ]);
+    });
+
+    it('accepts exactly 20 choices', () => {
+      const text = Array.from({ length: 20 }, (_, i) => `c${i}`).join('\n');
+      const errors = validate('Size', 'enum', text);
+      expect(errors.choices).toBeUndefined();
+    });
+
+    it('accepts a 60-char choice', () => {
+      const errors = validate('Size', 'enum', 'a'.repeat(60));
+      expect(errors.choices).toBeUndefined();
+    });
+  });
+
+  describe('combined', () => {
+    it('returns both name and choices errors at once', () => {
+      const errors = validate('', 'enum', '');
+      expect(errors.name).toBe('Name is required.');
+      expect(errors.choices).toEqual(['Add at least one choice.']);
+    });
+
+    it('returns no errors for a valid form', () => {
+      const errors = validate('Size', 'enum', 'Small\nMedium\nLarge');
+      expect(errors).toEqual({});
+    });
+  });
+});

--- a/src/components/build-grid/fieldEditorValidation.ts
+++ b/src/components/build-grid/fieldEditorValidation.ts
@@ -1,0 +1,53 @@
+import type { FieldType } from '@/schemas/slot-fields';
+
+export type FieldEditorErrors = {
+  name?: string;
+  choices?: string[];
+};
+
+const NAME_MAX = 80;
+const CHOICE_MAX = 60;
+const CHOICES_MAX = 20;
+
+export function validate(
+  name: string,
+  fieldType: FieldType,
+  choicesText: string,
+): FieldEditorErrors {
+  const errors: FieldEditorErrors = {};
+
+  const trimmedName = name.trim();
+  if (trimmedName.length === 0) {
+    errors.name = 'Name is required.';
+  } else if (trimmedName.length > NAME_MAX) {
+    errors.name = `Name must be ${NAME_MAX} characters or fewer.`;
+  }
+
+  if (fieldType === 'enum') {
+    const nonEmpty = choicesText
+      .split('\n')
+      .map((c) => c.trim())
+      .filter((c) => c.length > 0);
+
+    if (nonEmpty.length === 0) {
+      errors.choices = ['Add at least one choice.'];
+    } else {
+      const choiceErrors: string[] = [];
+      nonEmpty.forEach((choice, idx) => {
+        if (choice.length > CHOICE_MAX) {
+          choiceErrors.push(
+            `Choice ${idx + 1} must be ${CHOICE_MAX} characters or fewer.`,
+          );
+        }
+      });
+      if (nonEmpty.length > CHOICES_MAX) {
+        choiceErrors.push(`At most ${CHOICES_MAX} choices allowed.`);
+      }
+      if (choiceErrors.length > 0) {
+        errors.choices = choiceErrors;
+      }
+    }
+  }
+
+  return errors;
+}

--- a/src/components/build-grid/fieldEditorValidation.ts
+++ b/src/components/build-grid/fieldEditorValidation.ts
@@ -1,13 +1,14 @@
-import type { FieldType } from '@/schemas/slot-fields';
+import {
+  CHOICE_MAX_LENGTH,
+  LABEL_MAX_LENGTH,
+  MAX_CHOICES,
+  type FieldType,
+} from '@/schemas/slot-fields';
 
 export type FieldEditorErrors = {
   name?: string;
   choices?: string[];
 };
-
-const NAME_MAX = 80;
-const CHOICE_MAX = 60;
-const CHOICES_MAX = 20;
 
 export function validate(
   name: string,
@@ -19,8 +20,8 @@ export function validate(
   const trimmedName = name.trim();
   if (trimmedName.length === 0) {
     errors.name = 'Name is required.';
-  } else if (trimmedName.length > NAME_MAX) {
-    errors.name = `Name must be ${NAME_MAX} characters or fewer.`;
+  } else if (trimmedName.length > LABEL_MAX_LENGTH) {
+    errors.name = `Name must be ${LABEL_MAX_LENGTH} characters or fewer.`;
   }
 
   if (fieldType === 'enum') {
@@ -34,14 +35,14 @@ export function validate(
     } else {
       const choiceErrors: string[] = [];
       nonEmpty.forEach((choice, idx) => {
-        if (choice.length > CHOICE_MAX) {
+        if (choice.length > CHOICE_MAX_LENGTH) {
           choiceErrors.push(
-            `Choice ${idx + 1} must be ${CHOICE_MAX} characters or fewer.`,
+            `Choice ${idx + 1} must be ${CHOICE_MAX_LENGTH} characters or fewer.`,
           );
         }
       });
-      if (nonEmpty.length > CHOICES_MAX) {
-        choiceErrors.push(`At most ${CHOICES_MAX} choices allowed.`);
+      if (nonEmpty.length > MAX_CHOICES) {
+        choiceErrors.push(`At most ${MAX_CHOICES} choices allowed.`);
       }
       if (choiceErrors.length > 0) {
         errors.choices = choiceErrors;

--- a/src/schemas/slot-fields.ts
+++ b/src/schemas/slot-fields.ts
@@ -3,13 +3,17 @@ import { z } from 'zod';
 export const FIELD_TYPES = ['text', 'date', 'time', 'number', 'enum'] as const;
 export type FieldType = (typeof FIELD_TYPES)[number];
 
+export const LABEL_MAX_LENGTH = 80;
+export const CHOICE_MAX_LENGTH = 60;
+export const MAX_CHOICES = 20;
+
 const RefSchema = z
   .string()
   .min(1)
   .max(40)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'ref must be lowercase kebab');
 
-const LabelSchema = z.string().min(1).max(80);
+const LabelSchema = z.string().min(1).max(LABEL_MAX_LENGTH);
 
 const TextConfigSchema = z.object({
   fieldType: z.literal('text'),
@@ -32,7 +36,7 @@ const NumberConfigSchema = z.object({
 
 const EnumConfigSchema = z.object({
   fieldType: z.literal('enum'),
-  choices: z.array(z.string().min(1).max(60)).min(1).max(20),
+  choices: z.array(z.string().min(1).max(CHOICE_MAX_LENGTH)).min(1).max(MAX_CHOICES),
 });
 
 export const SlotFieldConfigSchema = z.discriminatedUnion('fieldType', [


### PR DESCRIPTION
## Summary

- Save in the New/Edit column dialog was silently disabled when invalid, leaving users guessing which field was the problem.
- Replaced the disabled Save with on-submit validation: required-field `*`, inline error messages, full a11y wiring (`aria-required`, `aria-invalid`, `aria-describedby`, `role="alert"`), focus jumps to the first invalid input on Save.
- Pulled the rules from the existing `slot-fields` schema (label <=80 chars, choices <=20 entries each <=60 chars). Pure `validate()` extracted to its own file and covered by 20 unit tests.

## Out of scope (follow-ups)

1. **`effectiveRequired` demotion** at `useGridState.ts:272` silently flips `required: true` to `false` when a signup already has slots, suppressing the server 409 the user actually wanted feedback on. Remove the demotion and pipe server errors into the dialog in a single follow-up.
2. **Client/server label-length mismatch.** `LabelSchema` allows up to 80 chars (mirrored here), but the derived `ref` is sliced to 48 chars and `RefSchema` caps at 40 — so a ~50-char label passes client validation and 409s on ref length. Pre-existing; surfaces once the demotion is removed and server errors render inline.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — clean (284 tests, +20 new for `validate()`)
- [x] Top-hatted in dev:
  - Empty Name → Save → "Name is required.", focus → Name, dialog stays open
  - Type=List, empty Choices → Save → single error renders as `<p role="alert">` (matches name-error markup)
  - Type=List, 21 lines incl. one 61-char → Save → `<ul role="alert">` with two `<li>` items: "Choice 3 must be 60 characters or fewer." and "At most 20 choices allowed."
- [x] Reviewer: try the verification steps above in a fresh dev session

🤖 Generated with [Claude Code](https://claude.com/claude-code)