### PR TITLE
Refine "Add slot" button styling and copy

### DIFF
--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -41,12 +41,12 @@ function AddRowAffordance({ onAdd }: { onAdd: () => void }) {
     <button
       type="button"
       onClick={onAdd}
-      aria-label="Add another slot"
+      aria-label="Add slot"
       className="w-full bg-surface-raised border-t border-surface-sunk cursor-pointer text-left font-[inherit] hover:bg-surface-sunk/50"
     >
-      <span className="flex items-center gap-1.5 px-3 py-3 text-sm text-ink-soft">
+      <span className="flex items-center gap-1 px-3 py-3 text-sm text-ink-muted font-medium">
         <Plus size={13} />
-        Add another slot
+        Add slot
       </span>
     </button>
   );


### PR DESCRIPTION
## Summary
Updated the "Add slot" button in the BuildGrid component to use clearer, more concise copy and improved visual styling.

## Changes
- Simplified aria-label from "Add another slot" to "Add slot" for clarity
- Updated button text from "Add another slot" to "Add slot"
- Adjusted icon gap from `gap-1.5` to `gap-1` for tighter spacing
- Changed text color from `text-ink-soft` to `text-ink-muted` for better contrast
- Added `font-medium` weight to the button text for improved visual hierarchy

## Details
These changes improve the affordance clarity and visual consistency of the add-row button while maintaining accessibility through the updated aria-label.

https://claude.ai/code/session_018pEYsJ4A4gix4C1EgyXDAS