### PR TITLE
refactor(build-grid): render live preview through the public signup view

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/build/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/build/page.tsx
@@ -4,7 +4,7 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { recordOrganizerView } from '@/lib/view-tracker';
 import { BuildGrid } from '@/components/build-grid';
-import { SignupSettingsSchema } from '@/schemas/signups';
+import { SignupSettingsSchema, type SignupStatus } from '@/schemas/signups';
 
 type PageParams = { params: Promise<{ id: string }> };
 
@@ -26,6 +26,12 @@ export default async function BuildTab({ params }: PageParams) {
   return (
     <BuildGrid
       signupId={id}
+      signupMeta={{
+        title: sig.title,
+        description: sig.description,
+        status: sig.status as SignupStatus,
+        slug: sig.slug,
+      }}
       initialFields={sig.fields}
       initialSlots={sig.slots.map((s) => ({
         id: s.id,

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -68,6 +68,9 @@ interface SignupViewProps {
   slug: string;
   mode: 'live' | 'preview';
   ownCommitments?: OwnCommitment[];
+  /** Show the preview/closed status banner. Default true; set false when the
+   *  surrounding context already conveys preview state (e.g. the build rail). */
+  showStateBanner?: boolean;
 }
 
 interface SlotGroup {
@@ -108,7 +111,7 @@ function titleFor(
   primary: SignupViewField | null,
 ): string {
   const value = primary ? renderFieldValue(primary, slot.values[primary.ref]) : null;
-  return value || slot.ref;
+  return value || 'Untitled slot';
 }
 
 export function SignupViewBody({
@@ -119,6 +122,7 @@ export function SignupViewBody({
   slug,
   mode,
   ownCommitments,
+  showStateBanner = true,
 }: SignupViewProps) {
   const isPreview = mode === 'preview';
   const effectiveStatus =
@@ -146,7 +150,7 @@ export function SignupViewBody({
 
   return (
     <>
-      {isPreview ? (
+      {!showStateBanner ? null : isPreview ? (
         <Banner kind="preview" title="Preview" body={previewCopy} />
       ) : effectiveStatus === 'closed' ? (
         <Banner

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -111,7 +111,7 @@ function titleFor(
   return value || slot.ref;
 }
 
-export default function SignupView({
+export function SignupViewBody({
   signup,
   fields,
   groupByRef,
@@ -145,7 +145,7 @@ export default function SignupView({
           : 'This signup is live. The page below shows what visitors see.';
 
   return (
-    <div className="container-tight flex flex-col gap-7">
+    <>
       {isPreview ? (
         <Banner kind="preview" title="Preview" body={previewCopy} />
       ) : effectiveStatus === 'closed' ? (
@@ -261,7 +261,14 @@ export default function SignupView({
           </section>
         ))}
       </div>
+    </>
+  );
+}
 
+export default function SignupView(props: SignupViewProps) {
+  return (
+    <div className="container-tight flex flex-col gap-7">
+      <SignupViewBody {...props} />
       <footer className="text-ink-soft pt-4 text-center text-xs">
         Ad-free · Run by OpenSignup · <Link className="underline" href="/">About</Link>
       </footer>

--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -86,7 +86,7 @@ export function BuildGrid({ signupId, signupMeta, initialFields, initialSlots, i
   return (
     <>
       <div
-        className={`grid gap-5 items-start ${state.showPreview ? 'grid-cols-[minmax(720px,1fr)_minmax(380px,440px)]' : 'grid-cols-[1fr]'}`}
+        className={`grid gap-5 items-start ${state.showPreview ? 'grid-cols-[minmax(720px,1fr)_minmax(320px,360px)]' : 'grid-cols-[1fr]'}`}
       >
         {/* Build Grid panel */}
         <div className="border border-surface-sunk rounded-2xl bg-white overflow-hidden min-w-0">

--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -12,10 +12,19 @@ import { GridBody } from './GridBody';
 import { SideRail } from './SideRail';
 import { FieldEditor } from './FieldEditor';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
-import type { SignupSettings } from '@/schemas/signups';
+import type { SignupSettings, SignupStatus } from '@/schemas/signups';
+
+/** Server-loaded signup chrome snapshot; not updated live during editing. */
+export type SignupMeta = {
+  title: string;
+  description: string | null;
+  status: SignupStatus;
+  slug: string;
+};
 
 type BuildGridProps = {
   signupId: string;
+  signupMeta: SignupMeta;
   initialFields: SlotFieldDefinition[];
   initialSlots: Array<{
     id: string;
@@ -42,7 +51,7 @@ function AddRowAffordance({ onAdd }: { onAdd: () => void }) {
   );
 }
 
-export function BuildGrid({ signupId, initialFields, initialSlots, initialSettings }: BuildGridProps) {
+export function BuildGrid({ signupId, signupMeta, initialFields, initialSlots, initialSettings }: BuildGridProps) {
   const {
     state,
     addField,
@@ -77,7 +86,7 @@ export function BuildGrid({ signupId, initialFields, initialSlots, initialSettin
   return (
     <>
       <div
-        className={`grid gap-5 items-start ${state.showPreview ? 'grid-cols-[1fr_320px]' : 'grid-cols-[1fr]'}`}
+        className={`grid gap-5 items-start ${state.showPreview ? 'grid-cols-[minmax(720px,1fr)_minmax(380px,440px)]' : 'grid-cols-[1fr]'}`}
       >
         {/* Build Grid panel */}
         <div className="border border-surface-sunk rounded-2xl bg-white overflow-hidden min-w-0">
@@ -119,10 +128,10 @@ export function BuildGrid({ signupId, initialFields, initialSlots, initialSettin
         {/* Side Rail */}
         {state.showPreview && (
           <SideRail
+            signupMeta={signupMeta}
             fields={state.fields}
             rows={state.rows}
-            previewRowIdx={state.previewRowIdx}
-            onSelectRow={(idx) => setPreviewRow(idx)}
+            groupByFieldRef={state.groupByFieldRef}
           />
         )}
       </div>

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -44,19 +44,24 @@ export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRail
         <Eye size={12} className="text-brand" />
         LIVE PREVIEW
       </span>
-      <div className="flex flex-col gap-7 rounded-2xl border border-surface-sunk bg-surface-raised p-5">
-        <SignupViewBody
-          signup={{
-            title: signupMeta.title,
-            description: signupMeta.description,
-            status: signupMeta.status,
-          }}
-          fields={fields.map(toViewField)}
-          groupByRef={groupByFieldRef}
-          slots={rows.map(toViewSlot)}
-          slug={signupMeta.slug}
-          mode="preview"
-        />
+      <div className="rounded-[22px] bg-[#0b1220] p-2 shadow-[0_8px_32px_rgb(11_18_32/0.12)]">
+        <div className="overflow-hidden rounded-[16px] bg-white p-4">
+          <div className="flex flex-col gap-7 origin-top-left" style={{ zoom: 0.7 }}>
+            <SignupViewBody
+              signup={{
+                title: signupMeta.title,
+                description: signupMeta.description,
+                status: signupMeta.status,
+              }}
+              fields={fields.map(toViewField)}
+              groupByRef={groupByFieldRef}
+              slots={rows.map(toViewSlot)}
+              slug={signupMeta.slug}
+              mode="preview"
+              showStateBanner={false}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -45,7 +45,7 @@ export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRail
         LIVE PREVIEW
       </span>
       <div className="rounded-[28px] bg-[#0b1220] p-2 shadow-[0_8px_32px_rgb(11_18_32/0.12)]">
-        <div className="flex h-[640px] flex-col overflow-hidden rounded-[22px] bg-surface">
+        <div className="flex h-[560px] flex-col overflow-hidden rounded-[22px] bg-surface">
           <div className="flex h-7 flex-shrink-0 items-center justify-between bg-white px-4 text-[10px] font-semibold text-ink">
             <span>9:41</span>
             <span>••• Wi-Fi 100%</span>

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -51,7 +51,10 @@ export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRail
             <span>••• Wi-Fi 100%</span>
           </div>
           <div className="flex-1 overflow-y-auto p-4">
-            <div className="flex flex-col gap-7 origin-top-left" style={{ zoom: 0.7 }}>
+            <div
+              className="flex flex-col gap-7 origin-top-left"
+              style={{ transform: 'scale(0.7)', width: 'calc(100% / 0.7)' }}
+            >
               <SignupViewBody
                 signup={{
                   title: signupMeta.title,

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -1,99 +1,62 @@
 'use client';
 
 import { Eye } from 'lucide-react';
-import { summarizeSlot } from '@/lib/slot-summary';
+import { SignupViewBody } from '@/app/s/[slug]/signup-view';
+import type {
+  SignupViewField,
+  SignupViewSlot,
+} from '@/app/s/[slug]/signup-view-types';
+import type { SignupMeta } from './BuildGrid';
 import type { GridField, GridRow } from './useGridState';
 
 type SideRailProps = {
+  signupMeta: SignupMeta;
   fields: GridField[];
   rows: GridRow[];
-  previewRowIdx: number;
-  onSelectRow: (idx: number) => void;
+  groupByFieldRef: string | null;
 };
 
-export function SideRail({ fields, rows, previewRowIdx, onSelectRow }: SideRailProps) {
-  // summarizeSlot expects SlotFieldDefinition[] which has `label` not `name`
-  const fieldDefs = fields.map((f) => ({
-    id: f.id,
-    ref: f.ref,
-    label: f.name,
-    fieldType: f.type,
-    required: f.required,
-    sortOrder: f.sortOrder,
-    config: f.config,
-  }));
+// Adapter: build-grid edit state → public-page render types.
+// Synthetic fields (always-open status, zero commitments) are safe because
+// SignupViewBody's slot-row branching only treats slots as closed when the
+// signup itself is closed/archived. Title/description/status come from the
+// initial server load and don't update live during editing.
+function toViewField(f: GridField): SignupViewField {
+  return { ref: f.ref, label: f.name, fieldType: f.type };
+}
 
+function toViewSlot(r: GridRow): SignupViewSlot {
+  return {
+    id: r.id,
+    ref: r.id,
+    values: r.values,
+    slotAt: null,
+    capacity: r.capacity,
+    status: 'open',
+    committed: 0,
+  };
+}
+
+export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRailProps) {
   return (
     <div className="sticky top-5 flex flex-col gap-2.5">
-      {/* Caption row */}
-      <div className="flex items-center justify-between">
-        <span className="flex items-center gap-1.5 text-xs font-semibold text-brand tracking-wide">
-          <Eye size={12} className="text-brand" />
-          LIVE PREVIEW
-        </span>
-        <span className="text-xs text-ink-soft">
-          Row {previewRowIdx + 1} of {rows.length}
-        </span>
-      </div>
-
-      {/* Phone frame */}
-      <div className="bg-[#0b1220] rounded-[28px] p-2 shadow-[0_8px_32px_rgb(11_18_32/0.12)]">
-        {/* Screen */}
-        <div className="bg-surface-raised rounded-[22px] overflow-hidden h-[540px] flex flex-col">
-          {/* Status bar */}
-          <div className="h-7 bg-white flex items-center justify-between px-4 text-[10px] font-semibold text-ink flex-shrink-0">
-            <span>9:41</span>
-            <span>••• Wi-Fi 100%</span>
-          </div>
-
-          {/* Page content */}
-          <div className="flex-1 overflow-y-auto p-3.5 flex flex-col gap-2">
-            {/* Title */}
-            <div className="text-sm font-bold tracking-tight text-ink leading-snug">
-              Sign-up Preview
-            </div>
-
-            {/* Divider */}
-            <div className="h-px bg-surface-sunk my-1" />
-
-            {/* Slot cards */}
-            {rows.map((row, i) => {
-              const summary = summarizeSlot(fieldDefs, row.values as Record<string, unknown>);
-              const isActive = i === previewRowIdx;
-              return (
-                <button
-                  key={row.id}
-                  onClick={() => onSelectRow(i)}
-                  className={[
-                    'border rounded-[10px] p-2 w-full text-left font-[inherit] flex items-center justify-between gap-2 transition-all duration-100 cursor-pointer',
-                    isActive
-                      ? 'bg-white border-brand shadow-[0_0_0_2px_#dbe7ff]'
-                      : 'bg-transparent border-surface-sunk',
-                  ].join(' ')}
-                >
-                  <div className="min-w-0 flex-1">
-                    <div className="text-[12px] font-medium text-ink truncate">
-                      {summary || 'Untitled slot'}
-                    </div>
-                    <div className="text-[10px] text-ink-soft mt-0.5">
-                      0{row.capacity != null ? `/${row.capacity}` : ''} signed up
-                    </div>
-                  </div>
-                  <div
-                    className={[
-                      'text-[10px] font-medium px-2.5 py-0.5 rounded-full border flex-shrink-0',
-                      isActive
-                        ? 'bg-brand text-white border-brand'
-                        : 'bg-white text-ink border-surface-sunk',
-                    ].join(' ')}
-                  >
-                    Sign up
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </div>
+      <span className="flex items-center gap-1.5 text-xs font-semibold text-brand tracking-wide">
+        <Eye size={12} className="text-brand" />
+        LIVE PREVIEW
+      </span>
+      <div className="flex flex-col gap-7 rounded-2xl border border-surface-sunk bg-surface-raised p-5">
+        <SignupViewBody
+          signup={{
+            title: signupMeta.title,
+            description: signupMeta.description,
+            status: signupMeta.status,
+          }}
+          fields={fields.map(toViewField)}
+          groupByRef={groupByFieldRef}
+          slots={rows.map(toViewSlot)}
+          slug={signupMeta.slug}
+          mode="preview"
+        />
       </div>
     </div>
   );

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -44,8 +44,8 @@ export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRail
         <Eye size={12} className="text-brand" />
         LIVE PREVIEW
       </span>
-      <div className="rounded-[22px] bg-[#0b1220] p-2 shadow-[0_8px_32px_rgb(11_18_32/0.12)]">
-        <div className="overflow-hidden rounded-[16px] bg-white p-4">
+      <div className="rounded-[40px] bg-[#0b1220] p-2.5 shadow-[0_20px_50px_-12px_rgb(11_18_32/0.25)]">
+        <div className="overflow-hidden rounded-[32px] bg-surface p-5">
           <div className="flex flex-col gap-7 origin-top-left" style={{ zoom: 0.7 }}>
             <SignupViewBody
               signup={{

--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -44,22 +44,28 @@ export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRail
         <Eye size={12} className="text-brand" />
         LIVE PREVIEW
       </span>
-      <div className="rounded-[40px] bg-[#0b1220] p-2.5 shadow-[0_20px_50px_-12px_rgb(11_18_32/0.25)]">
-        <div className="overflow-hidden rounded-[32px] bg-surface p-5">
-          <div className="flex flex-col gap-7 origin-top-left" style={{ zoom: 0.7 }}>
-            <SignupViewBody
-              signup={{
-                title: signupMeta.title,
-                description: signupMeta.description,
-                status: signupMeta.status,
-              }}
-              fields={fields.map(toViewField)}
-              groupByRef={groupByFieldRef}
-              slots={rows.map(toViewSlot)}
-              slug={signupMeta.slug}
-              mode="preview"
-              showStateBanner={false}
-            />
+      <div className="rounded-[28px] bg-[#0b1220] p-2 shadow-[0_8px_32px_rgb(11_18_32/0.12)]">
+        <div className="flex h-[640px] flex-col overflow-hidden rounded-[22px] bg-surface">
+          <div className="flex h-7 flex-shrink-0 items-center justify-between bg-white px-4 text-[10px] font-semibold text-ink">
+            <span>9:41</span>
+            <span>••• Wi-Fi 100%</span>
+          </div>
+          <div className="flex-1 overflow-y-auto p-4">
+            <div className="flex flex-col gap-7 origin-top-left" style={{ zoom: 0.7 }}>
+              <SignupViewBody
+                signup={{
+                  title: signupMeta.title,
+                  description: signupMeta.description,
+                  status: signupMeta.status,
+                }}
+                fields={fields.map(toViewField)}
+                groupByRef={groupByFieldRef}
+                slots={rows.map(toViewSlot)}
+                slug={signupMeta.slug}
+                mode="preview"
+                showStateBanner={false}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Extract `SignupViewBody` from `signup-view.tsx` so the build-page side rail, the `/app/signups/[id]/preview` route, and the public `/s/[slug]` page all share one renderer. The drift between rail and public page (introduced when PR #77 redesigned the slot list) is resolved at the source — there is now no separate rendering path for the rail's slot list.
- Thread a `signupMeta` snapshot (`title`, `description`, `status`, `slug`) from the server through `BuildGrid` to `SideRail`; fields/slots/group-by stay live from `useGridState`.
- Keep the phone-mockup chrome (rounded bezel, `9:41 / Wi-Fi 100%` status bar, fixed device height with internal scroll) but render `SignupViewBody` inside it at `zoom: 0.7` so the embedded view sits at device-preview proportions.
- Suppress the in-body preview banner via a new `showStateBanner` prop (default true on existing call sites) so it doesn't duplicate the rail's own `LIVE PREVIEW` caption.
- Improve the empty-primary-field fallback: slots without a primary value now render as `Untitled slot` instead of the synthetic `slot_…` ref.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test` (284 tests passing)
- [x] Build page `/app/signups/[id]/build` — toggle Live preview, confirm slot title is the bare primary field (no `Label:` prefix), dates render as `Mon, Jan 1`, real `0/N` counts, phone bezel + status bar visible
- [x] Canonical preview route `/app/signups/[id]/preview` — visually identical body
- [x] Public page `/s/[slug]` — unchanged for published signups
- [x] Group by a field — rail shows section headers live (`WED, MAY 6`, etc.)
- [x] Edit a slot value in the grid — preview updates immediately
- [x] Empty primary-field slot — renders `Untitled slot`, not `slot_xxx`
- [x] Draft signup — `Sign up` buttons disabled with `publish to enable signups` title

🤖 Generated with [Claude Code](https://claude.com/claude-code)