### PR TITLE
fix(magic-compose): demote groupBy when every group has one slot

### DIFF
--- a/evals/magic-compose/README.md
+++ b/evals/magic-compose/README.md
@@ -4,7 +4,7 @@ Developer evals for OpenSignup's Magic Compose feature (natural-language to sign
 
 ## Files
 
-- `dev-evals.json` — 23-case developer eval suite covering each `fieldType`, cross-product/groupBy correctness, edge cases, multilingual input, hostile prompts, and the server invariants that hold regardless of model output.
+- `dev-evals.json` — 24-case developer eval suite covering each `fieldType`, cross-product/groupBy correctness, edge cases, multilingual input, hostile prompts, and the server invariants that hold regardless of model output.
 
 The user-facing starter prompts (School, Sports, Volunteering) shipped in the UI as click-to-try chips live in the Magic Compose UI code, not as a JSON file in this directory.
 
@@ -103,7 +103,7 @@ When adding a case:
 ## Regression targets (don't let these break)
 
 - Cross-product expansion: 3×12 grid produces 36 slots, every `values` non-empty (`ev_021`).
-- `groupBy` correctness: small named dimension → `groupBy=<that ref>`; pure date list → `null` (`ev_021`, `ev_022`, `ev_023`).
+- `groupBy` correctness: small named dimension → `groupBy=<that ref>`; pure date list → `null` (`ev_021`, `ev_022`, `ev_023`); uniform-unique candidate column → `null` (`ev_024`).
 - Server forces `state='draft'` and writes `templateId='magic-compose'` in activity (`ev_018`).
 - Empty prompt rejected with `invalid_input` before LLM call (`ev_014`).
 - No PII fields, no tenant IDs in model output (`ev_012`, `ev_020`).

--- a/evals/magic-compose/dev-evals.json
+++ b/evals/magic-compose/dev-evals.json
@@ -396,6 +396,17 @@
         "groupBy_or_converter_fallback_must_reference_enum_field": true,
         "rationale": "If the model omits groupBy, the converter's fallback uses the sole enum field. Either path should yield groupByFieldRefs=['<enum-ref>']."
       }
+    },
+    {
+      "id": "ev_024_unique_items_no_groupby",
+      "tags": ["groupBy", "regression"],
+      "runner": "llm",
+      "prompt": "Easter party potluck — three items to bring: cookies, candy, and plastic eggs.",
+      "expect": {
+        "slots.count_range": [3, 3],
+        "groupBy_should_be_null": true,
+        "rationale": "Regression: model set groupBy on a uniform-unique item column, producing one-item groups that confuse organizers (screenshot 2026-05-18). Prompt now instructs groupBy=null when every row would be unique; converter sanitizer enforces it server-side regardless."
+      }
     }
   ]
 }

--- a/src/lib/magic-compose/prompt.ts
+++ b/src/lib/magic-compose/prompt.ts
@@ -93,6 +93,7 @@ GROUPING — set "groupBy" to the field ref the participant will visually scan b
 - Cross-product with a small named dimension (classes, teachers, stations): groupBy that dimension's ref.
 - Pure date list (weekly games, shift dates): groupBy = null.
 - Single dimension with many text labels: groupBy = null.
+- If every slot would have a unique value for the candidate field (one row per value, no repeats), set groupBy = null — grouping only helps when participants can scan multiple options under one heading.
 
 WORKED EXAMPLES — study these patterns then apply to the user's request:
 

--- a/src/lib/magic-compose/to-template.test.ts
+++ b/src/lib/magic-compose/to-template.test.ts
@@ -124,6 +124,7 @@ describe('magicComposeToTemplate', () => {
         ],
         slots: [
           { values: { class: 'Maple', time: '09:00' } },
+          { values: { class: 'Maple', time: '09:30' } },
           { values: { class: 'Cedar', time: '09:00' } },
         ],
       });
@@ -137,7 +138,10 @@ describe('magicComposeToTemplate', () => {
           { ref: 'class', label: 'Class', fieldType: 'enum', choices: ['Maple', 'Cedar'] },
           { ref: 'time', label: 'Time', fieldType: 'time' },
         ],
-        slots: [{ values: { class: 'Maple', time: '09:00' } }],
+        slots: [
+          { values: { class: 'Maple', time: '09:00' } },
+          { values: { class: 'Maple', time: '09:30' } },
+        ],
       });
       expect(r.groupByFieldRefs).toEqual(['class']);
     });
@@ -162,6 +166,66 @@ describe('magicComposeToTemplate', () => {
         slots: [{ values: { a: 'hi' } }],
       });
       expect(r.groupByFieldRefs).toEqual([]);
+    });
+
+    it('demotes groupBy when every slot has a unique value', () => {
+      const r = parseFull({
+        title: 'Easter potluck',
+        groupBy: 'item',
+        fields: [{ ref: 'item', label: 'Item to Bring', fieldType: 'text' }],
+        slots: [
+          { values: { item: 'Cookies' } },
+          { values: { item: 'Candy' } },
+          { values: { item: 'Plastic Eggs' } },
+        ],
+      });
+      expect(r.groupByFieldRefs).toEqual([]);
+    });
+
+    it('keeps groupBy when at least one group has multiple slots', () => {
+      const r = parseFull({
+        title: 'Snack rotation',
+        groupBy: 'week',
+        fields: [{ ref: 'week', label: 'Week', fieldType: 'text' }],
+        slots: [
+          { values: { week: 'Week 1' } },
+          { values: { week: 'Week 1' } },
+          { values: { week: 'Week 2' } },
+        ],
+      });
+      expect(r.groupByFieldRefs).toEqual(['week']);
+    });
+
+    it('demotes the single-enum fallback when every slot has a unique enum value', () => {
+      const r = parseFull({
+        title: 'PT conferences',
+        fields: [
+          { ref: 'class', label: 'Class', fieldType: 'enum', choices: ['Maple', 'Cedar'] },
+          { ref: 'time', label: 'Time', fieldType: 'time' },
+        ],
+        slots: [
+          { values: { class: 'Maple', time: '09:00' } },
+          { values: { class: 'Cedar', time: '09:00' } },
+        ],
+      });
+      expect(r.groupByFieldRefs).toEqual([]);
+    });
+
+    it('ignores missing values when counting groups', () => {
+      const r = parseFull({
+        title: 'Snack rotation',
+        groupBy: 'week',
+        fields: [
+          { ref: 'week', label: 'Week', fieldType: 'text' },
+          { ref: 'note', label: 'Note', fieldType: 'text' },
+        ],
+        slots: [
+          { values: { week: 'Week 1', note: 'a' } },
+          { values: { week: 'Week 1', note: 'b' } },
+          { values: { note: 'c' } },
+        ],
+      });
+      expect(r.groupByFieldRefs).toEqual(['week']);
     });
   });
 

--- a/src/lib/magic-compose/to-template.ts
+++ b/src/lib/magic-compose/to-template.ts
@@ -122,6 +122,18 @@ export function buildWarnings(dropped: DroppedSummary): string[] {
   return out;
 }
 
+function hasUsableGrouping(slots: SignupTemplateSlot[], fieldRef: string): boolean {
+  const counts = new Map<string, number>();
+  for (const s of slots) {
+    const raw = s.values[fieldRef];
+    if (raw === undefined || raw === null) continue;
+    const key = String(raw);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  for (const n of counts.values()) if (n >= 2) return true;
+  return false;
+}
+
 export function magicComposeToTemplate(draft: MagicComposeDraft): MagicComposeConversion {
   const seenRefs = new Set<string>();
   const fields: SlotFieldInput[] = [];
@@ -190,12 +202,19 @@ export function magicComposeToTemplate(draft: MagicComposeDraft): MagicComposeCo
   // Honour the model's groupBy if it points at a declared field. Otherwise
   // fall back: if exactly one enum field exists, group by it (covers the
   // common cross-product case even when the model forgets to set groupBy).
+  // Either way, only keep the grouping if it produces at least one group with
+  // >1 slot — otherwise the "Group by" pill creates one-item groups that add
+  // no scannability and confuse organizers.
   let groupByFieldRefs: string[] = [];
+  let candidate: string | undefined;
   if (draft.groupBy && fieldByRef.has(draft.groupBy)) {
-    groupByFieldRefs = [draft.groupBy];
+    candidate = draft.groupBy;
   } else {
     const enumFields = fields.filter((f) => f.fieldType === 'enum');
-    if (enumFields.length === 1) groupByFieldRefs = [enumFields[0]!.ref];
+    if (enumFields.length === 1) candidate = enumFields[0]!.ref;
+  }
+  if (candidate && hasUsableGrouping(slots, candidate)) {
+    groupByFieldRefs = [candidate];
   }
 
   return { template, groupByFieldRefs, dropped };


### PR DESCRIPTION
## Summary
- Magic Compose sometimes set `groupBy` on a column where every slot has a unique value (e.g. 3 items: Cookies, Candy, Plastic Eggs → one-item groups), which adds no scannability and confuses organizers.
- Sanitize in `magicComposeToTemplate`: only keep `groupBy` if at least one group has > 1 slot. Applies to both branches — model-provided `draft.groupBy` and the single-enum fallback.
- Tighten the prompt with a new GROUPING bullet so the model stops emitting this shape (soft fix; the converter is the hard backstop).
- Add `ev_024_unique_items_no_groupby` regression case mirroring the screenshot.

## Intentional behavior change
Single-slot drafts no longer auto-group via the single-enum fallback (a one-slot signup gains nothing from a group header).

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 401/401 pass (4 new regression tests added)
- [x] Manual repro: dev server, prompt *"Easter party potluck — three items to bring: cookies, candy, and plastic eggs"*, confirmed Group by pill reads **None**.
- [ ] Optional `pnpm eval:magic-compose --case=ev_024_unique_items_no_groupby` (live LLM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)