### PR TITLE
fix(build-grid): align mobile slot card values consistently

### DIFF
--- a/src/components/build-grid/mobile/SlotCard.tsx
+++ b/src/components/build-grid/mobile/SlotCard.tsx
@@ -99,7 +99,7 @@ function FieldRow({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           aria-label={field.name}
-          className="min-w-0 flex-1 appearance-none border-none bg-transparent py-1 text-base text-ink outline-none"
+          className="min-w-0 flex-1 appearance-none border-none bg-transparent py-1 text-right text-base text-ink outline-none"
         >
           <option value="">—</option>
           {(field.config.fieldType === 'enum' ? field.config.choices : []).map((choice) => (
@@ -114,7 +114,7 @@ function FieldRow({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           aria-label={field.name}
-          className="min-w-0 flex-1 border-none bg-transparent py-1 text-base text-ink outline-none"
+          className="min-w-0 flex-1 border-none bg-transparent py-1 text-right text-base text-ink outline-none"
         />
       )}
     </div>
@@ -158,7 +158,7 @@ function CapacityRow({
         }}
         aria-label="Capacity"
         placeholder="Unlimited"
-        className="min-w-0 flex-1 border-none bg-transparent py-1 text-base text-ink outline-none placeholder:text-ink-soft"
+        className="min-w-0 flex-1 border-none bg-transparent py-1 text-right text-base text-ink outline-none placeholder:text-ink-soft"
       />
     </div>
   );


### PR DESCRIPTION
Native iOS Safari renders <input type="date"> and <input type="time">
values right-aligned, but type="number" and type="text" render
left-aligned. The capacity row in a mobile slot card therefore drifted
left while date/time rows stayed right, producing visible misalignment
between rows. Force text-right on the value side of every FieldRow and
the CapacityRow so all values line up on the right edge of the card.