### PR TITLE
fix(magic-compose): remove Re-draft button from AI draft banner

### DIFF
--- a/src/components/magic-compose/AiDraftBanner.tsx
+++ b/src/components/magic-compose/AiDraftBanner.tsx
@@ -45,7 +45,6 @@ export function AiDraftBanner({
           fieldsCount === 1 ? 'column' : 'columns'
         } and ${slotsCount} ${slotsCount === 1 ? 'slot' : 'slots'}`}
         body="Edit anything below, then publish when you're ready."
-        action={{ label: 'Re-draft', href: '/app/signups/new' }}
         onDismiss={onDismiss}
       />
       {warnings.length > 0 && (


### PR DESCRIPTION
## Summary
- Drops the `Re-draft` action from the AI draft banner shown on the build tab after a magic-compose draft is created. The banner now only shows the title, body, and the dismiss (X) control.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (382 tests pass)
- [x] Manual: open a freshly drafted signup with `?aiDraft=1` and confirm the banner no longer renders the `Re-draft` button

🤖 Generated with [Claude Code](https://claude.com/claude-code)