### PR TITLE
fix(build-grid): hide live-preview overflow instead of scrolling

### DIFF
--- a/src/components/build-grid/SideRail.tsx
+++ b/src/components/build-grid/SideRail.tsx
@@ -50,7 +50,7 @@ export function SideRail({ signupMeta, fields, rows, groupByFieldRef }: SideRail
             <span>9:41</span>
             <span>••• Wi-Fi 100%</span>
           </div>
-          <div className="flex-1 overflow-y-auto p-4">
+          <div className="flex-1 overflow-hidden p-4">
             <div
               className="flex flex-col gap-7 origin-top-left"
               style={{ transform: 'scale(0.7)', width: 'calc(100% / 0.7)' }}


### PR DESCRIPTION
## Summary
- The phone-frame live preview was showing a phantom vertical scrollbar even when its content visually fit
- Root cause: the inner content uses `transform: scale(0.7)`, which scales pixels but not the layout box — so the scrollable parent measured the un-scaled height and triggered overflow
- Fix: swap `overflow-y-auto` for `overflow-hidden` on the phone screen content area. The preview isn't interactive, so clipping at the bezel is fine when content runs long

## Test plan
- [ ] Open a signup in the build view with few slots — phone preview shows no scrollbar
- [ ] Add enough slots to overflow — content gets clipped at the bezel cleanly, no scrollbar
- [ ] `pnpm lint && pnpm typecheck && pnpm test` — passes (292/292)

🤖 Generated with [Claude Code](https://claude.com/claude-code)