### PR TITLE
Generalize Magic Compose starter prompt templates

### DIFF
--- a/src/lib/magic-compose/templates.ts
+++ b/src/lib/magic-compose/templates.ts
@@ -10,18 +10,18 @@ export const STARTER_PROMPTS: MagicComposeStarter[] = [
     id: 'sports',
     label: 'Sports team',
     blurb: 'Snack, treat, or carpool rosters across a season of games',
-    body: "Snack duty for our U9 soccer team. We have 6 Saturday games starting April 25 through May 30, against Hawks, Foxes, Bears, Otters, Wolves, and Lions. Two families bring snacks plus drinks per game. No nuts please.",
+    body: "Snack duty for our soccer team. We have 6 Saturday games starting next Saturday. Two families bring snacks plus drinks per game. No nuts please.",
   },
   {
     id: 'classroom',
     label: 'Classroom or school',
     blurb: 'Potlucks, conference signups, supply drives, volunteer days',
-    body: "End-of-year potluck for Mrs. Liu's grade 3 class on Friday May 30 at 5pm. 20 families. We need mains, sides, desserts, and drinks, roughly 5 of each.",
+    body: "End-of-year potluck for our grade 3 class on the last Friday of the month at 5pm. 20 families. We need mains, sides, desserts, and drinks, roughly 5 of each.",
   },
   {
     id: 'community',
     label: 'Community shifts',
     blurb: 'Volunteer shifts, event setup, or rotating roles',
-    body: "Volunteers for the spring book fair. Thursday and Friday May 14 to 15, three 2-hour shifts each day (9 to 11, 11 to 1, 1 to 3). 2 volunteers per shift.",
+    body: "Volunteers for our spring book fair. Thursday and Friday next week, three 2-hour shifts each day (9 to 11, 11 to 1, 1 to 3). 2 volunteers per shift.",
   },
 ];


### PR DESCRIPTION
## Summary

Updated the Magic Compose starter prompt templates to use relative, generic language instead of specific dates and team/class names. This makes the templates more reusable and timeless as examples for users creating their own signups.

## Changes

- **Sports team template**: Removed specific team names (Hawks, Foxes, Bears, Otters, Wolves, Lions), age group (U9), and exact dates (April 25–May 30). Replaced with "next Saturday" and generic "soccer team."
- **Classroom template**: Removed teacher name (Mrs. Liu) and specific date (May 30). Replaced with "our grade 3 class" and "the last Friday of the month."
- **Community template**: Removed specific dates (May 14–15). Replaced with "next week" and added "our" to "spring book fair" for consistency.

## Implementation Details

These templates serve as starting points for users composing new signups. By using relative dates ("next Saturday," "next week," "last Friday of the month") and generic descriptors, the examples remain relevant regardless of when they're viewed and better illustrate the pattern without prescribing specific details.

https://claude.ai/code/session_01C5rar4EvrxaVsjFSsuEQN3