### PR TITLE
chore(activity): scrub email/title from payload, refresh organizers.last_active_at

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -33,7 +33,7 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 
 | event | actor | payload | fired from |
 |---|---|---|---|
-| `signup.created` | organizer | `{ title, templateId, fieldsAdded, slotsAdded }` | `services/signups.ts` |
+| `signup.created` | organizer | `{ templateId, fieldsAdded, slotsAdded }` | `services/signups.ts` |
 | `signup.updated` | organizer | `{ changes }` | `services/signups.ts` |
 | `signup.published` | organizer | `{}` | `services/signups.ts` |
 | `signup.closed` | organizer | `{}` | `services/signups.ts` |
@@ -77,7 +77,7 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 
 | event | actor | payload | fired from |
 |---|---|---|---|
-| `auth.magic_link_sent` | system | `{ email, expiresInMinutes }` | `auth/config.ts` (`sendVerificationRequest`) |
+| `auth.magic_link_sent` | system | `{ emailDomain, expiresInMinutes }` | `auth/config.ts` (`sendVerificationRequest`) |
 | `auth.signed_in` | organizer | `{ isNewUser }` | `auth/config.ts` (`events.signIn`) |
 | `workspace.created` | organizer | `{ kind: 'personal' }` | `auth/adapter.ts` (first-login tx) |
 
@@ -100,9 +100,16 @@ deliberately minimal:
 - `DNT: 1` and `Sec-GPC: 1` short-circuit the insert before any DB write.
 - Bots are skipped via a User-Agent regex.
 
-`auth.magic_link_sent` deliberately keeps the email address in the payload
-(it's necessary to compute consumption rate by linking with `auth.signed_in`).
-Treat the activity table as PII-bearing for retention purposes.
+`auth.magic_link_sent` records only the email **domain**, not the local-part.
+Aggregate anti-abuse questions ("what fraction of magic-link sends go to
+gmail.com / corporate domains / fresh free-mail providers?") work on the
+domain alone, and consumption rate is computed by counting
+`auth.magic_link_sent` vs `auth.signed_in` events — neither requires the
+recipient's full address.
+
+The remaining PII reachable from activity is the foreign-key path to
+`organizers` via `actor_id` when `actor_type = 'organizer'`. Deny `SELECT`
+on `organizers` separately if exposing this table to an analytics role.
 
 ## Workspace scoping
 
@@ -230,6 +237,25 @@ documented here.
 
 The TypeScript compiler will enforce that every `recordActivity` call site
 uses a known event type.
+
+### Organizer activity timestamps
+
+Every `recordActivity` call with `actor_type = 'organizer'` and a non-null
+`actor_id` also bumps `organizers.last_active_at` on the same handle
+(transaction-internal when the caller is inside one). WAU / MAU can therefore
+be answered directly:
+
+```sql
+SELECT count(*) FROM organizers
+WHERE last_active_at >= now() - interval '7 days';
+```
+
+without a `SELECT DISTINCT actor_id` scan of `activity`. The definition of
+"active" is "any organizer-actor activity write" — signup mutations, slot
+edits, `auth.signed_in`, **and** the organizer-side RSC pageview events
+(`signup.editor_opened`, `signup.previewed`, `signup.draft_started`) which
+are written with the organizer as actor. `signup.viewed` is system-actor
+and does not advance `last_active_at`.
 
 ### What's not captured
 

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -12,6 +12,7 @@ import { RateLimits, consumeRateLimit } from '@/lib/rate-limit';
 import { ServiceException } from '@/lib/errors';
 import { SignupAdapter } from './adapter';
 import { canonicalizeMagicLinkUrl } from './magic-link-url';
+import { extractEmailDomain } from './email-domain';
 import { getCurrentRequestIp } from './request-context';
 
 // Built lazily on first request: SignupAdapter() touches getDb() → getEnv(),
@@ -74,7 +75,7 @@ function buildConfig(): NextAuthConfig {
               workspaceId: null,
               actor: { actorId: null, actorType: 'system' },
               eventType: 'auth.magic_link_sent',
-              payload: { email: identifier, expiresInMinutes },
+              payload: { emailDomain: extractEmailDomain(identifier), expiresInMinutes },
             });
           } catch (err) {
             log.warn({ err }, 'recordActivity auth.magic_link_sent failed');

--- a/src/auth/email-domain.test.ts
+++ b/src/auth/email-domain.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { extractEmailDomain } from './email-domain';
+
+describe('extractEmailDomain', () => {
+  it('returns the domain after the @', () => {
+    expect(extractEmailDomain('user@example.com')).toBe('example.com');
+  });
+
+  it('preserves subdomains and case as written', () => {
+    expect(extractEmailDomain('a@Mail.Example.CO.UK')).toBe('Mail.Example.CO.UK');
+  });
+
+  it('returns "unknown" when there is no @', () => {
+    expect(extractEmailDomain('no-at-here')).toBe('unknown');
+  });
+
+  it('returns "unknown" for the empty string', () => {
+    expect(extractEmailDomain('')).toBe('unknown');
+  });
+
+  it('returns "unknown" when the domain part is empty', () => {
+    expect(extractEmailDomain('user@')).toBe('unknown');
+  });
+
+  it('takes the part after the first @ on malformed input with multiple @', () => {
+    expect(extractEmailDomain('a@b@c')).toBe('b');
+  });
+});

--- a/src/auth/email-domain.ts
+++ b/src/auth/email-domain.ts
@@ -1,0 +1,9 @@
+// Returns the substring after the first `@`, or `'unknown'` if absent
+// or empty. Intentionally lenient — the auth layer validates the
+// address upstream. No lowercasing, no IDN handling: aggregate
+// consumers that need case-insensitive grouping should normalize at
+// query time.
+export function extractEmailDomain(email: string): string {
+  const domain = email.split('@')[1];
+  return domain && domain.length > 0 ? domain : 'unknown';
+}

--- a/src/lib/activity.db.test.ts
+++ b/src/lib/activity.db.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb, type Db } from '@/db/client';
+import { organizers } from '@/db/schema/organizers';
+import { workspaces } from '@/db/schema/workspaces';
+import { workspaceMembers } from '@/db/schema/members';
+import { makeId } from '@/lib/ids';
+import { recordActivity } from '@/lib/activity';
+
+interface Fixture {
+  db: Db;
+  workspaceId: string;
+  organizerId: string;
+}
+
+async function setup(): Promise<Fixture> {
+  const db = getDb();
+  const organizerId = makeId('org');
+  const workspaceId = makeId('ws');
+  const memberId = makeId('mem');
+  const slug = `act-${workspaceId.slice(-8).toLowerCase()}`;
+  const email = `${slug}@example.test`;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(organizers).values({ id: organizerId, email, name: 'Activity Test Org' });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      slug,
+      name: 'Activity Test Workspace',
+      type: 'personal',
+      plan: 'free',
+    });
+    await tx.insert(workspaceMembers).values({
+      id: memberId,
+      workspaceId,
+      organizerId,
+      role: 'owner',
+      status: 'active',
+    });
+  });
+
+  return { db, workspaceId, organizerId };
+}
+
+async function teardown(db: Db, workspaceId: string, organizerId: string) {
+  await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+  await db.delete(organizers).where(eq(organizers.id, organizerId));
+}
+
+async function readLastActiveAt(db: Db, organizerId: string): Promise<Date> {
+  const rows = await db
+    .select({ lastActiveAt: organizers.lastActiveAt })
+    .from(organizers)
+    .where(eq(organizers.id, organizerId));
+  if (rows.length !== 1 || !rows[0]) throw new Error('organizer not found');
+  return rows[0].lastActiveAt;
+}
+
+describe('recordActivity → organizers.last_active_at', () => {
+  let fx: Fixture;
+
+  beforeAll(async () => {
+    fx = await setup();
+  });
+
+  afterAll(async () => {
+    await teardown(fx.db, fx.workspaceId, fx.organizerId);
+  });
+
+  it('advances last_active_at when actorType is organizer', async () => {
+    const before = await readLastActiveAt(fx.db, fx.organizerId);
+    // Postgres `now()` is set at statement time and we want a strict `>`,
+    // so wait long enough to clear sub-millisecond rounding.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    await recordActivity(fx.db, {
+      signupId: null,
+      workspaceId: fx.workspaceId,
+      actor: { actorId: fx.organizerId, actorType: 'organizer' },
+      eventType: 'auth.signed_in',
+      payload: {},
+    });
+
+    const after = await readLastActiveAt(fx.db, fx.organizerId);
+    expect(after.getTime()).toBeGreaterThan(before.getTime());
+  });
+
+  it('does not advance last_active_at when actorType is system', async () => {
+    const before = await readLastActiveAt(fx.db, fx.organizerId);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    await recordActivity(fx.db, {
+      signupId: null,
+      workspaceId: null,
+      actor: { actorId: null, actorType: 'system' },
+      eventType: 'auth.magic_link_sent',
+      payload: { emailDomain: 'example.test', expiresInMinutes: 10 },
+    });
+
+    const after = await readLastActiveAt(fx.db, fx.organizerId);
+    expect(after.getTime()).toBe(before.getTime());
+  });
+});

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,5 +1,6 @@
-import { desc, eq } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { activity, type ActivityEvent } from '@/db/schema/activity';
+import { organizers } from '@/db/schema/organizers';
 import type { Db, Queryable } from '@/db/client';
 import { makeId } from './ids';
 
@@ -27,6 +28,13 @@ export async function recordActivity(
     eventType: args.eventType,
     payload: args.payload ?? {},
   });
+
+  if (args.actor.actorType === 'organizer' && args.actor.actorId !== null) {
+    await db
+      .update(organizers)
+      .set({ lastActiveAt: sql`now()` })
+      .where(eq(organizers.id, args.actor.actorId));
+  }
 }
 
 export async function listActivityForSignup(db: Db, signupId: string, limit = 100) {

--- a/src/services/signups.db.test.ts
+++ b/src/services/signups.db.test.ts
@@ -169,6 +169,7 @@ describe('signups service (db)', () => {
       expect(payload.templateId).toBe(DEFAULT_TEMPLATE.id);
       expect(payload.fieldsAdded).toBe(1);
       expect(payload.slotsAdded).toBe(1);
+      expect('title' in payload).toBe(false);
     });
 
     it('applies a custom template when supplied', async () => {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -169,7 +169,6 @@ export async function createSignup(
       actor: { actorId: requireOrganizerId(actor), actorType: 'organizer' },
       eventType: 'signup.created',
       payload: {
-        title: inserted.title,
         templateId: template.id,
         fieldsAdded: template.fields.length,
         slotsAdded: template.slots.length,


### PR DESCRIPTION
## Summary

Closes #85. Three additive, no-migration hygiene changes so the `activity` table is safe to grant `SELECT` on for an aggregate-only read-only DB role:

- **`auth.magic_link_sent`** payload now writes `emailDomain` (via a small pure helper in `src/auth/email-domain.ts`) instead of the raw recipient email. Domain alone suffices for anti-abuse aggregates ("what fraction of magic-link sends went to gmail.com / corporate domains / fresh free-mail providers?").
- **`signup.created`** payload drops the organizer-authored `title`. Canonical value still lives on `signups.title` and can be joined when needed.
- **`recordActivity()`** now bumps `organizers.last_active_at` for `actorType === 'organizer'` writes, on the same `Queryable` (so in-tx callers stay atomic, out-of-tx callers like `workspace.created` execute as a standalone update). `auth.magic_link_sent` uses `actorType: 'system'` and is unaffected. Existing `auth.signed_in` (organizer actor) now also advances `last_active_at`, which is the intended "any organizer-actor activity counts as active" definition.

No schema migration. No historical backfill (out of scope per the issue). A repo-wide grep for `payload.email` / `payload.title` returned no readers other than the two write sites themselves.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 290/290 pass (incl. 6 new `extractEmailDomain` cases)
- [x] `pnpm test:db` — 77/77 pass (incl. 2 new `recordActivity → organizers.last_active_at` cases: positive organizer-actor advance, negative system-actor no-op)
- [x] Top-hat: triggered a magic-link via the live `/api/auth/signin/nodemailer` route → new `activity` row has `payload = {"emailDomain":"verify.example","expiresInMinutes":1440}`, no raw email.
- [x] Top-hat: created a signup against an existing organizer's session via `POST /api/signups` → `signup.created` payload is `{"slotsAdded":1,"templateId":"default","fieldsAdded":1}` (no `title`), and `organizers.last_active_at` advanced from `2026-05-03 00:29:58` to `2026-05-15 22:38:39.143546` — identical to the activity row's `occurred_at`, confirming the two writes share the transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)