### PR TITLE
Auto-enable live preview on mount for large viewports

### DIFF
--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -707,3 +707,39 @@ describe('useGridState moveField', () => {
     expect(result.current.state.fields.map((f) => f.id)).toEqual(['a', 'b']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// useGridState mount-time showPreview default (viewport-aware)
+// ---------------------------------------------------------------------------
+
+function stubMatchMedia(matches: boolean) {
+  const mql = {
+    matches,
+    media: '',
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    addListener: () => {},
+    removeListener: () => {},
+  };
+  vi.stubGlobal('matchMedia', vi.fn(() => mql));
+}
+
+describe('useGridState mount-time showPreview default', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults showPreview to true when viewport is ≥1280px', () => {
+    stubMatchMedia(true);
+    const { result } = renderGrid([]);
+    expect(result.current.state.showPreview).toBe(true);
+  });
+
+  it('leaves showPreview false when viewport is <1280px', () => {
+    stubMatchMedia(false);
+    const { result } = renderGrid([]);
+    expect(result.current.state.showPreview).toBe(false);
+  });
+});

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -226,6 +226,16 @@ export function useGridState(
     };
   }, []);
 
+  // On mount: default the live-preview side rail to ON when the viewport has
+  // room for both panels (≥xl breakpoint). One-shot — does not re-evaluate on
+  // resize, so a manual toggle off is respected until the next mount.
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    if (window.matchMedia('(min-width: 1280px)').matches) {
+      dispatch({ type: 'SET_SHOW_PREVIEW', show: true });
+    }
+  }, []);
+
   // ---------------------------------------------------------------------------
   // Save status helpers
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add viewport-aware initialization of the live-preview side rail in the build grid. When the component mounts on a viewport ≥1280px (xl breakpoint), `showPreview` now defaults to `true`, allowing both the editor and preview panels to display side-by-side on larger screens.

## Changes

- **useGridState.ts**: Added a mount-time `useEffect` that checks viewport width via `matchMedia('(min-width: 1280px)')` and dispatches `SET_SHOW_PREVIEW` if the condition is met. This is a one-shot initialization — resizing does not re-evaluate, so manual toggles are respected until the next mount.
- **useGridState.test.ts**: Added comprehensive test suite with:
  - Helper function `stubMatchMedia()` to mock the global `matchMedia` API
  - Test verifying preview defaults to `true` on ≥1280px viewports
  - Test verifying preview remains `false` on <1280px viewports
  - Proper cleanup via `afterEach` to unstub globals

## Implementation Details

The feature uses the standard `window.matchMedia()` API with a guard for environments where it may not be available. The one-shot behavior (no re-evaluation on resize) is intentional — it respects user preference if they manually toggle the preview off, while still providing a sensible default for first-time users on capable devices.