### PR TITLE
fix(magic-compose): start new-signup textarea empty

### DIFF
--- a/src/components/magic-compose/MagicComposeRoot.tsx
+++ b/src/components/magic-compose/MagicComposeRoot.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { DraftPreview } from '@/app/api/signups/magic-compose/preview';
-import { STARTER_PROMPTS } from '@/lib/magic-compose/templates';
 import { Compose } from './Compose';
 import { Drafting } from './Drafting';
 import { writeAiDraftWarnings } from './ai-draft-warnings';
@@ -43,7 +42,7 @@ const DRAFTING_WATCHDOG_MS = 210_000;
 export function MagicComposeRoot() {
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
-  const [prompt, setPrompt] = useState(STARTER_PROMPTS[0]?.body ?? '');
+  const [prompt, setPrompt] = useState('');
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- The new-signup textarea was prepopulating with the first starter prompt body, so users had to clear it before typing their own context.
- Initialize `prompt` state to `''` so the placeholder shows on first load. Starter cards below still one-click load their example.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (382 passed)
- [x] Eyeball `/app/signups/new` — textarea is empty, placeholder visible, starter cards still populate on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)