### PR TITLE
feat(build-wysiwyg): PR 2 — FieldsPopover schema modal

### DIFF
--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useGridState } from '../build-grid/useGridState';
 import { Editable } from './Editable';
 import { EditingRail } from './EditingRail';
+import { FieldsPopover } from './FieldsPopover';
 import type { SignupMeta } from '../build-grid/BuildGrid';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
 import type { SignupSettings } from '@/schemas/signups';
@@ -35,7 +36,15 @@ export function BuildWysiwyg({
   initialSlots,
   initialSettings,
 }: BuildWysiwygProps) {
-  const { state, updateSignupMeta } = useGridState(
+  const {
+    state,
+    updateSignupMeta,
+    addField,
+    updateField,
+    deleteField,
+    moveField,
+    setGroupBy,
+  } = useGridState(
     signupId,
     initialFields,
     initialSlots.map((s) => ({
@@ -84,7 +93,7 @@ export function BuildWysiwyg({
             />
           </div>
 
-          {/* Slot groups + Fields modal land in PR 2 / PR 3. */}
+          {/* Slot list lands in PR 3. */}
           <div className="mt-6 rounded-lg border border-dashed border-surface-sunk bg-surface-raised p-6 text-center text-xs text-ink-soft">
             <p>
               Slot list lands in PR 3.
@@ -94,6 +103,18 @@ export function BuildWysiwyg({
           </div>
         </div>
       </div>
+
+      <FieldsPopover
+        open={fieldsOpen}
+        onOpenChange={setFieldsOpen}
+        fields={state.fields}
+        groupByFieldRef={state.groupByFieldRef}
+        onAddField={(type, name, config) => { void addField(type, name, config); }}
+        onUpdateField={(fieldId, patch) => { void updateField(fieldId, patch); }}
+        onDeleteField={(fieldId) => { void deleteField(fieldId); }}
+        onMoveField={(fieldId, toIdx) => { void moveField(fieldId, toIdx); }}
+        onGroupByChange={(ref) => { void setGroupBy(ref); }}
+      />
     </div>
   );
 }

--- a/src/components/build-wysiwyg/FieldsPopover.test.tsx
+++ b/src/components/build-wysiwyg/FieldsPopover.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FieldsPopover } from './FieldsPopover';
+import type { GridField } from '../build-grid/useGridState';
+
+function makeField(overrides: Partial<GridField> = {}): GridField {
+  return {
+    id: 'f1',
+    ref: 'date',
+    name: 'Date',
+    type: 'date',
+    config: { fieldType: 'date' },
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+type RenderProps = {
+  fields?: GridField[];
+  groupByFieldRef?: string | null;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onAddField?: ReturnType<typeof vi.fn>;
+  onUpdateField?: ReturnType<typeof vi.fn>;
+  onDeleteField?: ReturnType<typeof vi.fn>;
+  onMoveField?: ReturnType<typeof vi.fn>;
+  onGroupByChange?: ReturnType<typeof vi.fn>;
+};
+
+function renderPopover(overrides: RenderProps = {}) {
+  const onOpenChange = overrides.onOpenChange ?? vi.fn();
+  const onAddField = overrides.onAddField ?? vi.fn();
+  const onUpdateField = overrides.onUpdateField ?? vi.fn();
+  const onDeleteField = overrides.onDeleteField ?? vi.fn();
+  const onMoveField = overrides.onMoveField ?? vi.fn();
+  const onGroupByChange = overrides.onGroupByChange ?? vi.fn();
+  const utils = render(
+    <FieldsPopover
+      open={overrides.open ?? true}
+      onOpenChange={onOpenChange}
+      fields={overrides.fields ?? [makeField()]}
+      groupByFieldRef={overrides.groupByFieldRef ?? null}
+      onAddField={onAddField}
+      onUpdateField={onUpdateField}
+      onDeleteField={onDeleteField}
+      onMoveField={onMoveField}
+      onGroupByChange={onGroupByChange}
+    />,
+  );
+  return { ...utils, onOpenChange, onAddField, onUpdateField, onDeleteField, onMoveField, onGroupByChange };
+}
+
+beforeEach(() => {
+  // Radix Dialog reads HTMLElement.prototype.hasPointerCapture which jsdom doesn't ship.
+  if (!('hasPointerCapture' in HTMLElement.prototype)) {
+    Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+      value: () => false,
+      configurable: true,
+    });
+  }
+});
+
+describe('FieldsPopover', () => {
+  it('renders a dialog titled "Fields · N" when open', () => {
+    renderPopover({ fields: [makeField({ id: 'a' }), makeField({ id: 'b', ref: 'name', name: 'Name' })] });
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(screen.getByText('Fields · 2')).toBeTruthy();
+  });
+
+  it('renders nothing when closed', () => {
+    renderPopover({ open: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('lists each field with its name and type label', () => {
+    renderPopover({
+      fields: [
+        makeField({ id: 'f1', name: 'StartDate', type: 'date', ref: 'startdate', config: { fieldType: 'date' } }),
+        makeField({ id: 'f2', name: 'Shift', type: 'time', ref: 'shift', config: { fieldType: 'time' } }),
+      ],
+    });
+    expect(screen.getByRole('button', { name: 'StartDate' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Shift' })).toBeTruthy();
+    // Type-label badges
+    expect(screen.getByText('Date')).toBeTruthy();
+    expect(screen.getByText('Time')).toBeTruthy();
+  });
+
+  it('reports an enum field with its choice count', () => {
+    renderPopover({
+      fields: [
+        makeField({
+          id: 'e1',
+          name: 'Course',
+          type: 'enum',
+          ref: 'course',
+          config: { fieldType: 'enum', choices: ['Main', 'Side', 'Dessert'] },
+        }),
+      ],
+    });
+    expect(screen.getByText('List · 3')).toBeTruthy();
+  });
+
+  it('Add field swaps to the create form', () => {
+    renderPopover();
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    expect(screen.getByText('New field')).toBeTruthy();
+    expect(screen.queryByText(/^Fields ·/)).toBeNull();
+  });
+
+  it('Cancel from the create form returns to the list', () => {
+    renderPopover();
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.getByText(/Fields · 1/)).toBeTruthy();
+  });
+
+  it('saving from the create form calls onAddField and returns to the list', () => {
+    const { onAddField } = renderPopover();
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    fireEvent.change(screen.getByLabelText('Field name'), { target: { value: 'Teacher' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Add field$/ }));
+    expect(onAddField).toHaveBeenCalledWith('text', 'Teacher', expect.objectContaining({ fieldType: 'text' }));
+    expect(screen.getByText(/Fields · 1/)).toBeTruthy();
+  });
+
+  it('clicking a field name opens the edit form for that field', () => {
+    const field = makeField({ id: 'x', name: 'Subject', type: 'text', ref: 'subject', config: { fieldType: 'text', maxLength: 200 } });
+    renderPopover({ fields: [field] });
+    fireEvent.click(screen.getByRole('button', { name: 'Subject' }));
+    expect(screen.getByText('Edit field')).toBeTruthy();
+    expect((screen.getByLabelText('Field name') as HTMLInputElement).value).toBe('Subject');
+  });
+
+  it('deleting a field via the row X calls onDeleteField', () => {
+    const field = makeField({ id: 'x', name: 'Subject' });
+    const { onDeleteField } = renderPopover({ fields: [field] });
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Subject' }));
+    expect(onDeleteField).toHaveBeenCalledWith('x');
+  });
+
+  it('group-by picker offers each compatible field and "Don\u2019t group"', async () => {
+    renderPopover({
+      fields: [
+        makeField({ id: 'd', name: 'StartDate', type: 'date', ref: 'startdate' }),
+        makeField({ id: 't', name: 'Shift', type: 'time', ref: 'shift', config: { fieldType: 'time' } }),
+        makeField({ id: 'e', name: 'Course', type: 'enum', ref: 'course', config: { fieldType: 'enum', choices: [] } }),
+      ],
+    });
+    // The trigger button's name matches the current selection — "Don't group" by default.
+    const trigger = screen.getByRole('button', { name: /Don.t group/ });
+    fireEvent.click(trigger);
+    const listbox = await waitFor(() => screen.getByRole('listbox', { name: 'Group slots by' }));
+    const optLabels = Array.from(listbox.querySelectorAll('[role="option"]')).map((o) =>
+      o.textContent?.replace(/\s+/g, ' ').trim(),
+    );
+    // Don't group always rendered as the first option.
+    expect(optLabels.some((l) => l && /Don.t group/.test(l))).toBe(true);
+    expect(optLabels).toContain('StartDate');
+    expect(optLabels).toContain('Course');
+    // Time is intentionally excluded.
+    expect(optLabels).not.toContain('Shift');
+  });
+
+  it('picking a group-by option calls onGroupByChange with the field ref', async () => {
+    const { onGroupByChange } = renderPopover({
+      fields: [makeField({ id: 'd', name: 'StartDate', type: 'date', ref: 'startdate' })],
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Don.t group/ }));
+    const dateOption = await waitFor(() => screen.getByRole('option', { name: 'StartDate' }));
+    fireEvent.click(dateOption);
+    expect(onGroupByChange).toHaveBeenCalledWith('startdate');
+  });
+
+  it('resets to the list view when reopened after a create form was open', () => {
+    const { rerender, onAddField } = renderPopover();
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    expect(screen.getByText('New field')).toBeTruthy();
+    // Simulate close then re-open from the parent.
+    rerender(
+      <FieldsPopover
+        open={false}
+        onOpenChange={vi.fn()}
+        fields={[makeField()]}
+        groupByFieldRef={null}
+        onAddField={onAddField}
+        onUpdateField={vi.fn()}
+        onDeleteField={vi.fn()}
+        onMoveField={vi.fn()}
+        onGroupByChange={vi.fn()}
+      />,
+    );
+    rerender(
+      <FieldsPopover
+        open
+        onOpenChange={vi.fn()}
+        fields={[makeField()]}
+        groupByFieldRef={null}
+        onAddField={onAddField}
+        onUpdateField={vi.fn()}
+        onDeleteField={vi.fn()}
+        onMoveField={vi.fn()}
+        onGroupByChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('New field')).toBeNull();
+    expect(screen.getByText(/Fields · 1/)).toBeTruthy();
+  });
+});

--- a/src/components/build-wysiwyg/FieldsPopover.tsx
+++ b/src/components/build-wysiwyg/FieldsPopover.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { ChevronDown, GripVertical, List, Plus, X } from 'lucide-react';
+import { FIELD_TYPE_META } from '../build-grid/fieldTypes';
+import { useReorderable } from '../build-grid/useReorderable';
+import type { GridField } from '../build-grid/useGridState';
+import type { FieldType, SlotFieldConfig } from '@/schemas/slot-fields';
+import { InlineFieldForm, type InlineFieldFormMode } from './InlineFieldForm';
+
+type FieldsPopoverProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  fields: GridField[];
+  groupByFieldRef: string | null;
+  onAddField: (type: FieldType, name: string, config: SlotFieldConfig) => void;
+  onUpdateField: (fieldId: string, patch: { name?: string; type?: FieldType; config?: SlotFieldConfig }) => void;
+  onDeleteField: (fieldId: string) => void;
+  onMoveField: (fieldId: string, toIdx: number) => void;
+  onGroupByChange: (ref: string | null) => void;
+};
+
+export function FieldsPopover({
+  open,
+  onOpenChange,
+  fields,
+  groupByFieldRef,
+  onAddField,
+  onUpdateField,
+  onDeleteField,
+  onMoveField,
+  onGroupByChange,
+}: FieldsPopoverProps) {
+  // null = list view; otherwise inline-edit view (create or edit existing).
+  const [formMode, setFormMode] = useState<InlineFieldFormMode | null>(null);
+
+  // Reset back to the list view whenever the modal is closed/reopened so a
+  // half-finished create state doesn't leak across mounts.
+  useEffect(() => {
+    if (!open) setFormMode(null);
+  }, [open]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-ink/30 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          aria-label="Fields"
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-[10vh] z-50 w-[420px] max-w-[calc(100%-2rem)] max-h-[80vh] -translate-x-1/2 overflow-y-auto rounded-xl border border-surface-sunk bg-white p-4 shadow-card focus:outline-none"
+        >
+          <FieldsPopoverHeader
+            title={
+              formMode?.mode === 'edit'
+                ? 'Edit field'
+                : formMode?.mode === 'create'
+                  ? 'New field'
+                  : `Fields · ${fields.length}`
+            }
+          />
+
+          {formMode ? (
+            <InlineFieldForm
+              formMode={formMode}
+              onCancel={() => setFormMode(null)}
+              onSave={({ type, name, config }) => {
+                if (formMode.mode === 'edit') {
+                  onUpdateField(formMode.field.id, { type, name, config });
+                } else {
+                  onAddField(type, name, config);
+                }
+                setFormMode(null);
+              }}
+              onDelete={
+                formMode.mode === 'edit'
+                  ? () => {
+                      onDeleteField(formMode.field.id);
+                      setFormMode(null);
+                    }
+                  : undefined
+              }
+            />
+          ) : (
+            <FieldsListView
+              fields={fields}
+              groupByFieldRef={groupByFieldRef}
+              onDelete={onDeleteField}
+              onMoveField={onMoveField}
+              onGroupByChange={onGroupByChange}
+              onEdit={(field) => setFormMode({ mode: 'edit', field })}
+              onStartCreate={() => setFormMode({ mode: 'create' })}
+            />
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function FieldsPopoverHeader({ title }: { title: string }) {
+  return (
+    <div className="mb-3.5 flex items-center justify-between">
+      <Dialog.Title className="text-[11px] font-bold uppercase tracking-[0.06em] text-ink-soft">
+        {title}
+      </Dialog.Title>
+      <Dialog.Close asChild>
+        <button
+          type="button"
+          aria-label="Close"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-md border-none bg-transparent text-ink-soft hover:bg-surface-raised hover:text-ink"
+        >
+          <X size={13} />
+        </button>
+      </Dialog.Close>
+    </div>
+  );
+}
+
+type FieldsListViewProps = {
+  fields: GridField[];
+  groupByFieldRef: string | null;
+  onDelete: (fieldId: string) => void;
+  onMoveField: (fieldId: string, toIdx: number) => void;
+  onGroupByChange: (ref: string | null) => void;
+  onEdit: (field: GridField) => void;
+  onStartCreate: () => void;
+};
+
+function FieldsListView({
+  fields,
+  groupByFieldRef,
+  onDelete,
+  onMoveField,
+  onGroupByChange,
+  onEdit,
+  onStartCreate,
+}: FieldsListViewProps) {
+  const reorder = useReorderable({
+    items: fields,
+    onReorder: (fromIdx, toIdx) => {
+      const field = fields[fromIdx];
+      if (!field) return;
+      onMoveField(field.id, toIdx);
+    },
+  });
+
+  return (
+    <>
+      <div className="mb-3 flex items-center justify-between gap-2.5 border-b border-surface-sunk pb-3">
+        <span className="text-xs font-medium text-ink-muted">Group slots by</span>
+        <GroupByInlinePicker
+          fields={fields}
+          value={groupByFieldRef}
+          onChange={onGroupByChange}
+        />
+      </div>
+
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-ink-soft">
+          Drag to reorder
+        </span>
+        <button
+          type="button"
+          onClick={onStartCreate}
+          className="inline-flex items-center gap-1 rounded-md border border-surface-sunk bg-white px-2.5 py-1 text-xs font-medium text-ink hover:bg-surface-raised"
+        >
+          <Plus size={11} />
+          Add field
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {fields.length === 0 && (
+          <div className="rounded-md bg-surface-raised px-3 py-3 text-center text-[11px] italic text-ink-soft">
+            No fields yet — add one to get started.
+          </div>
+        )}
+        {fields.map((f) => {
+          const TypeIcon = FIELD_TYPE_META[f.type].icon;
+          const isDragging = reorder.dragId === f.id;
+          const isDropTarget = reorder.overId === f.id && reorder.dragId && reorder.dragId !== f.id;
+          const enumChoiceCount =
+            f.type === 'enum' && f.config.fieldType === 'enum' ? f.config.choices.length : 0;
+          return (
+            <div
+              key={f.id}
+              {...reorder.target(f.id)}
+              data-testid={`fields-row-${f.id}`}
+              className={
+                'flex items-center gap-1.5 rounded-md px-2 py-2 transition-colors duration-180 ' +
+                (isDragging
+                  ? 'bg-brand-soft opacity-50'
+                  : isDropTarget
+                    ? 'border border-brand bg-surface-raised'
+                    : 'bg-surface-raised border border-transparent')
+              }
+            >
+              <span
+                {...reorder.source(f.id)}
+                role="button"
+                aria-label={`Drag ${f.name} to reorder`}
+                tabIndex={0}
+                className="inline-flex cursor-grab items-center justify-center p-1 text-ink-soft hover:text-ink"
+              >
+                <GripVertical size={11} />
+              </span>
+              <span className="inline-flex text-brand">
+                <TypeIcon size={13} />
+              </span>
+              <button
+                type="button"
+                onClick={() => onEdit(f)}
+                className="flex-1 truncate text-left text-[13px] font-medium text-ink border-none bg-transparent cursor-pointer p-0"
+              >
+                {f.name}
+              </button>
+              <span className="text-[11px] text-ink-soft">
+                {enumChoiceCount > 0
+                  ? `${FIELD_TYPE_META[f.type].label} · ${enumChoiceCount}`
+                  : FIELD_TYPE_META[f.type].label}
+              </span>
+              <button
+                type="button"
+                onClick={() => onDelete(f.id)}
+                aria-label={`Delete ${f.name}`}
+                className="inline-flex h-5 w-5 items-center justify-center rounded border-none bg-transparent text-ink-soft hover:text-danger"
+              >
+                <X size={11} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+type GroupByInlinePickerProps = {
+  fields: GridField[];
+  value: string | null;
+  onChange: (ref: string | null) => void;
+};
+
+function GroupByInlinePicker({ fields, value, onChange }: GroupByInlinePickerProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Time fields are intentionally excluded — every unique HH:MM would become
+  // its own group, which defeats the purpose. Mirrors the grid's Toolbar.
+  const groupable = useMemo(
+    () => fields.filter((f) => f.type === 'date' || f.type === 'enum' || f.type === 'text'),
+    [fields],
+  );
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        menuRef.current && !menuRef.current.contains(target) &&
+        triggerRef.current && !triggerRef.current.contains(target)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const activeField = value ? fields.find((f) => f.ref === value) : null;
+  const label =
+    value === null
+      ? 'Don\u2019t group'
+      : activeField
+        ? activeField.name
+        : 'Don\u2019t group';
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1 rounded-md border border-surface-sunk bg-white px-2 py-1 text-xs font-medium text-ink hover:bg-surface-raised"
+      >
+        {label}
+        <ChevronDown size={11} />
+      </button>
+      {open && (
+        <div
+          ref={menuRef}
+          role="listbox"
+          aria-label="Group slots by"
+          className="absolute right-0 top-[calc(100%+4px)] z-50 min-w-[200px] rounded-lg border border-surface-sunk bg-white p-1 shadow-card"
+        >
+          <PickItem
+            active={value === null}
+            icon={<List size={12} />}
+            label={'Don\u2019t group'}
+            onClick={() => { onChange(null); setOpen(false); }}
+          />
+          {groupable.length > 0 && <div className="my-1 h-px bg-surface-sunk" />}
+          {groupable.map((f) => {
+            const TypeIcon = FIELD_TYPE_META[f.type].icon;
+            return (
+              <PickItem
+                key={f.id}
+                active={value === f.ref}
+                icon={<TypeIcon size={12} />}
+                label={f.name}
+                onClick={() => { onChange(f.ref); setOpen(false); }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PickItem({
+  active,
+  icon,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      onClick={onClick}
+      className={
+        'flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left text-xs font-medium cursor-pointer ' +
+        (active ? 'bg-brand-soft text-brand' : 'bg-transparent text-ink hover:bg-surface-raised')
+      }
+    >
+      <span className="inline-flex">{icon}</span>
+      <span className="flex-1">{label}</span>
+    </button>
+  );
+}
+

--- a/src/components/build-wysiwyg/InlineFieldForm.test.tsx
+++ b/src/components/build-wysiwyg/InlineFieldForm.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineFieldForm } from './InlineFieldForm';
+import type { GridField } from '../build-grid/useGridState';
+
+function makeField(overrides: Partial<GridField> = {}): GridField {
+  return {
+    id: 'f1',
+    ref: 'name',
+    name: 'Name',
+    type: 'text',
+    config: { fieldType: 'text', maxLength: 200 },
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+describe('InlineFieldForm — create mode', () => {
+  it('focuses the name input on mount', () => {
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('Field name') as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('renders a Back button (parent modal title provides the heading)', () => {
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Back to fields list' })).toBeTruthy();
+  });
+
+  it('does not render a delete affordance', () => {
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('Remove field')).toBeNull();
+  });
+
+  it('toggles type via the type buttons', () => {
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const enumBtn = screen.getByRole('button', { name: 'List' });
+    fireEvent.click(enumBtn);
+    expect(enumBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('saves with trimmed name and the selected type config', () => {
+    const onSave = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('Field name');
+    fireEvent.change(input, { target: { value: '  Teacher  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'List' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    expect(onSave).toHaveBeenCalledWith({
+      type: 'enum',
+      name: 'Teacher',
+      config: { fieldType: 'enum', choices: [] },
+    });
+  });
+
+  it('falls back to "Untitled" when the name is empty', () => {
+    const onSave = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add field' }));
+    expect(onSave.mock.calls[0]![0].name).toBe('Untitled');
+  });
+
+  it('Enter commits the form', () => {
+    const onSave = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('Field name');
+    fireEvent.change(input, { target: { value: 'Subject' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('Escape cancels without saving', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={onSave}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(screen.getByLabelText('Field name'), { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('Cancel button calls onCancel', () => {
+    const onCancel = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'create' }}
+        onSave={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});
+
+describe('InlineFieldForm — edit mode', () => {
+  it('seeds name and type from the existing field', () => {
+    const field = makeField({ name: 'Subject', type: 'date' });
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'edit', field }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const input = screen.getByLabelText('Field name') as HTMLInputElement;
+    expect(input.value).toBe('Subject');
+    expect(screen.getByRole('button', { name: 'Date' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('renders a delete affordance', () => {
+    const field = makeField();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'edit', field }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Remove field' })).toBeTruthy();
+  });
+
+  it('preserves enum choices when saving an edit that does not change the type', () => {
+    const field = makeField({
+      type: 'enum',
+      name: 'Course',
+      config: { fieldType: 'enum', choices: ['Main', 'Side', 'Drink'] },
+    });
+    const onSave = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'edit', field }}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledWith({
+      type: 'enum',
+      name: 'Course',
+      config: { fieldType: 'enum', choices: ['Main', 'Side', 'Drink'] },
+    });
+  });
+
+  it('Remove field button calls onDelete', () => {
+    const onDelete = vi.fn();
+    render(
+      <InlineFieldForm
+        formMode={{ mode: 'edit', field: makeField() }}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Remove field' }));
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/src/components/build-wysiwyg/InlineFieldForm.tsx
+++ b/src/components/build-wysiwyg/InlineFieldForm.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { FIELD_TYPE_META } from '../build-grid/fieldTypes';
+import { FIELD_TYPES, type FieldType, type SlotFieldConfig } from '@/schemas/slot-fields';
+import type { GridField } from '../build-grid/useGridState';
+
+export type InlineFieldFormMode =
+  | { mode: 'edit'; field: GridField }
+  | { mode: 'create' };
+
+type InlineFieldFormProps = {
+  formMode: InlineFieldFormMode;
+  onSave: (input: { type: FieldType; name: string; config: SlotFieldConfig }) => void;
+  onCancel: () => void;
+  onDelete?: () => void;
+};
+
+function defaultConfigFor(type: FieldType): SlotFieldConfig {
+  switch (type) {
+    case 'text':
+      return { fieldType: 'text', maxLength: 200 };
+    case 'date':
+      return { fieldType: 'date' };
+    case 'time':
+      return { fieldType: 'time' };
+    case 'number':
+      return { fieldType: 'number' };
+    case 'enum':
+      // Enum choices are added inline from the slot editor in PR 5; brand-new
+      // enum fields seed an empty array so the picker has somewhere to push.
+      return { fieldType: 'enum', choices: [] };
+  }
+}
+
+export function InlineFieldForm({ formMode, onSave, onCancel, onDelete }: InlineFieldFormProps) {
+  const isEdit = formMode.mode === 'edit';
+  const initialName = isEdit ? formMode.field.name : '';
+  const initialType: FieldType = isEdit ? formMode.field.type : 'text';
+
+  const [name, setName] = useState(initialName);
+  const [type, setType] = useState<FieldType>(initialType);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    nameRef.current?.focus();
+    nameRef.current?.select();
+  }, []);
+
+  const save = () => {
+    const trimmed = name.trim() || 'Untitled';
+    // When the type changes on an existing field, reset its config to the
+    // type's default. The grid's FieldEditor preserves enum choices on edit
+    // via a richer flow; we keep things simple here because enum options
+    // land via the inline EnumPicker (PR 5), not this form.
+    const config: SlotFieldConfig =
+      isEdit && formMode.field.type === type
+        ? formMode.field.config
+        : defaultConfigFor(type);
+    onSave({ type, name: trimmed, config });
+  };
+
+  return (
+    <div>
+      <div className="mb-2.5 -mt-1">
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Back to fields list"
+          className="inline-flex h-6 items-center gap-1 rounded-md border-none bg-transparent px-1 text-[11px] font-medium text-ink-muted hover:bg-surface-raised"
+        >
+          <ArrowLeft size={11} />
+          Back
+        </button>
+      </div>
+
+      <label className="mb-2.5 block">
+        <span className="text-[11px] font-medium text-ink-muted">Name</span>
+        <input
+          ref={nameRef}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              save();
+            }
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+          placeholder="e.g. Teacher, Subject, Item"
+          aria-label="Field name"
+          className="mt-0.5 w-full rounded-md border border-surface-sunk bg-white px-2 py-1 text-xs text-ink outline-none focus:border-brand"
+        />
+      </label>
+
+      <div className="mb-2.5">
+        <span className="text-[11px] font-medium text-ink-muted">Type</span>
+        <div className="mt-0.5 grid grid-cols-3 gap-1.5">
+          {FIELD_TYPES.map((t) => {
+            const TypeIcon = FIELD_TYPE_META[t].icon;
+            const active = type === t;
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setType(t)}
+                aria-pressed={active}
+                className={
+                  'inline-flex items-center gap-1.5 rounded-md border px-1.5 py-1 text-[11px] font-medium transition-colors duration-180 ' +
+                  (active
+                    ? 'border-brand bg-brand-soft text-brand'
+                    : 'border-surface-sunk bg-white text-ink hover:bg-surface-raised')
+                }
+              >
+                <TypeIcon size={10} />
+                {FIELD_TYPE_META[t].label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between">
+        <div>
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="bg-transparent border-none cursor-pointer text-[11px] font-medium text-danger hover:underline"
+            >
+              Remove field
+            </button>
+          )}
+        </div>
+        <div className="flex gap-1.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border border-surface-sunk bg-white px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-surface-raised"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            className="rounded-md border border-brand bg-brand px-3 py-1 text-[11px] font-medium text-white hover:bg-brand/90"
+          >
+            {isEdit ? 'Save' : 'Add field'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Slice 2 of the B/3 WYSIWYG migration. Targets the integration branch
`feat/build-wysiwyg`; the cumulative PR for `main` is #119.

## What's in PR 2

- **Fields (N) button** in the EditingRail now opens a centred modal
  (Radix Dialog: backdrop, focus trap, Esc + click-outside close,
  `role="dialog" aria-modal="true"`, `aria-labelledby` from the title).
- **Group-by picker** at the top — "Don't group" plus each compatible
  field (date / enum / text). Time fields are intentionally excluded so
  organisers can't accidentally turn every HH:MM into its own group.
- **Drag-to-reorder field list** using the existing `useReorderable` hook
  (single-array case, perfect fit — group-aware drop lands in PR 6).
- **"+ Add field"** swaps the modal body into `InlineFieldForm` instead
  of stacking a second modal. The dialog title flips to "New field" /
  "Edit field" on the same surface.
- **InlineFieldForm**: name input (autofocus, Enter commits, Esc cancels),
  3-column type-button grid, edit mode preserves enum choices when the type
  doesn't change, "Remove field" in the footer.

No backend changes. All mutations go through hooks that already exist on
`useGridState` (`addField`, `updateField`, `deleteField`, `moveField`,
`setGroupBy`); each writes `field.added/updated/deleted` / `signup.updated`
activity entries inside the same transaction as the mutation (per CLAUDE.md).

## Tests

- `FieldsPopover.test.tsx` — open/closed render, list contents (incl.
  enum choice count), create/edit swap, group-by picker contents, reset
  to list view on close/reopen.
- `InlineFieldForm.test.tsx` — autofocus, type selection, save (incl.
  fallback to "Untitled"), Enter commits, Escape cancels, edit preserves
  enum choices.

486 unit tests pass; lint + typecheck clean.

## Manual verification (Chrome MCP)

- Click Fields (3) → modal opens centred over the sheet with backdrop.
- Modal lists the 3 live fields (Campus / Date / Shift) with their type
  icons and labels (List · 2 / Date / Time).
- Group-by trigger shows the current setting ("Campus"); list contains
  "Don't group" + Campus + Date but not Shift (Time excluded).
- Fields button in the EditingRail shows the active state (brand-soft
  bg + brand border) while the modal is open.
- Esc / click-outside / X all close cleanly.

## What's NOT in PR 2

- Slot list / groups (PR 3)
- Inline SlotEditor (PR 4)
- EnumPicker w/ "+ Add to list" (PR 5)
- Group-aware drag transfer (PR 6)
- Responsive (PR 7)
- Cutover (PR 8a/b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)