### PR TITLE
fix(auth): shorten magic-link expiry to 1h and humanize display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ DATABASE_URL=postgres://signup:signup@localhost:5433/signup
 AUTH_SECRET=change-me-to-a-32-byte-random-string-XXXXXXXXX
 AUTH_URL=http://localhost:3000
 
+# How long magic-link sign-in emails stay valid, in minutes.
+# Default 60. Min 1, max 10080 (1 week). Shorter = more secure; longer = more
+# forgiving if users don't check their inbox immediately.
+AUTH_MAGIC_LINK_MAX_AGE_MINUTES=60
+
 # Email transport: console | smtp | resend
 EMAIL_TRANSPORT=console
 EMAIL_FROM="OpenSignup <hello@signup.local>"

--- a/src/app/login/check/page.tsx
+++ b/src/app/login/check/page.tsx
@@ -1,7 +1,11 @@
-import { MAGIC_LINK_MAX_AGE_MINUTES } from '@/auth/magic-link-expiry';
+import { getMagicLinkMaxAgeMinutes } from '@/auth/magic-link-expiry';
 import { formatDuration } from '@/lib/format-duration';
 
 export const metadata = { title: 'Check your email' };
+
+// Force dynamic so getMagicLinkMaxAgeMinutes() (→ getEnv()) runs at request
+// time, not during `next build` where server env is absent.
+export const dynamic = 'force-dynamic';
 
 export default function CheckEmailPage() {
   return (
@@ -10,7 +14,7 @@ export default function CheckEmailPage() {
         <h1 className="text-3xl font-semibold tracking-tight">Check your email</h1>
         <p className="text-ink-muted">
           We sent a sign-in link to your inbox. Click it to continue. The link expires in{' '}
-          {formatDuration(MAGIC_LINK_MAX_AGE_MINUTES)}.
+          {formatDuration(getMagicLinkMaxAgeMinutes())}.
         </p>
       </div>
     </main>

--- a/src/app/login/check/page.tsx
+++ b/src/app/login/check/page.tsx
@@ -1,3 +1,6 @@
+import { MAGIC_LINK_MAX_AGE_MINUTES } from '@/auth/magic-link-expiry';
+import { formatDuration } from '@/lib/format-duration';
+
 export const metadata = { title: 'Check your email' };
 
 export default function CheckEmailPage() {
@@ -6,8 +9,8 @@ export default function CheckEmailPage() {
       <div className="space-y-3">
         <h1 className="text-3xl font-semibold tracking-tight">Check your email</h1>
         <p className="text-ink-muted">
-          We sent a sign-in link to your inbox. Click it to continue. The link expires in a few
-          minutes.
+          We sent a sign-in link to your inbox. Click it to continue. The link expires in{' '}
+          {formatDuration(MAGIC_LINK_MAX_AGE_MINUTES)}.
         </p>
       </div>
     </main>

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -13,7 +13,7 @@ import { ServiceException } from '@/lib/errors';
 import { SignupAdapter } from './adapter';
 import { canonicalizeMagicLinkUrl } from './magic-link-url';
 import { extractEmailDomain } from './email-domain';
-import { MAGIC_LINK_MAX_AGE_SECONDS } from './magic-link-expiry';
+import { getMagicLinkMaxAgeSeconds } from './magic-link-expiry';
 import { getCurrentRequestIp } from './request-context';
 
 // Built lazily on first request: SignupAdapter() touches getDb() → getEnv(),
@@ -33,7 +33,7 @@ function buildConfig(): NextAuthConfig {
         // which reads EMAIL_FROM lazily at request time.
         server: 'smtp://user:pass@localhost:2525',
         from: 'noreply@opensignup.invalid',
-        maxAge: MAGIC_LINK_MAX_AGE_SECONDS,
+        maxAge: getMagicLinkMaxAgeSeconds(),
         async sendVerificationRequest({ identifier, url, expires }) {
           const subject = identifier.trim().toLowerCase();
           const ip = await getCurrentRequestIp();

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -13,6 +13,7 @@ import { ServiceException } from '@/lib/errors';
 import { SignupAdapter } from './adapter';
 import { canonicalizeMagicLinkUrl } from './magic-link-url';
 import { extractEmailDomain } from './email-domain';
+import { MAGIC_LINK_MAX_AGE_SECONDS } from './magic-link-expiry';
 import { getCurrentRequestIp } from './request-context';
 
 // Built lazily on first request: SignupAdapter() touches getDb() → getEnv(),
@@ -32,6 +33,7 @@ function buildConfig(): NextAuthConfig {
         // which reads EMAIL_FROM lazily at request time.
         server: 'smtp://user:pass@localhost:2525',
         from: 'noreply@opensignup.invalid',
+        maxAge: MAGIC_LINK_MAX_AGE_SECONDS,
         async sendVerificationRequest({ identifier, url, expires }) {
           const subject = identifier.trim().toLowerCase();
           const ip = await getCurrentRequestIp();

--- a/src/auth/magic-link-expiry.ts
+++ b/src/auth/magic-link-expiry.ts
@@ -1,2 +1,9 @@
-export const MAGIC_LINK_MAX_AGE_SECONDS = 60 * 60;
-export const MAGIC_LINK_MAX_AGE_MINUTES = 60;
+import { getEnv } from '@/lib/env';
+
+export function getMagicLinkMaxAgeMinutes(): number {
+  return getEnv().AUTH_MAGIC_LINK_MAX_AGE_MINUTES;
+}
+
+export function getMagicLinkMaxAgeSeconds(): number {
+  return getMagicLinkMaxAgeMinutes() * 60;
+}

--- a/src/auth/magic-link-expiry.ts
+++ b/src/auth/magic-link-expiry.ts
@@ -1,0 +1,2 @@
+export const MAGIC_LINK_MAX_AGE_SECONDS = 60 * 60;
+export const MAGIC_LINK_MAX_AGE_MINUTES = 60;

--- a/src/email/templates/magic-link.tsx
+++ b/src/email/templates/magic-link.tsx
@@ -1,4 +1,5 @@
 import { Button, Heading, Text } from '@react-email/components';
+import { formatDuration } from '@/lib/format-duration';
 import { EmailLayout } from './layout';
 
 export interface MagicLinkEmailProps {
@@ -7,15 +8,15 @@ export interface MagicLinkEmailProps {
   expiresInMinutes?: number;
 }
 
-export function MagicLinkEmail({ url, email, expiresInMinutes = 15 }: MagicLinkEmailProps) {
+export function MagicLinkEmail({ url, email, expiresInMinutes = 60 }: MagicLinkEmailProps) {
   return (
     <EmailLayout preview={`Sign in to OpenSignup as ${email}`}>
       <Heading as="h1" className="m-0 text-xl font-semibold">
         Sign in to OpenSignup
       </Heading>
       <Text className="mt-2 text-[#5b6474]">
-        Click the button below to sign in as <strong>{email}</strong>. This link will expire in
-        {` ${expiresInMinutes} minutes`}.
+        Click the button below to sign in as <strong>{email}</strong>. This link will expire in{' '}
+        {formatDuration(expiresInMinutes)}.
       </Text>
       <Button
         href={url}

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -53,6 +53,28 @@ describe('parseEnv', () => {
     expect(env.SMTP_PORT).toBe(587);
   });
 
+  it('defaults AUTH_MAGIC_LINK_MAX_AGE_MINUTES to 60', () => {
+    const env = parseEnv(base);
+    expect(env.AUTH_MAGIC_LINK_MAX_AGE_MINUTES).toBe(60);
+  });
+
+  it('coerces AUTH_MAGIC_LINK_MAX_AGE_MINUTES from a string', () => {
+    const env = parseEnv({ ...base, AUTH_MAGIC_LINK_MAX_AGE_MINUTES: '15' });
+    expect(env.AUTH_MAGIC_LINK_MAX_AGE_MINUTES).toBe(15);
+  });
+
+  it('rejects AUTH_MAGIC_LINK_MAX_AGE_MINUTES below 1', () => {
+    expect(() => parseEnv({ ...base, AUTH_MAGIC_LINK_MAX_AGE_MINUTES: '0' })).toThrow(
+      /AUTH_MAGIC_LINK_MAX_AGE_MINUTES/,
+    );
+  });
+
+  it('rejects AUTH_MAGIC_LINK_MAX_AGE_MINUTES above 10080', () => {
+    expect(() => parseEnv({ ...base, AUTH_MAGIC_LINK_MAX_AGE_MINUTES: '20000' })).toThrow(
+      /AUTH_MAGIC_LINK_MAX_AGE_MINUTES/,
+    );
+  });
+
   it('rejects LLM_BASE_URL without LLM_MODEL', () => {
     expect(() =>
       parseEnv({ ...base, LLM_BASE_URL: 'https://api.openai.com/v1' }),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -7,6 +7,12 @@ const baseSchema = z.object({
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
   AUTH_SECRET: z.string().min(32, 'AUTH_SECRET must be at least 32 characters'),
   AUTH_URL: z.string().url('AUTH_URL must be a valid URL'),
+  AUTH_MAGIC_LINK_MAX_AGE_MINUTES: z.coerce
+    .number()
+    .int()
+    .min(1, 'AUTH_MAGIC_LINK_MAX_AGE_MINUTES must be at least 1')
+    .max(10_080, 'AUTH_MAGIC_LINK_MAX_AGE_MINUTES must be at most 10080 (1 week)')
+    .default(60),
   EMAIL_TRANSPORT: transportEnum.default('console'),
   EMAIL_FROM: z.string().min(1, 'EMAIL_FROM is required'),
   RESEND_API_KEY: z.string().optional(),

--- a/src/lib/format-duration.test.ts
+++ b/src/lib/format-duration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration } from './format-duration';
+
+describe('formatDuration', () => {
+  it('formats sub-hour values in minutes with pluralization', () => {
+    expect(formatDuration(1)).toBe('1 minute');
+    expect(formatDuration(30)).toBe('30 minutes');
+    expect(formatDuration(59)).toBe('59 minutes');
+  });
+
+  it('formats hour-scale values in hours with pluralization', () => {
+    expect(formatDuration(60)).toBe('1 hour');
+    expect(formatDuration(120)).toBe('2 hours');
+    expect(formatDuration(180)).toBe('3 hours');
+  });
+
+  it('formats day-scale values in days with pluralization', () => {
+    expect(formatDuration(1440)).toBe('1 day');
+    expect(formatDuration(2880)).toBe('2 days');
+  });
+});

--- a/src/lib/format-duration.test.ts
+++ b/src/lib/format-duration.test.ts
@@ -8,14 +8,29 @@ describe('formatDuration', () => {
     expect(formatDuration(59)).toBe('59 minutes');
   });
 
-  it('formats hour-scale values in hours with pluralization', () => {
+  it('formats clean hour-scale values in hours', () => {
     expect(formatDuration(60)).toBe('1 hour');
     expect(formatDuration(120)).toBe('2 hours');
     expect(formatDuration(180)).toBe('3 hours');
   });
 
-  it('formats day-scale values in days with pluralization', () => {
+  it('formats hours with a leftover as "X hours Y minutes" (never rounds up)', () => {
+    expect(formatDuration(90)).toBe('1 hour 30 minutes');
+    expect(formatDuration(75)).toBe('1 hour 15 minutes');
+    expect(formatDuration(121)).toBe('2 hours 1 minute');
+  });
+
+  it('formats clean day-scale values in days', () => {
     expect(formatDuration(1440)).toBe('1 day');
     expect(formatDuration(2880)).toBe('2 days');
+  });
+
+  it('formats days with a leftover as "X days Y hours" (never rounds up)', () => {
+    expect(formatDuration(2160)).toBe('1 day 12 hours');
+    expect(formatDuration(1500)).toBe('1 day 1 hour');
+  });
+
+  it('drops sub-hour leftovers in the day branch so we never overstate', () => {
+    expect(formatDuration(1470)).toBe('1 day');
   });
 });

--- a/src/lib/format-duration.ts
+++ b/src/lib/format-duration.ts
@@ -1,0 +1,7 @@
+export function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+  const days = Math.round(hours / 24);
+  return `${days} ${days === 1 ? 'day' : 'days'}`;
+}

--- a/src/lib/format-duration.ts
+++ b/src/lib/format-duration.ts
@@ -1,7 +1,24 @@
+function pluralize(n: number, unit: 'minute' | 'hour' | 'day'): string {
+  return `${n} ${n === 1 ? unit : `${unit}s`}`;
+}
+
+// Never overstates: an expiration deadline must round DOWN, so a link advertised
+// as "1 hour 30 minutes" never expires before that claim.
 export function formatDuration(minutes: number): string {
-  if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
-  const days = Math.round(hours / 24);
-  return `${days} ${days === 1 ? 'day' : 'days'}`;
+  if (minutes < 60) return pluralize(minutes, 'minute');
+
+  if (minutes < 60 * 24) {
+    const hours = Math.floor(minutes / 60);
+    const rem = minutes % 60;
+    return rem === 0
+      ? pluralize(hours, 'hour')
+      : `${pluralize(hours, 'hour')} ${pluralize(rem, 'minute')}`;
+  }
+
+  const days = Math.floor(minutes / (60 * 24));
+  const remMin = minutes - days * 60 * 24;
+  const remHours = Math.floor(remMin / 60);
+  return remHours === 0
+    ? pluralize(days, 'day')
+    : `${pluralize(days, 'day')} ${pluralize(remHours, 'hour')}`;
 }


### PR DESCRIPTION
The sign-in email previously read "expires in 1440 minutes" (Auth.js's
24h default) while /login/check claimed "a few minutes". Cap the
provider's maxAge at 1 hour and render the duration through a shared
formatter so both surfaces show "1 hour".