### PR TITLE
fix(magic-compose): reframe new-signup hero to invite richer prompts

### DIFF
--- a/src/components/magic-compose/Compose.tsx
+++ b/src/components/magic-compose/Compose.tsx
@@ -39,10 +39,10 @@ export function Compose({
           New signup
         </span>
         <h1 className="text-4xl font-semibold leading-tight tracking-tight md:text-[44px]">
-          What are you coordinating?
+          What are you organizing?
         </h1>
-        <p className="text-ink-muted max-w-[620px] text-base leading-relaxed md:text-lg">
-          A sentence or two is plenty. We&apos;ll draft a title, blurb, and slots for you to edit.
+        <p className="text-ink-muted text-base leading-relaxed md:text-lg">
+          The more detail you share, the better the draft. We&apos;ll turn it into a title, blurb, and slots for you to edit.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
- Heading: "What are you coordinating?" → "What are you organizing?"
- Helper: "A sentence or two is plenty…" was nudging users to under-describe; reframed to invite more detail since the LLM produces better drafts with richer prompts.
- Dropped the `max-w-[620px]` cap on the helper paragraph so it stops wrapping short of the input box below it.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (382 passed)
- [x] Eyeball `/app/signups/new` — paragraph spans the textarea width; copy reads as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)