### PR TITLE
feat(build-grid): unified Add field CTA + grouped body rendering

### DIFF
--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -118,7 +118,6 @@ export function BuildGrid({ signupId, signupMeta, initialFields, initialSlots, i
             showPreview={state.showPreview}
             onTogglePreview={() => setShowPreview(!state.showPreview)}
             saveStatus={state.saveStatus}
-            onAddField={() => setShowFieldEditorCreate(true)}
           />
           <ScrollableTable totalWidth={totalGridWidth(state.fields)}>
             <GridHeader

--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -8,7 +8,7 @@ import { totalGridWidth } from './columnSizing';
 import { Toolbar } from './Toolbar';
 import { ScrollableTable } from './ScrollableTable';
 import { GridHeader } from './GridHeader';
-import { GridBody } from './GridBody';
+import { GroupedBody } from './GroupedBody';
 import { SideRail } from './SideRail';
 import { FieldEditor } from './FieldEditor';
 import { MobileBuildGrid } from './mobile/MobileBuildGrid';
@@ -129,9 +129,10 @@ export function BuildGrid({ signupId, signupMeta, initialFields, initialSlots, i
               onResize={(fieldId, width) => setFieldWidth(fieldId, width)}
               onResetWidth={(fieldId) => setFieldWidth(fieldId, undefined)}
             />
-            <GridBody
+            <GroupedBody
               fields={state.fields}
               rows={state.rows}
+              groupByFieldRef={state.groupByFieldRef}
               highlightedRowIdx={state.previewRowIdx}
               onEditCell={(rowId, fieldRef, value) => editCell(rowId, fieldRef, value)}
               onSetCapacity={(rowId, cap) => { void setCapacity(rowId, cap); }}

--- a/src/components/build-grid/ColumnHeaderMenu.tsx
+++ b/src/components/build-grid/ColumnHeaderMenu.tsx
@@ -63,7 +63,7 @@ export function ColumnHeaderMenu({
       { kind: 'item', label: 'Move to start', icon: ArrowLeftToLine, onClick: onMoveStart, disabled: isFirst },
       { kind: 'item', label: 'Move to end', icon: ArrowRightToLine, onClick: onMoveEnd, disabled: isLast },
       { kind: 'divider' },
-      { kind: 'item', label: 'Delete column', icon: Trash2, onClick: onDelete, disabled: false, danger: true },
+      { kind: 'item', label: 'Delete field', icon: Trash2, onClick: onDelete, disabled: false, danger: true },
     ],
     [isFirst, isLast, onEdit, onMoveLeft, onMoveRight, onMoveStart, onMoveEnd, onDelete],
   );

--- a/src/components/build-grid/FieldEditor.test.tsx
+++ b/src/components/build-grid/FieldEditor.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FieldEditor } from './FieldEditor';
+import type { GridField } from './useGridState';
+
+const noop = () => {};
+
+const sampleField: GridField = {
+  id: 'sf_1',
+  ref: 'r1',
+  name: 'Date',
+  type: 'date',
+  config: { fieldType: 'date' },
+  sortOrder: 0,
+};
+
+describe('<FieldEditor />', () => {
+  it('shows "New field" when creating', () => {
+    render(<FieldEditor editorMode={{ mode: 'create' }} onSave={noop} onClose={noop} />);
+    expect(screen.getByRole('heading', { name: 'New field' })).toBeInTheDocument();
+    expect(screen.queryByText(/column/i)).toBeNull();
+  });
+
+  it('shows "Edit field" + "Remove field" when editing', () => {
+    render(
+      <FieldEditor
+        editorMode={{ mode: 'edit', field: sampleField }}
+        onSave={noop}
+        onDelete={vi.fn()}
+        onClose={noop}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: 'Edit field' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Remove field' })).toBeInTheDocument();
+    expect(screen.queryByText(/column/i)).toBeNull();
+  });
+});

--- a/src/components/build-grid/FieldEditor.tsx
+++ b/src/components/build-grid/FieldEditor.tsx
@@ -104,7 +104,7 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
   const nameError = errors.name;
   const choicesErrors = errors.choices;
 
-  const titleText = isEdit ? 'Edit column' : 'New column';
+  const titleText = isEdit ? 'Edit field' : 'New field';
 
   const nameInputClasses = [
     'border rounded-lg px-2.5 py-2 text-base md:text-sm font-[inherit] outline-none bg-white w-full',
@@ -257,7 +257,7 @@ export function FieldEditor({ editorMode, onSave, onDelete, onClose }: FieldEdit
                     onClick={onDelete}
                     className="text-sm text-danger font-medium hover:opacity-70"
                   >
-                    Remove column
+                    Remove field
                   </button>
                 )}
               </div>

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -72,8 +72,8 @@ export function GridBody({
             />
           </div>
 
-          {/* Trailing actions — 60px (visible on group-hover) */}
-          <div className="flex items-center justify-end opacity-0 group-hover:opacity-100 transition-opacity">
+          {/* Trailing actions — 130px, left-aligned to line up with the "+ Add field" header link */}
+          <div className="flex items-center justify-start pl-3 opacity-0 group-hover:opacity-100 transition-opacity">
             <button
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -72,8 +72,8 @@ export function GridBody({
             />
           </div>
 
-          {/* Trailing actions — 130px, left-aligned to line up with the "+ Add field" header link */}
-          <div className="flex items-center justify-start pl-3 opacity-0 group-hover:opacity-100 transition-opacity">
+          {/* Trailing actions — 130px, right-aligned to line up with the "+ Add field" header link */}
+          <div className="flex items-center justify-end pr-3 opacity-0 group-hover:opacity-100 transition-opacity">
             <button
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/components/build-grid/GridHeader.test.tsx
+++ b/src/components/build-grid/GridHeader.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GridHeader } from './GridHeader';
+import type { GridField } from './useGridState';
+
+const sampleFields: GridField[] = [
+  {
+    id: 'sf_1',
+    ref: 'r1',
+    name: 'Date',
+    type: 'date',
+    config: { fieldType: 'date' },
+    sortOrder: 0,
+  },
+  {
+    id: 'sf_2',
+    ref: 'r2',
+    name: 'Notes',
+    type: 'text',
+    config: { fieldType: 'text', maxLength: 200 },
+    sortOrder: 1,
+  },
+];
+
+function renderHeader(overrides: Partial<React.ComponentProps<typeof GridHeader>> = {}) {
+  return render(
+    <GridHeader
+      fields={sampleFields}
+      onEditField={vi.fn()}
+      onAddField={vi.fn()}
+      onDeleteField={vi.fn()}
+      onMoveField={vi.fn()}
+      onResize={vi.fn()}
+      onResetWidth={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('<GridHeader />', () => {
+  it('renders exactly one "Add field" entry point in the trailing cell', () => {
+    renderHeader();
+    const addButtons = screen.getAllByRole('button', { name: /add field/i });
+    expect(addButtons).toHaveLength(1);
+    expect(addButtons[0]).toHaveTextContent(/Add field/i);
+  });
+
+  it('does not render an "Add column" button anywhere', () => {
+    renderHeader();
+    expect(screen.queryByRole('button', { name: /add column/i })).toBeNull();
+  });
+
+  it('fires onAddField when the trailing link is clicked', () => {
+    const onAddField = vi.fn();
+    renderHeader({ onAddField });
+    screen.getByRole('button', { name: /add field/i }).click();
+    expect(onAddField).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -178,17 +178,17 @@ export function GridHeader({
         <span className="text-[13px] font-medium text-ink truncate">Cap.</span>
       </div>
 
-      {/* Trailing + button — 60px */}
-      <div className="flex items-center justify-center">
-        <button
-          onClick={onAddField}
-          title="Add column"
-          aria-label="Add column"
-          className="text-brand hover:text-brand/80 p-1 rounded"
-        >
-          <Plus size={13} />
-        </button>
-      </div>
+      {/* Trailing labeled "+ Add field" link — 130px. Mirrors the
+          AddRowAffordance footer style: muted ink + Plus icon + label. */}
+      <button
+        type="button"
+        onClick={onAddField}
+        aria-label="Add field"
+        className="flex h-full w-full items-center justify-start gap-1.5 border-l border-surface-sunk px-3 text-sm font-medium text-ink-muted hover:bg-surface-sunk/50 hover:text-ink transition-colors"
+      >
+        <Plus size={13} />
+        Add field
+      </button>
     </div>
   );
 }

--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -178,13 +178,13 @@ export function GridHeader({
         <span className="text-[13px] font-medium text-ink truncate">Cap.</span>
       </div>
 
-      {/* Trailing labeled "+ Add field" link — 130px. Mirrors the
-          AddRowAffordance footer style: muted ink + Plus icon + label. */}
+      {/* Trailing labeled "+ Add field" link — 130px. Right-aligned to match
+          the per-row trailing actions cell. */}
       <button
         type="button"
         onClick={onAddField}
         aria-label="Add field"
-        className="flex h-full w-full items-center justify-start gap-1.5 border-l border-surface-sunk px-3 text-sm font-medium text-ink-muted hover:bg-surface-sunk/50 hover:text-ink transition-colors"
+        className="flex h-full w-full items-center justify-end gap-1.5 border-l border-surface-sunk px-3 text-sm font-medium text-ink-muted hover:bg-surface-sunk/50 hover:text-ink transition-colors"
       >
         <Plus size={13} />
         Add field

--- a/src/components/build-grid/GroupedBody.test.tsx
+++ b/src/components/build-grid/GroupedBody.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { GroupedBody } from './GroupedBody';
+import type { GridField, GridRow } from './useGridState';
+
+const dateField: GridField = {
+  id: 'sf_date',
+  ref: 'date',
+  name: 'Date',
+  type: 'date',
+  config: { fieldType: 'date' },
+  sortOrder: 0,
+};
+
+const textField: GridField = {
+  id: 'sf_notes',
+  ref: 'notes',
+  name: 'Notes',
+  type: 'text',
+  config: { fieldType: 'text', maxLength: 200 },
+  sortOrder: 1,
+};
+
+const fields: GridField[] = [dateField, textField];
+
+function row(id: string, sortOrder: number, values: Record<string, string>): GridRow {
+  return { id, capacity: null, sortOrder, values };
+}
+
+const baseHandlers = {
+  onSelectRow: vi.fn(),
+  onEditCell: vi.fn(),
+  onSetCapacity: vi.fn(),
+  onDeleteRow: vi.fn(),
+  onMoveRowUp: vi.fn(),
+  onMoveRowDown: vi.fn(),
+};
+
+describe('<GroupedBody />', () => {
+  it('delegates to flat <GridBody /> when groupByFieldRef is null', () => {
+    const rows = [
+      row('r1', 0, { date: '2026-05-18', notes: 'first' }),
+      row('r2', 1, { date: '2026-05-19', notes: 'second' }),
+    ];
+    render(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef={null}
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /No value/i })).toBeNull();
+    // Both date cells render — flat passthrough.
+    expect(screen.getByDisplayValue('2026-05-18')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2026-05-19')).toBeInTheDocument();
+  });
+
+  it('renders one header per unique date value plus a "No value" header for empty rows', () => {
+    const rows = [
+      row('r1', 0, { date: '2026-05-18', notes: 'a' }),
+      row('r2', 1, { date: '2026-05-19', notes: 'b' }),
+      row('r3', 2, { date: '2026-05-18', notes: 'c' }), // duplicate date → same group
+      row('r4', 3, { date: '', notes: 'd' }), // empty → No value
+    ];
+
+    render(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef="date"
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+      />,
+    );
+
+    // Two real date groups (deduped) + one "No value" group.
+    const headers = screen.getAllByRole('button', { expanded: true });
+    expect(headers).toHaveLength(3);
+
+    // Date headers carry localised "Mon, May 18" style labels.
+    expect(screen.getByRole('button', { name: /May 18/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /May 19/ })).toBeInTheDocument();
+    // Empty-bucket header.
+    expect(screen.getByRole('button', { name: /No value/ })).toBeInTheDocument();
+
+    // Slot counts: May 18 has 2, May 19 has 1, No value has 1.
+    expect(screen.getByRole('button', { name: /May 18.*2 slots/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /May 19.*1 slot$/ })).toBeInTheDocument();
+  });
+
+  it('pins the "No value" header last in the rendered order', () => {
+    const rows = [
+      row('r1', 0, { date: '', notes: 'a' }),
+      row('r2', 1, { date: '2026-05-19', notes: 'b' }),
+      row('r3', 2, { date: '2026-05-18', notes: 'c' }),
+    ];
+    render(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef="date"
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+      />,
+    );
+
+    const headers = screen.getAllByRole('button', { expanded: true });
+    expect(headers).toHaveLength(3);
+    // Order: 2026-05-18, 2026-05-19, No value.
+    expect(headers[0]).toHaveTextContent(/May 18/);
+    expect(headers[1]).toHaveTextContent(/May 19/);
+    expect(headers[2]).toHaveTextContent(/No value/);
+  });
+
+  it('collapses a group when its header is clicked', async () => {
+    const rows = [
+      row('r1', 0, { date: '2026-05-18', notes: 'a' }),
+      row('r2', 1, { date: '2026-05-19', notes: 'b' }),
+    ];
+    render(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef="date"
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('2026-05-18')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2026-05-19')).toBeInTheDocument();
+
+    const may18Header = screen.getByRole('button', { name: /May 18/ });
+    act(() => may18Header.click());
+
+    // The collapsed group's date input is gone; the other one remains.
+    expect(screen.queryByDisplayValue('2026-05-18')).toBeNull();
+    expect(screen.getByDisplayValue('2026-05-19')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /May 18/, expanded: false })).toBeInTheDocument();
+  });
+
+  it('resets collapsed groups when groupByFieldRef changes', () => {
+    const rows = [
+      row('r1', 0, { date: '2026-05-18', notes: 'alpha' }),
+      row('r2', 1, { date: '2026-05-19', notes: 'beta' }),
+    ];
+    const { rerender } = render(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef="date"
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+      />,
+    );
+    act(() => screen.getByRole('button', { name: /May 18/ }).click());
+    expect(screen.queryByDisplayValue('2026-05-18')).toBeNull();
+
+    // Switch to notes — the new groups should all be expanded.
+    rerender(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef="notes"
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+      />,
+    );
+
+    const alphaGroup = screen.getByRole('button', { name: /^alpha/i });
+    const betaGroup = screen.getByRole('button', { name: /^beta/i });
+    expect(alphaGroup).toHaveAttribute('aria-expanded', 'true');
+    expect(betaGroup).toHaveAttribute('aria-expanded', 'true');
+    // Body rows are visible again.
+    expect(screen.getByDisplayValue('alpha')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('beta')).toBeInTheDocument();
+  });
+
+  it('translates a per-group row click to the flat sortOrder index via onSelectRow', () => {
+    const onSelectRow = vi.fn();
+    const rows = [
+      row('r1', 0, { date: '2026-05-19', notes: 'a' }),
+      row('r2', 1, { date: '2026-05-18', notes: 'b' }),
+      row('r3', 2, { date: '2026-05-19', notes: 'c' }),
+    ];
+    render(
+      <GroupedBody
+        fields={fields}
+        rows={rows}
+        groupByFieldRef="date"
+        highlightedRowIdx={-1}
+        {...baseHandlers}
+        onSelectRow={onSelectRow}
+      />,
+    );
+
+    // The May 18 group has one row (r2 — flat index 1). Click that row.
+    const may18Body = screen.getByDisplayValue('2026-05-18').closest('.group') as HTMLElement;
+    expect(may18Body).not.toBeNull();
+    act(() => may18Body.click());
+    expect(onSelectRow).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/components/build-grid/GroupedBody.tsx
+++ b/src/components/build-grid/GroupedBody.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { GridBody } from './GridBody';
+import type { GridField, GridRow } from './useGridState';
+
+export const EMPTY_KEY = '__empty';
+
+type GroupedBodyProps = {
+  fields: GridField[];
+  rows: GridRow[];
+  groupByFieldRef: string | null;
+  highlightedRowIdx: number;
+  onSelectRow: (idx: number) => void;
+  onEditCell: (rowId: string, fieldRef: string, value: string) => void;
+  onSetCapacity: (rowId: string, capacity: number | null) => void;
+  onDeleteRow: (rowId: string) => void;
+  onMoveRowUp: (rowId: string) => void;
+  onMoveRowDown: (rowId: string) => void;
+};
+
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+
+function formatGroupLabel(field: GridField, key: string): string {
+  if (field.type === 'date') {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(key);
+    if (m) {
+      const [, y, mo, d] = m;
+      const dt = new Date(Number(y), Number(mo) - 1, Number(d));
+      return dateFmt.format(dt);
+    }
+  }
+  return key;
+}
+
+export function GroupedBody({
+  fields,
+  rows,
+  groupByFieldRef,
+  highlightedRowIdx,
+  onSelectRow,
+  onEditCell,
+  onSetCapacity,
+  onDeleteRow,
+  onMoveRowUp,
+  onMoveRowDown,
+}: GroupedBodyProps) {
+  const groupField = groupByFieldRef
+    ? fields.find((f) => f.ref === groupByFieldRef) ?? null
+    : null;
+
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set());
+
+  // Switching the group field resets which groups are collapsed.
+  useEffect(() => {
+    setCollapsed(new Set());
+  }, [groupByFieldRef]);
+
+  const flatIndexById = useMemo(
+    () => new Map(rows.map((r, i) => [r.id, i])),
+    [rows],
+  );
+
+  if (!groupField) {
+    return (
+      <GridBody
+        fields={fields}
+        rows={rows}
+        highlightedRowIdx={highlightedRowIdx}
+        onSelectRow={onSelectRow}
+        onEditCell={onEditCell}
+        onSetCapacity={onSetCapacity}
+        onDeleteRow={onDeleteRow}
+        onMoveRowUp={onMoveRowUp}
+        onMoveRowDown={onMoveRowDown}
+      />
+    );
+  }
+
+  const ref = groupField.ref;
+
+  // Bucket rows by group key. Preserve flat sortOrder within each bucket.
+  const groups = new Map<string, GridRow[]>();
+  for (const r of rows) {
+    const raw = r.values[ref];
+    const key = raw === undefined || raw === null || raw === '' ? EMPTY_KEY : String(raw);
+    let bucket = groups.get(key);
+    if (!bucket) {
+      bucket = [];
+      groups.set(key, bucket);
+    }
+    bucket.push(r);
+  }
+
+  // Ascending lex; YYYY-MM-DD sorts chronologically; '__empty' pinned last.
+  const keys = [...groups.keys()].sort((a, b) => {
+    if (a === EMPTY_KEY) return 1;
+    if (b === EMPTY_KEY) return -1;
+    return a.localeCompare(b);
+  });
+
+  const highlightedRowId =
+    highlightedRowIdx >= 0 ? rows[highlightedRowIdx]?.id ?? null : null;
+
+  function toggle(key: string) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  return (
+    <div>
+      {keys.map((key) => {
+        const groupRows = groups.get(key) ?? [];
+        const isCollapsed = collapsed.has(key);
+        const localHighlight = highlightedRowId
+          ? groupRows.findIndex((r) => r.id === highlightedRowId)
+          : -1;
+        const label = key === EMPTY_KEY ? null : formatGroupLabel(groupField, key);
+        const count = groupRows.length;
+
+        return (
+          <div key={key}>
+            <button
+              type="button"
+              onClick={() => toggle(key)}
+              aria-expanded={!isCollapsed}
+              className="flex w-full items-center gap-2 border-t border-b border-surface-sunk bg-surface-raised px-3.5 py-2 text-left text-[11px] font-bold uppercase tracking-wider text-ink-muted"
+            >
+              <ChevronDown
+                size={11}
+                className="transition-transform"
+                style={{ transform: isCollapsed ? 'rotate(-90deg)' : 'none' }}
+              />
+              {label === null ? (
+                <em className="not-italic">No value</em>
+              ) : (
+                <span>{label}</span>
+              )}
+              <span className="text-[10px] font-semibold tracking-normal text-ink-soft normal-case">
+                {count} slot{count === 1 ? '' : 's'}
+              </span>
+            </button>
+            {!isCollapsed && (
+              <GridBody
+                fields={fields}
+                rows={groupRows}
+                highlightedRowIdx={localHighlight}
+                onSelectRow={(localIdx) => {
+                  const r = groupRows[localIdx];
+                  if (!r) return;
+                  const flat = flatIndexById.get(r.id);
+                  if (flat !== undefined) onSelectRow(flat);
+                }}
+                onEditCell={onEditCell}
+                onSetCapacity={onSetCapacity}
+                onDeleteRow={onDeleteRow}
+                onMoveRowUp={onMoveRowUp}
+                onMoveRowDown={onMoveRowDown}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/build-grid/Toolbar.test.tsx
+++ b/src/components/build-grid/Toolbar.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Toolbar } from './Toolbar';
+import type { GridField } from './useGridState';
+
+const sampleFields: GridField[] = [
+  {
+    id: 'sf_1',
+    ref: 'r1',
+    name: 'Date',
+    type: 'date',
+    config: { fieldType: 'date' },
+    sortOrder: 0,
+  },
+];
+
+describe('<Toolbar />', () => {
+  it('does not render an "Add column" or "Add field" button (single CTA now lives in the header)', () => {
+    render(
+      <Toolbar
+        fields={sampleFields}
+        rows={[]}
+        groupByFieldRef={null}
+        onGroupByChange={() => {}}
+        showPreview={false}
+        onTogglePreview={() => {}}
+        saveStatus="idle"
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /add (field|column)/i })).toBeNull();
+  });
+
+  it('still renders Group by and Live preview controls', () => {
+    render(
+      <Toolbar
+        fields={sampleFields}
+        rows={[]}
+        groupByFieldRef={null}
+        onGroupByChange={() => {}}
+        showPreview={false}
+        onTogglePreview={() => {}}
+        saveStatus="idle"
+      />,
+    );
+
+    expect(screen.getByText('Group by')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show live preview' })).toBeInTheDocument();
+  });
+});

--- a/src/components/build-grid/Toolbar.tsx
+++ b/src/components/build-grid/Toolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { Plus, ChevronDown, Smartphone } from 'lucide-react';
+import { ChevronDown, Smartphone } from 'lucide-react';
 import { SaveStatus } from './SaveStatus';
 import type { GridField, GridRow, SaveStatus as SaveStatusType } from './useGridState';
 
@@ -13,7 +13,6 @@ type ToolbarProps = {
   showPreview: boolean;
   onTogglePreview: () => void;
   saveStatus: SaveStatusType;
-  onAddField: () => void;
 };
 
 export function Toolbar({
@@ -24,7 +23,6 @@ export function Toolbar({
   showPreview,
   onTogglePreview,
   saveStatus,
-  onAddField,
 }: ToolbarProps) {
   const [groupByOpen, setGroupByOpen] = useState(false);
   const groupByRef = useRef<HTMLDivElement>(null);
@@ -47,19 +45,6 @@ export function Toolbar({
 
   return (
     <div className="flex items-center gap-2 px-3.5 py-2.5 border-b border-surface-sunk bg-surface-raised">
-      {/* Add column button */}
-      <button
-        onClick={onAddField}
-        aria-label="Add column"
-        className="flex items-center gap-1 text-sm text-ink-muted font-medium hover:text-ink"
-      >
-        <Plus size={13} />
-        Add column
-      </button>
-
-      {/* Divider */}
-      <div className="w-px h-4.5 bg-surface-sunk mx-1" />
-
       {/* Group by label */}
       <span className="text-xs text-ink-soft">Group by</span>
 

--- a/src/components/build-grid/Toolbar.tsx
+++ b/src/components/build-grid/Toolbar.tsx
@@ -116,7 +116,7 @@ export function Toolbar({
 
       {/* Stats */}
       <span className="text-xs text-ink-soft">
-        {fields.length} columns · {rows.length} slots
+        {fields.length} fields · {rows.length} slots
       </span>
 
       {/* Divider */}

--- a/src/components/build-grid/columnSizing.test.ts
+++ b/src/components/build-grid/columnSizing.test.ts
@@ -49,50 +49,50 @@ describe('sizingFor', () => {
 
 describe('buildColsTemplate', () => {
   it('returns fixed header/footer with no fields', () => {
-    expect(buildColsTemplate([])).toBe('38px 90px 60px');
+    expect(buildColsTemplate([])).toBe('38px 90px 130px');
   });
 
   it('inserts fixed px track for a date field', () => {
-    expect(buildColsTemplate([{ type: 'date' }])).toBe('38px 150px 90px 60px');
+    expect(buildColsTemplate([{ type: 'date' }])).toBe('38px 150px 90px 130px');
   });
 
   it('inserts minmax track for a text field (first text gets +0.5 bonus)', () => {
-    expect(buildColsTemplate([{ type: 'text' }])).toBe('38px minmax(140px, 2fr) 90px 60px');
+    expect(buildColsTemplate([{ type: 'text' }])).toBe('38px minmax(140px, 2fr) 90px 130px');
   });
 
   it('handles two text fields: first is 2fr, second is 1.5fr', () => {
     expect(buildColsTemplate([{ type: 'text' }, { type: 'text' }])).toBe(
-      '38px minmax(140px, 2fr) minmax(140px, 1.5fr) 90px 60px',
+      '38px minmax(140px, 2fr) minmax(140px, 1.5fr) 90px 130px',
     );
   });
 
   it('handles mixed fixed and flex fields', () => {
     expect(buildColsTemplate([{ type: 'date' }, { type: 'text' }])).toBe(
-      '38px 150px minmax(140px, 1.5fr) 90px 60px',
+      '38px 150px minmax(140px, 1.5fr) 90px 130px',
     );
   });
 
   it('uses custom width override as fixed track', () => {
-    expect(buildColsTemplate([{ type: 'text', width: 220 }])).toBe('38px 220px 90px 60px');
+    expect(buildColsTemplate([{ type: 'text', width: 220 }])).toBe('38px 220px 90px 130px');
   });
 });
 
 describe('totalGridWidth', () => {
-  it('returns 188 for no fields (38 + 90 + 60)', () => {
-    expect(totalGridWidth([])).toBe(188);
+  it('returns 258 for no fields (38 + 90 + 130)', () => {
+    expect(totalGridWidth([])).toBe(258);
   });
 
-  it('returns 338 for one date field (188 + 150)', () => {
-    expect(totalGridWidth([{ type: 'date' }])).toBe(338);
+  it('returns 408 for one date field (258 + 150)', () => {
+    expect(totalGridWidth([{ type: 'date' }])).toBe(408);
   });
 
-  it('returns 328 for one text field (188 + 140)', () => {
-    expect(totalGridWidth([{ type: 'text' }])).toBe(328);
+  it('returns 398 for one text field (258 + 140)', () => {
+    expect(totalGridWidth([{ type: 'text' }])).toBe(398);
   });
 
   it('sums min widths for multiple fields', () => {
-    // date (150) + text (140) = 290 + 188 = 478
-    expect(totalGridWidth([{ type: 'date' }, { type: 'text' }])).toBe(478);
+    // date (150) + text (140) = 290 + 258 = 548
+    expect(totalGridWidth([{ type: 'date' }, { type: 'text' }])).toBe(548);
   });
 });
 

--- a/src/components/build-grid/columnSizing.ts
+++ b/src/components/build-grid/columnSizing.ts
@@ -47,10 +47,11 @@ export function sizingFor(field: SizableField, isFirst: boolean): FieldSizing {
 /**
  * Builds a CSS `grid-template-columns` string for the build grid.
  *
- * Layout: 38px <field tracks…> 90px 60px
+ * Layout: 38px <field tracks…> 90px 130px
  * - 38px = leading row-index column
  * - 90px = trailing Capacity column (fixed)
- * - 60px = trailing actions column (fixed)
+ * - 130px = trailing actions column (fixed) — sized for the labeled
+ *   "+ Add field" link in the header and the slot delete `×` in the body.
  * - fixed fields → "${px}px"
  * - flex fields  → "minmax(${min}px, ${weight}fr)"
  *
@@ -65,7 +66,7 @@ export function buildColsTemplate(fields: SizableField[]): string {
     return `minmax(${s.min}px, ${s.weight}fr)`;
   });
 
-  return ['38px', ...tracks, '90px', '60px'].join(' ');
+  return ['38px', ...tracks, '90px', '130px'].join(' ');
 }
 
 /**
@@ -80,10 +81,10 @@ export function widthFor(field: SizableField, fieldIndex: number): number {
 /**
  * Returns the sum of minimum column widths for the full grid.
  *
- * = 38 (index) + 90 (capacity) + 60 (actions) + Σ each field's min/fixed width
+ * = 38 (index) + 90 (capacity) + 130 (actions) + Σ each field's min/fixed width
  */
 export function totalGridWidth(fields: SizableField[]): number {
-  const FIXED_COLS = 38 + 90 + 60;
+  const FIXED_COLS = 38 + 90 + 130;
   const fieldsWidth = fields.reduce((sum, f) => {
     const s = sizingFor(f, false); // isFirst doesn't affect width for totalGridWidth
     return sum + (s.mode === 'fixed' ? s.px : s.min);

--- a/src/components/build-grid/mobile/FieldChipStrip.tsx
+++ b/src/components/build-grid/mobile/FieldChipStrip.tsx
@@ -34,7 +34,7 @@ export function FieldChipStrip({ fields, onEditField, onAddField }: FieldChipStr
           className="inline-flex shrink-0 items-center gap-1 rounded-full border border-dashed border-brand-soft bg-white px-3 py-1.5 text-sm font-medium text-brand"
         >
           <Plus size={13} aria-hidden="true" />
-          Add column
+          Add field
         </button>
       </div>
     </div>

--- a/src/components/build-grid/mobile/MobileBuildGrid.tsx
+++ b/src/components/build-grid/mobile/MobileBuildGrid.tsx
@@ -45,7 +45,7 @@ export function MobileBuildGrid({
     <div className="flex min-h-[calc(100vh-280px)] flex-col">
       <div className="flex flex-col gap-4 pb-3">
         <SectionHeader
-          label="COLUMNS"
+          label="FIELDS"
           count={fields.length}
           right={<SaveStatus status={saveStatus} />}
         />


### PR DESCRIPTION
## Summary

First slice of the "Edit Sheet Option A" design ([handoff](https://api.anthropic.com/v1/design/h/dKCbkm1DSgtNeI73OXpFOg?open_file=Edit+Sheet+Option+A.html)). Closes the two friction points organisers hit on the Build tab: duplicate "Add column" CTAs that read as decoration, and a Group by pill that silently did nothing.

- **Single "+ Add field" entry point.** Drop the toolbar "Add column" button + divider; replace the trailing `+` icon-only button in the header with a labeled link styled like the "+ Add slot" footer. Widen the trailing column 60 → 130px to fit the label and the right-aligned hover row controls.
- **Group by is real.** New `GroupedBody` wrapper re-sections rows by the chosen field's value. Empty values bucket under a pinned-last "No value" header; date values get a localised "Wkdy, Mon D" label and sort chronologically by their raw `YYYY-MM-DD` storage. Per-group `GridBody` calls translate local row clicks back to flat `sortOrder` indices so preview-row selection still works. Collapsed state is local and resets when the group field changes.
- **Copy: column → field** in user-visible surfaces (FieldEditor titles, Toolbar stat, mobile chip strip). DB/types keep `slot_fields` / `GridField` per the design handoff intent.
- **Trailing column right-aligned** (header link + body hover controls) so the actions column reads as one visual unit.

What's intentionally *not* in this PR — to keep it reviewable on its own:
- Pencil affordance + draggable header + ResizeHandle carve-out (Task 4)
- Field + row drag and ⌘/Ctrl + Arrow reorder (Tasks 5–6)
- Persistent row `×`, aria-live region, Cap. tooltip, `ColumnHeaderMenu` deletion (Tasks 7–10)

Tracking plan: `~/.claude/plans/build-grid-kind-pinwheel.md`.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — 410 unit tests pass (up from 399; +6 GroupedBody, +3 GridHeader, +2 Toolbar, +2 FieldEditor)
- [ ] `pnpm dev` and open a signup's Build tab — confirm:
  - [ ] Toolbar shows only Group by + stats + preview toggle (no Add column button)
  - [ ] Trailing header cell shows "+ Add field" link; row hover shows ▲ ▼ × right-aligned in the same column
  - [ ] FieldEditor modal title reads "Edit field" / "New field" with "Remove field" delete
  - [ ] Pick a date Group by → body re-sections with chronological group headers; pick a text Group by → alphabetical
  - [ ] Empty-value rows collect under a pinned-last "No value" header
  - [ ] Collapse a group → its rows hide; switch Group by → all groups re-expand
- [ ] Mobile (<md): chip strip "Add field" copy correct; existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)