### PR TITLE
feat(build-grid): row drag/drop + simplified trailing cell

### DIFF
--- a/src/components/build-grid/BuildGrid.tsx
+++ b/src/components/build-grid/BuildGrid.tsx
@@ -62,6 +62,7 @@ export function BuildGrid({ signupId, signupMeta, initialFields, initialSlots, i
     setFieldWidth,
     addRow,
     deleteRow,
+    moveRow,
     moveRowUp,
     moveRowDown,
     editCell,
@@ -137,6 +138,7 @@ export function BuildGrid({ signupId, signupMeta, initialFields, initialSlots, i
               onEditCell={(rowId, fieldRef, value) => editCell(rowId, fieldRef, value)}
               onSetCapacity={(rowId, cap) => { void setCapacity(rowId, cap); }}
               onDeleteRow={(rowId) => { void deleteRow(rowId); }}
+              onMoveRow={(from, to) => { void moveRow(from, to); }}
               onMoveRowUp={(rowId) => { void moveRowUp(rowId); }}
               onMoveRowDown={(rowId) => { void moveRowDown(rowId); }}
               onSelectRow={(idx) => setPreviewRow(idx)}

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { ChevronUp, ChevronDown, X } from 'lucide-react';
+import { useState } from 'react';
+import { X, GripHorizontal } from 'lucide-react';
 import { buildColsTemplate } from './columnSizing';
 import { CellInput } from './CellInput';
 import { CapacityCell } from './CapacityCell';
+import { useReorderable } from './useReorderable';
 import type { GridField, GridRow } from './useGridState';
 
 interface GridBodyProps {
@@ -14,6 +16,9 @@ interface GridBodyProps {
   onEditCell: (rowId: string, fieldRef: string, value: string) => void;
   onSetCapacity: (rowId: string, capacity: number | null) => void;
   onDeleteRow: (rowId: string) => void;
+  /** Drag reorder by index. When absent, drag handle stays hidden (e.g. grouped mode). */
+  onMoveRow?: (fromIdx: number, toIdx: number) => void;
+  /** Keyboard reorder by id. Stays enabled in grouped mode (within-group). */
   onMoveRowUp: (rowId: string) => void;
   onMoveRowDown: (rowId: string) => void;
 }
@@ -26,90 +31,168 @@ export function GridBody({
   onEditCell,
   onSetCapacity,
   onDeleteRow,
+  onMoveRow,
   onMoveRowUp,
   onMoveRowDown,
 }: GridBodyProps) {
+  const dragEnabled = Boolean(onMoveRow);
+  const reorder = useReorderable({
+    items: rows,
+    onReorder: (from, to) => onMoveRow?.(from, to),
+  });
+  const cols = buildColsTemplate(fields);
+
   return (
     <div>
       {rows.map((row, i) => (
-        <div
+        <GridBodyRow
           key={row.id}
-          onClick={() => onSelectRow(i)}
-          style={{
-            display: 'grid',
-            gridTemplateColumns: buildColsTemplate(fields),
-            borderBottom: '1px solid #eef1f5',
-            background: i === highlightedRowIdx ? 'rgb(31 111 235 / 0.04)' : 'transparent',
-            cursor: 'pointer',
-          }}
-          className="group transition-colors hover:bg-brand/5"
+          row={row}
+          index={i}
+          fields={fields}
+          cols={cols}
+          highlighted={i === highlightedRowIdx}
+          dragEnabled={dragEnabled}
+          reorder={reorder}
+          onSelectRow={() => onSelectRow(i)}
+          onEditCell={onEditCell}
+          onSetCapacity={onSetCapacity}
+          onDeleteRow={onDeleteRow}
+          onMoveRowUp={onMoveRowUp}
+          onMoveRowDown={onMoveRowDown}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface GridBodyRowProps {
+  row: GridRow;
+  index: number;
+  fields: GridField[];
+  cols: string;
+  highlighted: boolean;
+  dragEnabled: boolean;
+  reorder: ReturnType<typeof useReorderable<GridRow>>;
+  onSelectRow: () => void;
+  onEditCell: (rowId: string, fieldRef: string, value: string) => void;
+  onSetCapacity: (rowId: string, capacity: number | null) => void;
+  onDeleteRow: (rowId: string) => void;
+  onMoveRowUp: (rowId: string) => void;
+  onMoveRowDown: (rowId: string) => void;
+}
+
+function GridBodyRow({
+  row,
+  index,
+  fields,
+  cols,
+  highlighted,
+  dragEnabled,
+  reorder,
+  onSelectRow,
+  onEditCell,
+  onSetCapacity,
+  onDeleteRow,
+  onMoveRowUp,
+  onMoveRowDown,
+}: GridBodyRowProps) {
+  const [hover, setHover] = useState(false);
+  const [handleFocused, setHandleFocused] = useState(false);
+  const showHandle = dragEnabled && (hover || handleFocused);
+  const isDragging = dragEnabled && reorder.dragId === row.id;
+  const isDropTarget =
+    dragEnabled && reorder.overId === row.id && reorder.dragId !== null && reorder.dragId !== row.id;
+
+  const targetProps = dragEnabled ? reorder.target(row.id) : {};
+  // Only attach the drag source while the handle is visible — keeps the rest
+  // of the row click-friendly and avoids accidental drags from the # text.
+  const sourceProps = showHandle ? reorder.source(row.id) : {};
+
+  return (
+    <div
+      onClick={onSelectRow}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      {...targetProps}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: cols,
+        borderTop: isDropTarget ? '2px solid var(--brand)' : '1px solid #eef1f5',
+        marginTop: isDropTarget ? -1 : 0,
+        background: highlighted ? 'rgb(31 111 235 / 0.04)' : 'transparent',
+        opacity: isDragging ? 0.5 : 1,
+        cursor: 'pointer',
+      }}
+      className={`group transition-colors hover:bg-brand/5 ${isDragging ? 'bg-brand-soft' : ''}`}
+    >
+      {/* Row # / drag handle — keyboard-focusable for Cmd/Ctrl+↑/↓ reorder. */}
+      <div
+        {...sourceProps}
+        role="button"
+        tabIndex={0}
+        onFocus={() => setHandleFocused(true)}
+        onBlur={() => setHandleFocused(false)}
+        onKeyDown={(e) => {
+          if (!(e.metaKey || e.ctrlKey)) return;
+          if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            onMoveRowUp(row.id);
+          } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            onMoveRowDown(row.id);
+          }
+        }}
+        aria-label={`Row ${index + 1}.${dragEnabled ? ' Drag to reorder, or focus and press Cmd or Ctrl plus up or down arrows.' : ' Focus and press Cmd or Ctrl plus up or down arrows to reorder.'}`}
+        aria-keyshortcuts="Meta+ArrowUp Meta+ArrowDown Control+ArrowUp Control+ArrowDown"
+        title={dragEnabled ? 'Drag or Cmd/Ctrl + ↑/↓ to reorder' : 'Cmd/Ctrl + ↑/↓ to reorder'}
+        style={{
+          cursor: showHandle ? 'grab' : 'default',
+          outline: handleFocused ? '2px solid var(--brand)' : 'none',
+          outlineOffset: handleFocused ? -2 : 0,
+        }}
+        className="flex items-center justify-center px-2 border-r border-surface-sunk text-[11px] font-mono text-ink-soft min-h-[38px]"
+      >
+        {showHandle ? <GripHorizontal size={12} /> : index + 1}
+      </div>
+
+      {/* Field cells */}
+      {fields.map((f) => (
+        <div
+          key={f.id}
+          className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]"
         >
-          {/* Row index — 38px */}
-          <div className="flex items-center justify-center px-2 border-r border-surface-sunk">
-            <span className="text-[11px] text-ink-soft font-mono">{i + 1}</span>
-          </div>
-
-          {/* Field cells */}
-          {fields.map((f) => (
-            <div
-              key={f.id}
-              className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]"
-            >
-              <CellInput
-                field={f}
-                value={row.values[f.ref] ?? ''}
-                onChange={(v) => onEditCell(row.id, f.ref, v)}
-                onClick={(e) => e.stopPropagation()}
-              />
-            </div>
-          ))}
-
-          {/* Capacity cell — 90px */}
-          <div className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]">
-            <CapacityCell
-              capacity={row.capacity}
-              onChange={(v) => onSetCapacity(row.id, v)}
-            />
-          </div>
-
-          {/* Trailing actions — 130px, right-aligned to line up with the "+ Add field" header link */}
-          <div className="flex items-center justify-end pr-3 opacity-0 group-hover:opacity-100 transition-opacity">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveRowUp(row.id);
-              }}
-              title="Move up"
-              aria-label="Move row up"
-              className="p-1 rounded text-ink-soft hover:text-ink hover:bg-surface-raised"
-            >
-              <ChevronUp size={12} />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveRowDown(row.id);
-              }}
-              title="Move down"
-              aria-label="Move row down"
-              className="p-1 rounded text-ink-soft hover:text-ink hover:bg-surface-raised"
-            >
-              <ChevronDown size={12} />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDeleteRow(row.id);
-              }}
-              title="Remove slot"
-              aria-label="Remove slot"
-              className="p-1 rounded text-ink-soft hover:text-danger hover:bg-surface-raised"
-            >
-              <X size={12} />
-            </button>
-          </div>
+          <CellInput
+            field={f}
+            value={row.values[f.ref] ?? ''}
+            onChange={(v) => onEditCell(row.id, f.ref, v)}
+            onClick={(e) => e.stopPropagation()}
+          />
         </div>
       ))}
+
+      {/* Capacity cell — 90px */}
+      <div className="flex items-center px-0 border-r border-surface-sunk min-h-[38px]">
+        <CapacityCell
+          capacity={row.capacity}
+          onChange={(v) => onSetCapacity(row.id, v)}
+        />
+      </div>
+
+      {/* Trailing actions — always-visible left-aligned delete, no chevrons. */}
+      <div className="flex items-center justify-start pl-3 min-h-[38px]">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteRow(row.id);
+          }}
+          title="Remove slot"
+          aria-label="Remove slot"
+          className="p-1 rounded text-ink-soft hover:text-danger hover:bg-surface-raised"
+        >
+          <X size={13} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/build-grid/GridBody.tsx
+++ b/src/components/build-grid/GridBody.tsx
@@ -18,7 +18,8 @@ interface GridBodyProps {
   onDeleteRow: (rowId: string) => void;
   /** Drag reorder by index. When absent, drag handle stays hidden (e.g. grouped mode). */
   onMoveRow?: (fromIdx: number, toIdx: number) => void;
-  /** Keyboard reorder by id. Stays enabled in grouped mode (within-group). */
+  /** Keyboard reorder by id. Caller defines "up/down" — flat-adjacent in flat
+   *  mode, within-group adjacent in grouped mode (see GroupedBody). */
   onMoveRowUp: (rowId: string) => void;
   onMoveRowDown: (rowId: string) => void;
 }
@@ -118,18 +119,28 @@ function GridBodyRow({
       style={{
         display: 'grid',
         gridTemplateColumns: cols,
-        borderTop: isDropTarget ? '2px solid var(--brand)' : '1px solid #eef1f5',
-        marginTop: isDropTarget ? -1 : 0,
-        background: highlighted ? 'rgb(31 111 235 / 0.04)' : 'transparent',
+        borderBottom: '1px solid #eef1f5',
+        // Inset shadow paints the 2px brand drop indicator at the top of the
+        // target row without affecting layout, so we avoid doubling the 1px
+        // separator that the header (and grouped-mode group header) already
+        // render. `undefined` lets the className `hover:bg-brand/5` apply.
+        boxShadow: isDropTarget ? 'inset 0 2px 0 var(--brand)' : undefined,
         opacity: isDragging ? 0.5 : 1,
         cursor: 'pointer',
+        // Only set inline backgroundColor when highlighted-and-not-dragging.
+        // Leaving it unset lets `bg-brand-soft` (dragged) and `hover:bg-brand/5`
+        // (hover) take effect via className specificity.
+        ...(highlighted && !isDragging
+          ? { backgroundColor: 'rgb(31 111 235 / 0.04)' }
+          : {}),
       }}
       className={`group transition-colors hover:bg-brand/5 ${isDragging ? 'bg-brand-soft' : ''}`}
     >
-      {/* Row # / drag handle — keyboard-focusable for Cmd/Ctrl+↑/↓ reorder. */}
+      {/* Row # / drag handle — focusable for Cmd/Ctrl+↑/↓ reorder. Not a
+          button: it doesn't activate on Enter/Space, so we leave it role-less
+          and rely on aria-label + aria-keyshortcuts to describe the contract. */}
       <div
         {...sourceProps}
-        role="button"
         tabIndex={0}
         onFocus={() => setHandleFocused(true)}
         onBlur={() => setHandleFocused(false)}

--- a/src/components/build-grid/GroupedBody.test.tsx
+++ b/src/components/build-grid/GroupedBody.test.tsx
@@ -35,6 +35,7 @@ const baseHandlers = {
   onEditCell: vi.fn(),
   onSetCapacity: vi.fn(),
   onDeleteRow: vi.fn(),
+  onMoveRow: vi.fn(),
   onMoveRowUp: vi.fn(),
   onMoveRowDown: vi.fn(),
 };

--- a/src/components/build-grid/GroupedBody.tsx
+++ b/src/components/build-grid/GroupedBody.tsx
@@ -16,6 +16,8 @@ type GroupedBodyProps = {
   onEditCell: (rowId: string, fieldRef: string, value: string) => void;
   onSetCapacity: (rowId: string, capacity: number | null) => void;
   onDeleteRow: (rowId: string) => void;
+  /** Drag reorder — only passed through in flat (ungrouped) mode. */
+  onMoveRow: (fromIdx: number, toIdx: number) => void;
   onMoveRowUp: (rowId: string) => void;
   onMoveRowDown: (rowId: string) => void;
 };
@@ -47,6 +49,7 @@ export function GroupedBody({
   onEditCell,
   onSetCapacity,
   onDeleteRow,
+  onMoveRow,
   onMoveRowUp,
   onMoveRowDown,
 }: GroupedBodyProps) {
@@ -76,6 +79,7 @@ export function GroupedBody({
         onEditCell={onEditCell}
         onSetCapacity={onSetCapacity}
         onDeleteRow={onDeleteRow}
+        onMoveRow={onMoveRow}
         onMoveRowUp={onMoveRowUp}
         onMoveRowDown={onMoveRowDown}
       />

--- a/src/components/build-grid/GroupedBody.tsx
+++ b/src/components/build-grid/GroupedBody.tsx
@@ -167,8 +167,29 @@ export function GroupedBody({
                 onEditCell={onEditCell}
                 onSetCapacity={onSetCapacity}
                 onDeleteRow={onDeleteRow}
-                onMoveRowUp={onMoveRowUp}
-                onMoveRowDown={onMoveRowDown}
+                // Group-aware keyboard reorder: swap with the within-group
+                // neighbor, not the flat-array neighbor. Calls onMoveRow with
+                // flat indices so other groups' relative order is preserved.
+                onMoveRowUp={(rowId) => {
+                  const local = groupRows.findIndex((r) => r.id === rowId);
+                  if (local <= 0) return;
+                  const fromFlat = flatIndexById.get(rowId);
+                  const prev = groupRows[local - 1];
+                  if (fromFlat === undefined || !prev) return;
+                  const toFlat = flatIndexById.get(prev.id);
+                  if (toFlat === undefined) return;
+                  onMoveRow(fromFlat, toFlat);
+                }}
+                onMoveRowDown={(rowId) => {
+                  const local = groupRows.findIndex((r) => r.id === rowId);
+                  if (local < 0 || local >= groupRows.length - 1) return;
+                  const fromFlat = flatIndexById.get(rowId);
+                  const next = groupRows[local + 1];
+                  if (fromFlat === undefined || !next) return;
+                  const toFlat = flatIndexById.get(next.id);
+                  if (toFlat === undefined) return;
+                  onMoveRow(fromFlat, toFlat);
+                }}
               />
             )}
           </div>

--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -707,6 +707,137 @@ describe('useGridState moveField', () => {
 });
 
 // ---------------------------------------------------------------------------
+// useGridState moveRow (renderHook + mocked fetch)
+// ---------------------------------------------------------------------------
+
+interface InitialRowInput {
+  id: string;
+  capacity: number | null;
+  sortOrder?: number;
+  values: Record<string, unknown>;
+}
+
+function rowIdFromUrl(url: string): string | undefined {
+  return url.match(/\/api\/slots\/([^/]+)$/)?.[1];
+}
+
+function renderGridWith(initialRows: InitialRowInput[]) {
+  return renderHook(() =>
+    useGridState('sig_test', [], initialRows, defaultSettings),
+  );
+}
+
+describe('useGridState moveRow', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reorders rows and PATCHes each changed row with its new sortOrder', async () => {
+    const r1: InitialRowInput = { id: 'r1', capacity: null, sortOrder: 0, values: {} };
+    const r2: InitialRowInput = { id: 'r2', capacity: null, sortOrder: 1, values: {} };
+    const r3: InitialRowInput = { id: 'r3', capacity: null, sortOrder: 2, values: {} };
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: {} }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGridWith([r1, r2, r3]);
+    await act(async () => {
+      await result.current.moveRow(2, 0);
+    });
+
+    expect(result.current.state.rows.map((r) => r.id)).toEqual(['r3', 'r1', 'r2']);
+    expect(result.current.state.rows.map((r) => r.sortOrder)).toEqual([0, 1, 2]);
+
+    const sentPatches = new Map<string, number>();
+    for (const call of fetchMock.mock.calls) {
+      const url = String(call[0]);
+      const init = call[1] as RequestInit | undefined;
+      if (init?.method !== 'PATCH') continue;
+      const id = rowIdFromUrl(url);
+      const body = JSON.parse(String(init.body)) as { sortOrder: number };
+      if (id !== undefined) sentPatches.set(id, body.sortOrder);
+    }
+    expect(sentPatches.get('r3')).toBe(0);
+    expect(sentPatches.get('r1')).toBe(1);
+    expect(sentPatches.get('r2')).toBe(2);
+    expect(result.current.state.saveStatus).toBe('saved');
+  });
+
+  it('refetches server truth on PATCH failure', async () => {
+    const r1: InitialRowInput = { id: 'r1', capacity: null, sortOrder: 0, values: { notes: 'one' } };
+    const r2: InitialRowInput = { id: 'r2', capacity: null, sortOrder: 1, values: { notes: 'two' } };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (init?.method === 'PATCH') {
+        return jsonResponse({}, { ok: false });
+      }
+      if (url.endsWith('/slots')) {
+        return jsonResponse({
+          data: [
+            { id: 'r1', capacity: null, sortOrder: 0, values: { notes: 'one' } },
+            { id: 'r2', capacity: null, sortOrder: 1, values: { notes: 'two' } },
+          ],
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGridWith([r1, r2]);
+    await act(async () => {
+      await result.current.moveRow(0, 1);
+    });
+
+    const getCalls = fetchMock.mock.calls.filter(
+      (c) => (c[1] as RequestInit | undefined)?.method !== 'PATCH',
+    );
+    expect(getCalls.length).toBe(1);
+    expect(result.current.state.rows.map((r) => r.id)).toEqual(['r1', 'r2']);
+    expect(result.current.state.saveStatus).toBe('error');
+  });
+
+  it('falls back to snapshot when refetch also fails', async () => {
+    const r1: InitialRowInput = { id: 'r1', capacity: null, sortOrder: 0, values: {} };
+    const r2: InitialRowInput = { id: 'r2', capacity: null, sortOrder: 1, values: {} };
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}, { ok: false }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGridWith([r1, r2]);
+    await act(async () => {
+      await result.current.moveRow(0, 1);
+    });
+
+    expect(result.current.state.rows.map((r) => r.id)).toEqual(['r1', 'r2']);
+    expect(result.current.state.saveStatus).toBe('error');
+  });
+
+  it('is a no-op when fromIdx clamps to toIdx or is out of bounds', async () => {
+    const r1: InitialRowInput = { id: 'r1', capacity: null, sortOrder: 0, values: {} };
+    const r2: InitialRowInput = { id: 'r2', capacity: null, sortOrder: 1, values: {} };
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderGridWith([r1, r2]);
+
+    await act(async () => {
+      await result.current.moveRow(0, -1); // clamps to 0 — same as fromIdx
+    });
+    await act(async () => {
+      await result.current.moveRow(0, 0); // explicit no-op
+    });
+    await act(async () => {
+      await result.current.moveRow(5, 0); // out of bounds
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.state.rows.map((r) => r.id)).toEqual(['r1', 'r2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // useGridState mount-time showPreview default (viewport-aware)
 // ---------------------------------------------------------------------------
 

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -491,6 +491,62 @@ export function useGridState(
     [state.rows],
   );
 
+  // Concurrent reorders by other organizers can race; this client converges via
+  // refetch on error. Mirrors moveField — fine for v1 slot counts (<30 typical).
+  const moveRow = useCallback(
+    async (fromIdx: number, toIdx: number): Promise<void> => {
+      const previous = state.rows;
+      if (fromIdx < 0 || fromIdx >= previous.length) return;
+      const clamped = Math.max(0, Math.min(previous.length - 1, toIdx));
+      if (clamped === fromIdx) return;
+
+      const reordered = previous.slice();
+      const [moved] = reordered.splice(fromIdx, 1);
+      if (!moved) return;
+      reordered.splice(clamped, 0, moved);
+      const resequenced = reordered.map((r, i) => ({ ...r, sortOrder: i }));
+
+      dispatch({ type: 'SET_ROWS', rows: resequenced });
+      markSaving();
+      try {
+        const changed = resequenced.filter(
+          (r, i) => previous[i]?.id !== r.id || previous[i]?.sortOrder !== r.sortOrder,
+        );
+        for (const r of changed) {
+          const res = await fetch(`/api/slots/${r.id}`, {
+            method: 'PATCH',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ sortOrder: r.sortOrder }),
+          });
+          if (!res.ok) throw new Error('reorder failed');
+        }
+        markSaved();
+      } catch {
+        try {
+          const res = await fetch(`/api/signups/${signupId}/slots`);
+          if (res.ok) {
+            const envelope = (await res.json()) as {
+              data: Array<{ id: string; capacity: number | null; sortOrder: number; values: Record<string, unknown> }>;
+            };
+            const refreshed = envelope.data.map((s) => ({
+              id: s.id,
+              capacity: s.capacity,
+              sortOrder: s.sortOrder,
+              values: toStringValues(s.values ?? {}),
+            }));
+            dispatch({ type: 'SET_ROWS', rows: refreshed });
+          } else {
+            dispatch({ type: 'SET_ROWS', rows: previous });
+          }
+        } catch {
+          dispatch({ type: 'SET_ROWS', rows: previous });
+        }
+        markError();
+      }
+    },
+    [signupId, state.rows],
+  );
+
   const moveRowDown = useCallback(
     async (rowId: string): Promise<void> => {
       const idx = state.rows.findIndex((r) => r.id === rowId);
@@ -674,6 +730,7 @@ export function useGridState(
     deleteRow,
     moveRowUp,
     moveRowDown,
+    moveRow,
     editCell,
     setCapacity,
     setPreviewRow,


### PR DESCRIPTION
Stacked on #114 (column drag/drop). Top of the Edit Sheet Option A series.

## Summary
- **Row drag-to-reorder** via the `#` cell (cursor: grab). Swaps to `GripHorizontal` on hover/focus. 2px brand top-border drop indicator; brand-soft fill on the dragged row.
- **Keyboard reorder** preserved on the focused `#` cell: Cmd/Ctrl+↑/↓.
- **Trailing cell** drops the two chevron move buttons. Just the `X` delete now — left-aligned, always visible (no opacity-on-hover, matching the design's "delete is always visible on every row").
- **`moveRow(fromIdx, toIdx)`** added to `useGridState`. Resequence + PATCH each changed row + refetch-on-error, mirroring `moveField` at `useGridState.ts:345`. O(n) PATCHes per drag — fine at v1 slot counts.
- **Grouped mode** disables drag (`onMoveRow` not threaded into the inner `GridBody`). Within-group Cmd/Ctrl+↑/↓ keyboard reorder still works. Cross-group drag would mutate the group-field value, a distinct mutation — deferred.
- Row `onClick` → `onSelectRow` preserved; the `#` cell click still selects the row (browsers suppress the synthetic `click` after a successful drop, so the paths don't collide).

## Test plan
- [x] `pnpm test src/components/build-grid` — 128 tests pass. 4 new `moveRow` cases (happy path, refetch on error, refetch-also-fails fallback, no-op on clamp/out-of-bounds).
- [x] `pnpm test` — full 436-test unit suite green.
- [x] `pnpm typecheck` clean.
- [x] `pnpm exec eslint src/components/build-grid/{GridBody,GroupedBody,BuildGrid,useGridState}*` clean.
- [ ] Manual smoke in `pnpm dev`: drag a row via the `#` cell to a different position, focus a `#` cell and press Cmd/Ctrl+↑/↓, click the X to delete, verify grouped mode shows numbers (no grip swap) but still supports keyboard reorder within each group. Pending reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)