### PR TITLE
feat(build-grid): info tooltip on Cap header

### DIFF
--- a/src/components/build-grid/GridHeader.tsx
+++ b/src/components/build-grid/GridHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, ChevronDown } from 'lucide-react';
+import { Tooltip } from '@/components/ui/Tooltip';
 import { buildColsTemplate } from './columnSizing';
 import { ColumnHeaderMenu } from './ColumnHeaderMenu';
 import { fieldTypeMeta } from './fieldTypes';
@@ -174,8 +175,18 @@ export function GridHeader({
       })}
 
       {/* Trailing Capacity header — 90px */}
-      <div className="flex items-center justify-center px-2 py-2 border-r border-surface-sunk">
+      <div className="flex items-center justify-center gap-1 px-2 py-2 border-r border-surface-sunk">
         <span className="text-[13px] font-medium text-ink truncate">Cap.</span>
+        <Tooltip label="Maximum number of people who can sign up for this slot.">
+          <span
+            tabIndex={0}
+            role="img"
+            aria-label="About the Cap column"
+            className="inline-flex h-[13px] w-[13px] cursor-help items-center justify-center rounded-full border border-ink-soft text-[9px] font-bold leading-none text-ink-soft"
+          >
+            i
+          </span>
+        </Tooltip>
       </div>
 
       {/* Trailing labeled "+ Add field" link — 130px. Right-aligned to match

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+
+type TooltipProps = {
+  label: string;
+  side?: 'top' | 'bottom';
+  children: ReactNode;
+};
+
+export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+
+  const show = () => setOpen(true);
+  const hide = () => setOpen(false);
+
+  const popoverPosition =
+    side === 'bottom'
+      ? 'top-[calc(100%+6px)]'
+      : 'bottom-[calc(100%+6px)]';
+
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocusCapture={show}
+      onBlurCapture={hide}
+    >
+      {children}
+      {open && label && (
+        <span
+          role="tooltip"
+          className={`pointer-events-none absolute left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-ink px-2 py-1 text-[11px] font-medium text-white ${popoverPosition}`}
+        >
+          {label}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,23 +1,30 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import {
+  cloneElement,
+  useId,
+  useState,
+  type ReactElement,
+} from 'react';
 
 type TooltipProps = {
   label: string;
   side?: 'top' | 'bottom';
-  children: ReactNode;
+  children: ReactElement<{ 'aria-describedby'?: string }>;
 };
 
 export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
   const [open, setOpen] = useState(false);
+  const id = useId();
 
   const show = () => setOpen(true);
   const hide = () => setOpen(false);
 
-  const popoverPosition =
-    side === 'bottom'
-      ? 'top-[calc(100%+6px)]'
-      : 'bottom-[calc(100%+6px)]';
+  const popoverClass = open
+    ? `pointer-events-none absolute left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-ink px-2 py-1 text-[11px] font-medium text-white ${
+        side === 'bottom' ? 'top-[calc(100%+6px)]' : 'bottom-[calc(100%+6px)]'
+      }`
+    : 'sr-only';
 
   return (
     <span
@@ -27,15 +34,10 @@ export function Tooltip({ label, side = 'bottom', children }: TooltipProps) {
       onFocusCapture={show}
       onBlurCapture={hide}
     >
-      {children}
-      {open && label && (
-        <span
-          role="tooltip"
-          className={`pointer-events-none absolute left-1/2 z-50 -translate-x-1/2 whitespace-nowrap rounded-md bg-ink px-2 py-1 text-[11px] font-medium text-white ${popoverPosition}`}
-        >
-          {label}
-        </span>
-      )}
+      {cloneElement(children, { 'aria-describedby': id })}
+      <span id={id} role="tooltip" className={popoverClass}>
+        {label}
+      </span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- Small circular "i" badge next to the "Cap." column header in the build grid, with a hover/focus tooltip explaining what the column means.
- Adds a reusable `Tooltip` primitive in `src/components/ui/Tooltip.tsx` matching the dark popover style from the *Edit Sheet Option A* design handoff.
- Scope deliberately narrow: only the Cap header info icon — other refinements from the design (header drag-to-reorder, keyboard moves, `+ Add field` restyle, etc.) are out of scope.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (410/410 passing)
- [x] Browser smoke: badge renders beside "Cap." matching the mock; hover shows the tooltip; tabbing onto the badge shows it via focus; mouseleave/blur hide it

🤖 Generated with [Claude Code](https://claude.com/claude-code)