### PR TITLE
feat(home): redesign landing page around organizers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,7 @@ LLM_MODEL=
 # Request timeout in ms (default 180000 = 3 min). Structured outputs on
 # large drafts can take >60s on some providers; bump higher if needed.
 LLM_TIMEOUT_MS=
+
+# Optional homepage demo video. When set, the home page shows a
+# "Watch 30-sec demo" secondary CTA that links here.
+DEMO_URL=

--- a/src/app/_components/HomeExampleCard.tsx
+++ b/src/app/_components/HomeExampleCard.tsx
@@ -1,0 +1,66 @@
+import {
+  SignupViewBody,
+  type SignupViewField,
+  type SignupViewSlot,
+} from '@/app/s/[slug]/signup-view';
+
+const FIELDS: SignupViewField[] = [
+  { ref: 'date', label: 'Date', fieldType: 'date' },
+  { ref: 'team', label: 'Team', fieldType: 'text' },
+];
+
+const ROWS: ReadonlyArray<{ date: string; team: string }> = [
+  { date: '2026-05-17', team: 'Hawks' },
+  { date: '2026-05-24', team: 'Foxes' },
+  { date: '2026-05-31', team: 'Bears' },
+  { date: '2026-06-07', team: 'Otters' },
+  { date: '2026-06-14', team: 'Wolves' },
+  { date: '2026-06-21', team: 'Lions' },
+];
+
+const SLOTS: SignupViewSlot[] = ROWS.map((row, i) => ({
+  id: `example-${i + 1}`,
+  ref: `example-${i + 1}`,
+  values: { date: row.date, team: row.team },
+  slotAt: null,
+  capacity: 2,
+  status: 'open',
+  committed: 0,
+}));
+
+const SIGNUP = {
+  title: 'U9 Soccer Snack Duty',
+  description:
+    'Two families per game to bring snacks and drinks. Please ensure all snacks are nut-free.',
+  status: 'open' as const,
+};
+
+export function HomeExampleCard() {
+  return (
+    <div className="relative">
+      <div className="bg-white rounded-2xl border border-surface-sunk shadow-card overflow-hidden">
+        <div className="text-ink-soft px-6 pt-5 text-xs">
+          <span className="text-ink font-semibold">OpenSignup</span>
+          {' · '}Public signup
+        </div>
+        <div className="flex flex-col gap-7 px-6 pb-6 pt-3">
+          <SignupViewBody
+            signup={SIGNUP}
+            fields={FIELDS}
+            groupByRef={null}
+            slots={SLOTS}
+            slug="example"
+            mode="showcase"
+            showStateBanner={false}
+          />
+        </div>
+        <div className="text-ink-soft border-t border-surface-sunk px-6 py-4 text-center text-xs">
+          Ad-free · Run by OpenSignup
+        </div>
+      </div>
+      <span className="bg-ink text-white absolute -top-3 right-4 rounded-full px-3 py-1.5 text-[11px] font-medium">
+        Example
+      </span>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ export default function LandingPage() {
       <main className="mx-auto grid w-full max-w-[1280px] flex-1 grid-cols-1 items-center gap-10 px-5 pb-12 pt-2 lg:grid-cols-[1.05fr_1fr] lg:gap-16 lg:px-12 lg:pb-16 lg:pt-4">
         <div className="flex flex-col gap-6 lg:gap-7">
           <span className="border-surface-sunk text-ink-muted inline-flex items-center gap-2 self-start rounded-full border px-3 py-1.5 text-xs font-medium">
-            <span className="bg-success h-1.5 w-1.5 rounded-full" />
+            <span aria-hidden="true" className="bg-success h-1.5 w-1.5 rounded-full" />
             Ad-free · No accounts for participants
           </span>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,96 @@
 import Link from 'next/link';
+import { HomeExampleCard } from './_components/HomeExampleCard';
+import { getEnv } from '@/lib/env';
+
+const GITHUB_URL = 'https://github.com/richshaw/OpenSignup';
 
 export default function LandingPage() {
+  const demoUrl = getEnv().DEMO_URL;
+
   return (
-    <main className="container-tight flex min-h-[100svh] flex-col justify-center gap-8 py-16">
-      <div className="space-y-4">
-        <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">OpenSignup</h1>
-        <p className="text-ink-muted text-lg">
-          Ad-free, open-source coordination for school parents, coaches, and community organizers.
-          A calm, modern way to coordinate sign-ups.
-        </p>
-      </div>
-      <div className="flex gap-3">
-        <Link
-          href="/login"
-          className="bg-brand inline-flex items-center rounded-lg px-5 py-3 font-medium text-white transition hover:brightness-110"
-        >
+    <div className="bg-surface text-ink flex min-h-[100svh] flex-col">
+      <header className="flex items-center justify-between px-5 py-5 lg:px-12 lg:py-6">
+        <span className="text-lg font-semibold tracking-tight lg:text-xl">OpenSignup</span>
+        <Link href="/login" className="text-sm font-medium hover:underline">
           Organizer sign in
         </Link>
-        <a
-          href="https://github.com/richshaw/OpenSignup"
-          className="text-ink-muted hover:text-ink inline-flex items-center rounded-lg border border-surface-sunk px-5 py-3 font-medium transition"
-        >
-          View source
+      </header>
+
+      <main className="mx-auto grid w-full max-w-[1280px] flex-1 grid-cols-1 items-center gap-10 px-5 pb-12 pt-2 lg:grid-cols-[1.05fr_1fr] lg:gap-16 lg:px-12 lg:pb-16 lg:pt-4">
+        <div className="flex flex-col gap-6 lg:gap-7">
+          <span className="border-surface-sunk text-ink-muted inline-flex items-center gap-2 self-start rounded-full border px-3 py-1.5 text-xs font-medium">
+            <span className="bg-success h-1.5 w-1.5 rounded-full" />
+            Ad-free · No accounts for participants
+          </span>
+
+          <h1 className="text-4xl font-semibold leading-[1.05] tracking-tight lg:text-[3.5rem]">
+            Sign-up sheets,
+            <br />
+            <span className="text-ink-muted">redone.</span>
+          </h1>
+
+          <p className="text-ink-muted max-w-[520px] text-base leading-normal lg:text-lg">
+            Coordinate snack rotations, potlucks, volunteer shifts, and carpools. Made for school
+            parents, coaches, and community organizers.
+          </p>
+
+          <div className="flex flex-col gap-3 lg:flex-row lg:flex-wrap">
+            <Link
+              href="/app/signups/new"
+              className="bg-brand inline-flex items-center justify-center gap-2 rounded-[14px] px-5 py-3 text-base font-semibold text-white transition hover:brightness-110 lg:text-[15px]"
+            >
+              Start a signup
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M5 12h14M13 5l7 7-7 7" />
+              </svg>
+            </Link>
+            {demoUrl ? (
+              <a
+                href={demoUrl}
+                className="bg-surface border-surface-sunk text-ink hover:bg-surface-raised inline-flex items-center justify-center gap-2 rounded-[14px] border px-5 py-3 text-base font-medium transition lg:text-[15px]"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+                  <polygon points="6 4 20 12 6 20 6 4" fill="currentColor" />
+                </svg>
+                Watch 30-sec demo
+              </a>
+            ) : null}
+          </div>
+
+          <p className="text-ink-soft text-center text-sm lg:text-left">
+            Free · publish in minutes · no credit card.
+          </p>
+        </div>
+
+        <div className="relative flex justify-center lg:justify-start">
+          <div
+            aria-hidden="true"
+            className="bg-surface-raised pointer-events-none absolute -inset-y-8 -left-4 -right-12 hidden rounded-full opacity-70 blur-2xl lg:block"
+          />
+          <div className="relative z-10 w-full max-w-[560px]">
+            <HomeExampleCard />
+          </div>
+        </div>
+      </main>
+
+      <footer className="text-ink-soft flex flex-col items-center justify-between gap-2 px-5 py-5 text-sm lg:flex-row lg:gap-3 lg:px-12">
+        <span>
+          v{process.env.npm_package_version ?? '0.1.0'} · AGPL-3.0 · Built for real community groups.
+        </span>
+        <a href={GITHUB_URL} className="hover:underline">
+          Source on GitHub
         </a>
-      </div>
-      <p className="text-ink-soft pt-8 text-sm">
-        v{process.env.npm_package_version ?? '0.1.0'} · AGPL-3.0 · Built for real community groups.
-      </p>
-    </main>
+      </footer>
+    </div>
   );
 }

--- a/src/app/s/[slug]/signup-view.test.tsx
+++ b/src/app/s/[slug]/signup-view.test.tsx
@@ -45,7 +45,7 @@ describe('<SignupViewBody mode="showcase" />', () => {
     expect(labels).toHaveLength(1);
     const pill = labels[0]!;
     expect(pill.tagName).toBe('SPAN');
-    expect(pill).toHaveAttribute('aria-hidden', 'true');
+    expect(pill).not.toHaveAttribute('aria-hidden');
     expect(pill).toHaveClass('bg-brand');
     expect(pill).not.toHaveClass('opacity-60');
     expect(pill).not.toHaveClass('cursor-not-allowed');

--- a/src/app/s/[slug]/signup-view.test.tsx
+++ b/src/app/s/[slug]/signup-view.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  SignupViewBody,
+  type SignupViewField,
+  type SignupViewSlot,
+} from './signup-view';
+
+const FIELDS: SignupViewField[] = [
+  { ref: 'date', label: 'Date', fieldType: 'date' },
+  { ref: 'team', label: 'Team', fieldType: 'text' },
+];
+
+const SLOTS: SignupViewSlot[] = [
+  {
+    id: 's1',
+    ref: 's1',
+    values: { date: '2026-05-17', team: 'Hawks' },
+    slotAt: null,
+    capacity: 2,
+    status: 'open',
+    committed: 0,
+  },
+];
+
+const SIGNUP = { title: 'Snack duty', description: null, status: 'open' as const };
+
+describe('<SignupViewBody mode="showcase" />', () => {
+  it('renders the row action as an inert span styled like the active button', () => {
+    render(
+      <SignupViewBody
+        signup={SIGNUP}
+        fields={FIELDS}
+        groupByRef={null}
+        slots={SLOTS}
+        slug="example"
+        mode="showcase"
+      />,
+    );
+
+    const labels = screen.getAllByText('Sign up');
+    expect(labels).toHaveLength(1);
+    const pill = labels[0]!;
+    expect(pill.tagName).toBe('SPAN');
+    expect(pill).toHaveAttribute('aria-hidden', 'true');
+    expect(pill).toHaveClass('bg-brand');
+    expect(pill).not.toHaveClass('opacity-60');
+    expect(pill).not.toHaveClass('cursor-not-allowed');
+  });
+
+  it('does not render the preview banner in showcase mode', () => {
+    render(
+      <SignupViewBody
+        signup={SIGNUP}
+        fields={FIELDS}
+        groupByRef={null}
+        slots={SLOTS}
+        slug="example"
+        mode="showcase"
+      />,
+    );
+    expect(screen.queryByText('Preview')).toBeNull();
+    expect(
+      screen.queryByText(/This signup is live\. The page below shows what visitors see\./),
+    ).toBeNull();
+  });
+
+  it('preview mode still renders a disabled Sign-up button (regression guard)', () => {
+    render(
+      <SignupViewBody
+        signup={{ ...SIGNUP, status: 'draft' }}
+        fields={FIELDS}
+        groupByRef={null}
+        slots={SLOTS}
+        slug="example"
+        mode="preview"
+        showStateBanner={false}
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'Sign up' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass('opacity-60');
+  });
+});

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -256,10 +256,7 @@ export function SignupViewBody({
                             Sign up
                           </button>
                         ) : mode === 'showcase' ? (
-                          <span
-                            aria-hidden="true"
-                            className="bg-brand rounded-lg px-4 py-1.5 text-sm font-medium text-white"
-                          >
+                          <span className="bg-brand rounded-lg px-4 py-1.5 text-sm font-medium text-white">
                             Sign up
                           </span>
                         ) : (

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -66,7 +66,15 @@ interface SignupViewProps {
   groupByRef: string | null;
   slots: SignupViewSlot[];
   slug: string;
-  mode: 'live' | 'preview';
+  /**
+   * - 'live': real signup, real CommitDialog.
+   * - 'preview': organizer-only preview (Build tab); Sign-up button is
+   *   disabled and the preview banner explains why.
+   * - 'showcase': marketing/example use (homepage); Sign-up button is rendered
+   *   as an inert solid-blue span so the card matches a published signup
+   *   visually. The wrapping context must convey that it's not real.
+   */
+  mode: 'live' | 'preview' | 'showcase';
   ownCommitments?: OwnCommitment[];
   /** Show the preview/closed status banner. Default true; set false when the
    *  surrounding context already conveys preview state (e.g. the build rail). */
@@ -247,6 +255,13 @@ export function SignupViewBody({
                           >
                             Sign up
                           </button>
+                        ) : mode === 'showcase' ? (
+                          <span
+                            aria-hidden="true"
+                            className="bg-brand rounded-lg px-4 py-1.5 text-sm font-medium text-white"
+                          >
+                            Sign up
+                          </span>
                         ) : (
                           <CommitDialog
                             slotId={slot.id}

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -73,6 +73,20 @@ describe('parseEnv', () => {
     expect(env.LLM_MODEL).toBe('gpt-4o-mini');
     expect(env.LLM_API_KEY).toBeUndefined();
   });
+
+  it('accepts an empty DEMO_URL (treats blank .env line as unset)', () => {
+    const env = parseEnv({ ...base, DEMO_URL: '' });
+    expect(env.DEMO_URL).toBeUndefined();
+  });
+
+  it('accepts a valid DEMO_URL', () => {
+    const env = parseEnv({ ...base, DEMO_URL: 'https://example.com/demo' });
+    expect(env.DEMO_URL).toBe('https://example.com/demo');
+  });
+
+  it('rejects an invalid DEMO_URL', () => {
+    expect(() => parseEnv({ ...base, DEMO_URL: 'not-a-url' })).toThrow(/DEMO_URL/);
+  });
 });
 
 describe('magicComposeEnabled', () => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -28,6 +28,7 @@ const baseSchema = z.object({
   LLM_API_KEY: z.string().optional(),
   LLM_MODEL: z.string().optional(),
   LLM_TIMEOUT_MS: z.coerce.number().int().positive().max(600_000).default(180_000),
+  DEMO_URL: z.string().url().optional(),
 });
 
 const conditional = baseSchema.superRefine((env, ctx) => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -28,7 +28,10 @@ const baseSchema = z.object({
   LLM_API_KEY: z.string().optional(),
   LLM_MODEL: z.string().optional(),
   LLM_TIMEOUT_MS: z.coerce.number().int().positive().max(600_000).default(180_000),
-  DEMO_URL: z.string().url().optional(),
+  DEMO_URL: z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z.string().url().optional(),
+  ),
 });
 
 const conditional = baseSchema.superRefine((env, ctx) => {


### PR DESCRIPTION
## Summary

- Replaces the placeholder home page with a single-screen layout aimed at organizers (not developers). Primary CTA is now **Start a signup**; "View source" is removed; a quiet **Source on GitHub** link survives in the footer for self-hosters.
- The hero composes the real `SignupViewBody` (same component the public `/s/[slug]` page uses) with a hard-coded snack-duty snapshot — same pattern as the Build-tab live preview. So the marketing example tracks the real product visually, no drift.
- To make that reuse work, `SignupViewBody` gains a third `mode: 'showcase'` that renders the Sign-up action as an inert active-blue `<span>` (the existing `'preview'` mode renders a faded disabled button — right for the Build tab, wrong for marketing). Three new unit tests cover the new branch + a regression guard on the preview branch.
- New optional env var `DEMO_URL` (server-only — no `NEXT_PUBLIC_` prefix). When set, renders a "Watch 30-sec demo" secondary CTA. Left empty for v0.1.0; the design's `showDemo={false}` future-state artboard is what flips on once a video exists.
- Marketing copy, GitHub URL, and the example-card snapshot are hardcoded — "no vendor lock-in" in `CLAUDE.md` is about services (email, telemetry), not branding.

## Knock-on

`/s/[slug]` footer's "About" link still points to `/`. It used to land on a placeholder; now it lands on the new marketing page — net improvement, intentional, no code change needed.

## Out of scope

- The demo video itself.
- Marketing pages behind the removed links (Examples, Self-host, About).
- A Playwright a11y sweep on `/` — `tests/e2e/` doesn't exist yet in this repo, so this would be new test infrastructure. Worth a follow-up.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 390/390 (3 new in `signup-view.test.tsx`)
- [x] Visual check at 1280px in `pnpm dev` — layout matches design intent (status pill, two-tone H1, hero column + example card with active blue Sign-up pills, footer)
- [x] Visual check at ≤768px (mobile stacking) — relies on standard Tailwind `lg:` responsive utilities used widely elsewhere in this codebase
- [ ] Set `DEMO_URL=...` in `.env.local`, restart dev, confirm "Watch 30-sec demo" appears
- [x] Visit a real published `/s/[slug]` and visually diff the slot rows against the example card — typography and Sign-up pill should match