### PR TITLE
style(signup-header): align actions + public link in equal-width grid

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/layout.tsx
+++ b/src/app/app/(chrome)/signups/[id]/layout.tsx
@@ -7,6 +7,7 @@ import { countCommitmentsForSignup } from '@/services/commitments';
 import { publicSignupUrl } from '@/lib/links';
 import { SignupHeader } from '@/components/signup/SignupHeader';
 import { TabsNav } from '@/components/signup/TabsNav';
+import type { SignupStatus } from '@/schemas/signups';
 import { closeAction, publishAction } from './actions';
 
 type LayoutProps = {
@@ -48,7 +49,7 @@ export default async function SignupDetailLayout({ children, params }: LayoutPro
         signupId={id}
         title={sig.title}
         description={sig.description ?? null}
-        status={sig.status}
+        status={sig.status as SignupStatus}
         publicUrl={publicSignupUrl(sig.slug)}
         publishAction={publishAction.bind(null, id)}
         closeAction={closeAction.bind(null, id)}

--- a/src/components/PublicLinkChip.tsx
+++ b/src/components/PublicLinkChip.tsx
@@ -6,9 +6,10 @@ import { Check, Copy, ExternalLink } from 'lucide-react';
 interface PublicLinkChipProps {
   url: string;
   compact?: boolean;
+  className?: string;
 }
 
-export function PublicLinkChip({ url, compact = false }: PublicLinkChipProps) {
+export function PublicLinkChip({ url, compact = false, className = '' }: PublicLinkChipProps) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -34,7 +35,9 @@ export function PublicLinkChip({ url, compact = false }: PublicLinkChipProps) {
   }
 
   return (
-    <div className="border-surface-sunk bg-surface-raised text-ink flex w-full max-w-full items-center rounded-full border py-0.5 pr-1 pl-3 text-[13px]">
+    <div
+      className={`border-surface-sunk bg-surface-raised text-ink inline-flex max-w-full items-center rounded-full border py-0.5 pr-1 pl-3 text-[13px] ${className}`}
+    >
       {!compact ? (
         <span className="text-ink-muted border-surface-sunk mr-2 border-r pr-2 text-xs font-medium">
           Public link

--- a/src/components/PublicLinkChip.tsx
+++ b/src/components/PublicLinkChip.tsx
@@ -34,7 +34,7 @@ export function PublicLinkChip({ url, compact = false }: PublicLinkChipProps) {
   }
 
   return (
-    <div className="border-surface-sunk bg-surface-raised text-ink inline-flex max-w-full items-center rounded-full border py-0.5 pr-1 pl-3 text-[13px]">
+    <div className="border-surface-sunk bg-surface-raised text-ink flex w-full max-w-full items-center rounded-full border py-0.5 pr-1 pl-3 text-[13px]">
       {!compact ? (
         <span className="text-ink-muted border-surface-sunk mr-2 border-r pr-2 text-xs font-medium">
           Public link

--- a/src/components/signup/MobileMoreMenuSheet.tsx
+++ b/src/components/signup/MobileMoreMenuSheet.tsx
@@ -4,12 +4,13 @@ import Link from 'next/link';
 import { ChevronRight, Download, Send, XCircle } from 'lucide-react';
 import { BottomSheet } from '@/components/ui/BottomSheet';
 import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
+import type { SignupStatus } from '@/schemas/signups';
 
 type MobileMoreMenuSheetProps = {
   open: boolean;
   onClose: () => void;
   signupId: string;
-  status: string;
+  status: SignupStatus;
   title: string;
   publishAction: () => void | Promise<void>;
   closeAction: () => void | Promise<void>;

--- a/src/components/signup/MobileSignupHeader.tsx
+++ b/src/components/signup/MobileSignupHeader.tsx
@@ -4,13 +4,14 @@ import { useState } from 'react';
 import { MoreHorizontal } from 'lucide-react';
 import { PublicLinkChip } from '@/components/PublicLinkChip';
 import { StatusPill } from '@/components/status-pill';
+import type { SignupStatus } from '@/schemas/signups';
 import { MobileMoreMenuSheet } from './MobileMoreMenuSheet';
 
 interface MobileSignupHeaderProps {
   signupId: string;
   title: string;
   description: string | null;
-  status: string;
+  status: SignupStatus;
   publicUrl: string;
   publishAction: () => void | Promise<void>;
   closeAction: () => void | Promise<void>;

--- a/src/components/signup/SignupHeader.tsx
+++ b/src/components/signup/SignupHeader.tsx
@@ -26,6 +26,10 @@ export function SignupHeader({
 }: SignupHeaderProps) {
   const previewHref = `/app/signups/${signupId}/preview`;
   const exportHref = `/api/signups/${signupId}/export.csv`;
+  const hasActionButton = status === 'draft' || status === 'open';
+  const buttonCount = hasActionButton ? 3 : 2;
+  const gridColsClass = buttonCount === 3 ? 'grid-cols-3' : 'grid-cols-2';
+  const colSpanClass = buttonCount === 3 ? 'col-span-3' : 'col-span-2';
 
   return (
     <>
@@ -41,58 +45,58 @@ export function SignupHeader({
         />
       </div>
       <header className="hidden space-y-3 md:block">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-x-8 gap-y-4">
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex min-h-[1.875rem] flex-wrap items-center gap-3">
             <h1 className="truncate text-2xl font-semibold tracking-tight">{title}</h1>
             <StatusPill status={status} />
           </div>
-          <div className="mt-3">
-            <PublicLinkChip url={publicUrl} />
-          </div>
+          {description ? (
+            <p className="text-ink-muted max-w-full text-sm leading-relaxed">{description}</p>
+          ) : null}
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        <div className={`grid w-full max-w-full shrink-0 ${gridColsClass} gap-x-2 gap-y-3 sm:w-auto sm:max-w-sm`}>
           <Link
             href={previewHref}
             target="_blank"
             rel="noreferrer"
-            className="hover:bg-surface-raised inline-flex items-center gap-2 rounded-lg border border-surface-sunk px-4 py-2 text-sm font-medium transition"
+            className="hover:bg-surface-raised inline-flex w-full items-center justify-center gap-2 rounded-lg border border-surface-sunk px-3 py-1.5 text-xs font-medium transition"
           >
-            <Eye size={16} aria-hidden="true" />
+            <Eye size={14} aria-hidden="true" />
             Preview
           </Link>
           <Link
             href={exportHref}
-            className="hover:bg-surface-raised inline-flex items-center gap-2 rounded-lg border border-surface-sunk px-4 py-2 text-sm font-medium transition"
+            className="hover:bg-surface-raised inline-flex w-full items-center justify-center gap-2 rounded-lg border border-surface-sunk px-3 py-1.5 text-xs font-medium transition"
           >
-            <Download size={16} aria-hidden="true" />
+            <Download size={14} aria-hidden="true" />
             Export
           </Link>
           {status === 'draft' ? (
-            <form action={publishAction}>
+            <form action={publishAction} className="w-full">
               <AsyncSubmitButton
                 loadingLabel="Publishing…"
-                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
+                className="bg-brand inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
               >
                 Publish
               </AsyncSubmitButton>
             </form>
           ) : null}
           {status === 'open' ? (
-            <form action={closeAction}>
+            <form action={closeAction} className="w-full">
               <AsyncSubmitButton
                 loadingLabel="Closing…"
-                className="bg-brand inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
+                className="bg-brand inline-flex w-full items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:brightness-90"
               >
                 Close signup
               </AsyncSubmitButton>
             </form>
           ) : null}
+          <div className={`${colSpanClass} min-w-0`}>
+            <PublicLinkChip url={publicUrl} />
+          </div>
         </div>
       </div>
-      {description ? (
-        <p className="text-ink-muted max-w-2xl text-sm leading-relaxed">{description}</p>
-      ) : null}
       </header>
     </>
   );

--- a/src/components/signup/SignupHeader.tsx
+++ b/src/components/signup/SignupHeader.tsx
@@ -3,13 +3,14 @@ import { Download, Eye } from 'lucide-react';
 import { PublicLinkChip } from '@/components/PublicLinkChip';
 import { StatusPill } from '@/components/status-pill';
 import { AsyncSubmitButton } from '@/components/ui/async-submit-button';
+import type { SignupStatus } from '@/schemas/signups';
 import { MobileSignupHeader } from './MobileSignupHeader';
 
 interface SignupHeaderProps {
   signupId: string;
   title: string;
   description: string | null;
-  status: string;
+  status: SignupStatus;
   publicUrl: string;
   publishAction: () => void | Promise<void>;
   closeAction: () => void | Promise<void>;
@@ -93,7 +94,7 @@ export function SignupHeader({
             </form>
           ) : null}
           <div className={`${colSpanClass} min-w-0`}>
-            <PublicLinkChip url={publicUrl} />
+            <PublicLinkChip url={publicUrl} className="flex w-full" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Move the public link chip beneath the action buttons on desktop and lock both rows into a shared grid so buttons are equal-width and the chip matches their total width
- Constrain the right column (`max-w-sm`) so the long URL truncates inside the chip instead of pushing the description; description now lives in the left flex-1 column and aligns at the top with the chip
- Slim down the action buttons (`px-3 py-1.5 text-xs`, 14px icons) so the cluster feels lighter while staying aligned

## Test plan
- [x] Open a draft signup (e.g. `/app/signups/<id>`) — Preview / Export / Publish are equal width, chip below spans the same width, description top aligns with chip top
- [x] Open an open signup — Preview / Export / Close signup still equal width
- [x] Open a closed signup — falls back to 2-column grid (Preview / Export) and the chip spans both
- [x] Resize narrow — right column wraps to a full-width row, no overlap with the description
- [x] Confirm mobile header (`md:hidden`) still renders the chip correctly (full-width via flex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)