### PR TITLE
docs(claude): document Magic Compose surface in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ pnpm db:migrate         # apply migrations via tsx src/db/migrate.ts
 pnpm db:push            # drizzle-kit push (dev-only; bypass migrations)
 pnpm db:studio
 pnpm email:dev          # react-email preview server on :3001
+pnpm eval:magic-compose # offline eval of Magic Compose drafts (needs LLM_* env)
 ```
 
 Run a single vitest file: `pnpm test src/lib/policy.test.ts`. Run a single test name: `pnpm test -t 'rejects over-capacity'`.
@@ -79,6 +80,16 @@ Helpers used by every service:
 
 pg-boss runs against the same Postgres (schema `pgboss`). The Next.js server **does not** run the worker — `pnpm worker` (`src/jobs/worker.ts`) is a separate process. Two queues: `reminderDispatch` (cron every 10 min, scans the 48h window) and `reminderSend` (per-commitment send with retries). On commit, schedule with `singletonKey: commitmentId` so swap/edit replaces the prior job.
 
+### Magic Compose (AI-drafted signups)
+
+Optional feature: organizers paste a description and get a draft signup. Provider-agnostic — any OpenAI-compatible Chat Completions endpoint works (OpenRouter, OpenAI, Ollama). Disabled when `LLM_BASE_URL` is unset, so the "no vendor lock-in" rule still holds.
+
+- `src/lib/magic-compose/llm-client.ts` — single fetch-based client; uses JSON Schema strict mode for structured outputs.
+- `src/app/api/signups/magic-compose/route.ts` — POST endpoint; returns a `preview` shape, never persists. Failure modes (`llm_failed`, `unexpected_refusal`) surface to the UI state machine.
+- `src/components/magic-compose/` — client UI; state machine drives loading/error/preview states.
+- Env: `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`, `LLM_TIMEOUT_MS` (default 180000 — structured outputs on large drafts can exceed 60s).
+- Offline eval harness: `pnpm eval:magic-compose` (see `scripts/eval-magic-compose.ts`).
+
 ### Routes
 
 - Organizer UI: `src/app/app/...` (requires session).
@@ -109,7 +120,7 @@ From `CONTRIBUTING.md` and the v1 plan:
 
 - `src/**/*.test.ts(x)` — unit, run by `pnpm test`.
 - `src/**/*.db.test.ts` — integration against real Postgres, run by `pnpm test:db` (sequential; needs `docker compose up -d` and migrations applied).
-- Playwright specs — `pnpm test:e2e`, includes axe-core a11y on `/s/[slug]`.
+- `tests/e2e/**` — Playwright (`testDir` in `playwright.config.ts`), run by `pnpm test:e2e`. Includes axe-core a11y checks on `/s/[slug]`.
 
 ## Recurring mistakes to avoid
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ pg-boss runs against the same Postgres (schema `pgboss`). The Next.js server **d
 
 Optional feature: organizers paste a description and get a draft signup. Provider-agnostic — any OpenAI-compatible Chat Completions endpoint works (OpenRouter, OpenAI, Ollama). Disabled when `LLM_BASE_URL` is unset, so the "no vendor lock-in" rule still holds.
 
-- `src/lib/magic-compose/llm-client.ts` — single fetch-based client; uses JSON Schema strict mode for structured outputs.
-- `src/app/api/signups/magic-compose/route.ts` — POST endpoint; returns a `preview` shape, never persists. Failure modes (`llm_failed`, `unexpected_refusal`) surface to the UI state machine.
+- `src/lib/magic-compose/llm-client.ts` — single fetch-based client. Sends `response_format: { type: 'json_object' }` (not strict `json_schema`); server-side Zod validation in `prompt.ts` is the source of truth for shape. Surfaces a closed set of error codes (`not_configured | rate_limited | upstream | invalid_json | schema_mismatch | timeout | aborted`).
+- `src/app/api/signups/magic-compose/route.ts` — POST endpoint; rate-limited per organizer, calls the LLM, then **persists** via `createSignup` and returns `{ id, slug, summary, warnings, draft }` plus build/self/public links. Errors are mapped through `mapMagicComposeError` (`./errors.ts`); structured refusals from the model surface as `invalid_input` with `details.reason: 'refusal'`.
 - `src/components/magic-compose/` — client UI; state machine drives loading/error/preview states.
 - Env: `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`, `LLM_TIMEOUT_MS` (default 180000 — structured outputs on large drafts can exceed 60s).
 - Offline eval harness: `pnpm eval:magic-compose` (see `scripts/eval-magic-compose.ts`).
@@ -120,7 +120,7 @@ From `CONTRIBUTING.md` and the v1 plan:
 
 - `src/**/*.test.ts(x)` — unit, run by `pnpm test`.
 - `src/**/*.db.test.ts` — integration against real Postgres, run by `pnpm test:db` (sequential; needs `docker compose up -d` and migrations applied).
-- `tests/e2e/**` — Playwright (`testDir` in `playwright.config.ts`), run by `pnpm test:e2e`. Includes axe-core a11y checks on `/s/[slug]`.
+- `tests/e2e/**` — Playwright (`testDir` in `playwright.config.ts`), run by `pnpm test:e2e`. `@axe-core/playwright` is installed; no axe specs exist yet (planned for `/s/[slug]`).
 
 ## Recurring mistakes to avoid
 


### PR DESCRIPTION
## Summary
- Document the Magic Compose feature (lib client, API route, components, env vars) in CLAUDE.md — previously undocumented despite being a substantial recent addition with its own env surface
- Add `pnpm eval:magic-compose` to the commands list
- Correct the Playwright test location to `tests/e2e/**` (per `playwright.config.ts`) — the prior wording was vague

## Test plan
- [x] Verified against codebase: `src/lib/magic-compose/llm-client.ts`, `src/app/api/signups/magic-compose/route.ts`, `src/components/magic-compose/`, `scripts/eval-magic-compose.ts` all exist
- [x] Verified env vars listed match `.env.example`
- [x] Verified `testDir` in `playwright.config.ts` is `./tests/e2e`
- [x] Docs-only change — no lint/typecheck/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)