### PR TITLE
feat(build-grid): allow grouping slots by list (enum) fields

### DIFF
--- a/src/components/build-grid/Toolbar.test.tsx
+++ b/src/components/build-grid/Toolbar.test.tsx
@@ -2,7 +2,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Toolbar } from './Toolbar';
 import type { GridField } from './useGridState';
 
@@ -14,6 +14,14 @@ const sampleFields: GridField[] = [
     type: 'date',
     config: { fieldType: 'date' },
     sortOrder: 0,
+  },
+  {
+    id: 'sf_2',
+    ref: 'r2',
+    name: 'Station',
+    type: 'enum',
+    config: { fieldType: 'enum', choices: ['A', 'B'] },
+    sortOrder: 1,
   },
 ];
 
@@ -49,5 +57,24 @@ describe('<Toolbar />', () => {
 
     expect(screen.getByText('Group by')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show live preview' })).toBeInTheDocument();
+  });
+
+  it('offers enum (list) fields in the Group-by menu', () => {
+    render(
+      <Toolbar
+        fields={sampleFields}
+        rows={[]}
+        groupByFieldRef={null}
+        onGroupByChange={() => {}}
+        showPreview={false}
+        onTogglePreview={() => {}}
+        saveStatus="idle"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'None' }));
+
+    expect(screen.getByRole('menuitemradio', { name: /Station/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /Date/ })).toBeInTheDocument();
   });
 });

--- a/src/components/build-grid/Toolbar.tsx
+++ b/src/components/build-grid/Toolbar.tsx
@@ -28,7 +28,9 @@ export function Toolbar({
   const [groupByOpen, setGroupByOpen] = useState(false);
   const groupByRef = useRef<HTMLDivElement>(null);
 
-  const groupableFields = fields.filter((f) => f.type === 'date' || f.type === 'text');
+  const groupableFields = fields.filter(
+    (f) => f.type === 'date' || f.type === 'text' || f.type === 'enum',
+  );
   const activeField = groupByFieldRef
     ? fields.find((f) => f.ref === groupByFieldRef)
     : null;
@@ -102,7 +104,7 @@ export function Toolbar({
             </button>
             {groupableFields.length === 0 ? (
               <div className="px-2.5 py-2 text-[11px] text-ink-muted leading-snug">
-                Add a date or text field to group slots.
+                Add a date, text, or list field to group slots.
               </div>
             ) : (
               groupableFields.map((f) => {

--- a/src/components/build-grid/mobile/MobileGroupByControl.tsx
+++ b/src/components/build-grid/mobile/MobileGroupByControl.tsx
@@ -15,7 +15,9 @@ export function MobileGroupByControl({ fields, value, onChange }: MobileGroupByC
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const groupable = fields.filter((f) => f.type === 'date' || f.type === 'text');
+  const groupable = fields.filter(
+    (f) => f.type === 'date' || f.type === 'text' || f.type === 'enum',
+  );
   const active = value ? fields.find((f) => f.ref === value) ?? null : null;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- The Build-tab Group-by dropdown only offered **Date** and **Text** fields, even though the renderer (`GroupedBody`) is type-agnostic and Magic Compose's prompt explicitly encourages drafting signups around a named-dimension enum to group on (`prompt.ts:92-96`). The result: "List" looks like a first-class field type in the editor but couldn't be used for grouping.
- Add `'enum'` to the groupable filter in `Toolbar.tsx` (desktop) and `MobileGroupByControl.tsx` (mobile); update the empty-state copy to mention list; extend `Toolbar.test.tsx` to assert enum fields appear in the menu.
- Not actually a regression — the date/text-only allowlist has been in place since the original build-grid PR (#65, `8fbcd7f`). Renderer untouched.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (441/441)
- [x] Manual smoke: add a List field with 2-3 choices, set values on some slots, open the Group-by pill, pick the List field, confirm body re-sections by choice
- [x] Mobile viewport: same flow via the bottom-sheet `MobileGroupByControl`

Note: enum groups currently sort alphabetically (via `localeCompare` in `GroupedBody.tsx:105-109`), not in `config.choices` order. Acceptable for v1 and matches today's text-field behaviour; choice-order sort is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)