### PR TITLE
feat(build-wysiwyg): PR 3 — slot groups (read-only)

### DIFF
--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -422,13 +422,15 @@ export function useGridState(
   // Row mutations
   // ---------------------------------------------------------------------------
 
-  const addRow = useCallback(async (): Promise<void> => {
+  const addRow = useCallback(async (
+    seed?: { values?: Record<string, unknown>; capacity?: number },
+  ): Promise<void> => {
     markSaving();
     try {
       const res = await fetch(`/api/signups/${signupId}/slots`, {
         method: 'POST',
         headers: JSON_HEADERS,
-        body: JSON.stringify({ values: {}, capacity: 1 }),
+        body: JSON.stringify({ values: seed?.values ?? {}, capacity: seed?.capacity ?? 1 }),
       });
       if (!res.ok) throw new Error(await res.text());
       const envelope = (await res.json()) as {

--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useState } from 'react';
-import { useGridState } from '../build-grid/useGridState';
+import { useMemo, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useGridState, type GridField, type GridRow } from '../build-grid/useGridState';
 import { Editable } from './Editable';
 import { EditingRail } from './EditingRail';
 import { FieldsPopover } from './FieldsPopover';
+import { WysiwygGroup, type SlotGroup } from './WysiwygGroup';
 import type { SignupMeta } from '../build-grid/BuildGrid';
 import type { SlotFieldDefinition } from '@/schemas/slot-fields';
 import type { SignupSettings } from '@/schemas/signups';
@@ -22,11 +24,42 @@ type BuildWysiwygProps = {
   initialSettings: SignupSettings;
 };
 
+const EMPTY_GROUP_KEY = '__empty__';
+
 /** Maximum sheet width grows with field count — keeps small schemas tight, wide ones legible. */
 function sheetMaxWidthClass(fieldCount: number): string {
   if (fieldCount <= 3) return 'max-w-[580px]';
   if (fieldCount === 4) return 'max-w-[720px]';
   return 'max-w-[960px]';
+}
+
+/** Bucket rows by the group field's value. Empty / missing values go into `__empty__`. */
+function partitionRows(rows: GridRow[], groupField: GridField | null): SlotGroup[] {
+  if (!groupField) {
+    return [{ key: '__flat__', rawValue: '', rows }];
+  }
+  const ref = groupField.ref;
+  const buckets = new Map<string, GridRow[]>();
+  for (const r of rows) {
+    const raw = r.values[ref] ?? '';
+    const key = raw === '' ? EMPTY_GROUP_KEY : raw;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+    }
+    bucket.push(r);
+  }
+  const keys = [...buckets.keys()].sort((a, b) => {
+    if (a === EMPTY_GROUP_KEY) return 1;
+    if (b === EMPTY_GROUP_KEY) return -1;
+    return a.localeCompare(b);
+  });
+  return keys.map((k) => ({
+    key: k,
+    rawValue: k === EMPTY_GROUP_KEY ? '' : k,
+    rows: buckets.get(k) ?? [],
+  }));
 }
 
 export function BuildWysiwyg({
@@ -44,6 +77,8 @@ export function BuildWysiwyg({
     deleteField,
     moveField,
     setGroupBy,
+    addRow,
+    editCell,
   } = useGridState(
     signupId,
     initialFields,
@@ -59,6 +94,44 @@ export function BuildWysiwyg({
 
   const [fieldsOpen, setFieldsOpen] = useState(false);
   const publicHref = `/s/${signupMeta.slug}`;
+
+  const groupField = state.groupByFieldRef
+    ? state.fields.find((f) => f.ref === state.groupByFieldRef) ?? null
+    : null;
+  const timeField = state.fields.find((f) => f.type === 'time') ?? null;
+  const otherFields = state.fields.filter(
+    (f) => f.ref !== groupField?.ref && f.ref !== timeField?.ref,
+  );
+
+  const groups = useMemo(() => partitionRows(state.rows, groupField), [state.rows, groupField]);
+
+  const handleAddSlot = (groupKey: string) => {
+    const seedValues: Record<string, string> = {};
+    if (groupField && groupKey !== EMPTY_GROUP_KEY && groupKey !== '__flat__') {
+      seedValues[groupField.ref] = groupKey;
+    }
+    void addRow({ values: seedValues });
+  };
+
+  const handleAddDate = () => {
+    // Add date is only rendered for date-typed group fields; empty seed lands
+    // the new row in the "Set a date" bucket the user can rename inline.
+    void addRow({ values: {} });
+  };
+
+  const handleRenameGroup = (oldKey: string, newKey: string) => {
+    if (!groupField) return;
+    if (newKey === oldKey) return;
+    // Rewrite every row in the group to the new group value. `editCell` is
+    // optimistic + debounced, so a burst of rewrites coalesces per row.
+    const ref = groupField.ref;
+    for (const r of state.rows) {
+      const raw = r.values[ref] ?? '';
+      const matches =
+        oldKey === EMPTY_GROUP_KEY ? raw === '' : raw === oldKey;
+      if (matches) editCell(r.id, ref, newKey);
+    }
+  };
 
   return (
     <div className="min-h-[calc(100vh-12rem)] bg-surface-raised">
@@ -93,14 +166,30 @@ export function BuildWysiwyg({
             />
           </div>
 
-          {/* Slot list lands in PR 3. */}
-          <div className="mt-6 rounded-lg border border-dashed border-surface-sunk bg-surface-raised p-6 text-center text-xs text-ink-soft">
-            <p>
-              Slot list lands in PR 3.
-              {' '}
-              {state.fields.length} field{state.fields.length === 1 ? '' : 's'}, {state.rows.length} slot{state.rows.length === 1 ? '' : 's'} loaded.
-            </p>
+          <div className="mt-6 flex flex-col gap-5">
+            {groups.map((g) => (
+              <WysiwygGroup
+                key={g.key}
+                group={g}
+                groupField={groupField}
+                timeField={timeField}
+                otherFields={otherFields}
+                onAddSlot={handleAddSlot}
+                onRenameGroup={handleRenameGroup}
+              />
+            ))}
           </div>
+
+          {groupField?.type === 'date' && (
+            <button
+              type="button"
+              onClick={handleAddDate}
+              className="mt-5 inline-flex items-center gap-1.5 rounded-full border-[1.5px] border-dashed border-surface-sunk bg-transparent px-3.5 py-1.5 text-xs font-medium text-ink-muted transition-colors duration-180 hover:border-brand hover:bg-brand-soft hover:text-brand"
+            >
+              <Plus size={12} />
+              Add date
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/build-wysiwyg/WysiwygGroup.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WysiwygGroup, type SlotGroup } from './WysiwygGroup';
+import type { GridField, GridRow } from '../build-grid/useGridState';
+
+function makeRow(overrides: Partial<GridRow> = {}): GridRow {
+  return {
+    id: 'r1',
+    capacity: 2,
+    sortOrder: 0,
+    values: {},
+    ...overrides,
+  };
+}
+
+function makeField(overrides: Partial<GridField> = {}): GridField {
+  return {
+    id: 'f1',
+    ref: 'date',
+    name: 'Date',
+    type: 'date',
+    config: { fieldType: 'date' },
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function renderGroup(overrides: {
+  group?: Partial<SlotGroup>;
+  groupField?: GridField | null;
+  timeField?: GridField | null;
+  otherFields?: GridField[];
+  onAddSlot?: ReturnType<typeof vi.fn>;
+  onRenameGroup?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const onAddSlot = overrides.onAddSlot ?? vi.fn();
+  const onRenameGroup = overrides.onRenameGroup ?? vi.fn();
+  const group: SlotGroup = {
+    key: '2026-05-21',
+    rawValue: '2026-05-21',
+    rows: [makeRow({ id: 'r1' }), makeRow({ id: 'r2' })],
+    ...overrides.group,
+  };
+  const groupField =
+    'groupField' in overrides ? overrides.groupField ?? null : makeField();
+  const utils = render(
+    <WysiwygGroup
+      group={group}
+      groupField={groupField}
+      timeField={overrides.timeField ?? null}
+      otherFields={overrides.otherFields ?? []}
+      onAddSlot={onAddSlot}
+      onRenameGroup={onRenameGroup}
+    />,
+  );
+  return { ...utils, onAddSlot, onRenameGroup };
+}
+
+describe('WysiwygGroup', () => {
+  it('renders one row per group row', () => {
+    renderGroup();
+    expect(screen.getByTestId('wysiwyg-slot-r1')).toBeTruthy();
+    expect(screen.getByTestId('wysiwyg-slot-r2')).toBeTruthy();
+  });
+
+  it('renders the prettified date as the editable header', () => {
+    renderGroup({ group: { rawValue: '2026-05-21', key: '2026-05-21' } });
+    expect(screen.getByRole('button', { name: /Group header.*THU, MAY 21/ })).toBeTruthy();
+  });
+
+  it('omits the header when no group field is supplied (flat mode)', () => {
+    renderGroup({ groupField: null, group: { key: '__flat__', rawValue: '' } });
+    expect(screen.queryByRole('button', { name: /Group header/ })).toBeNull();
+  });
+
+  it('"Add a slot" calls onAddSlot with the group key', () => {
+    const { onAddSlot } = renderGroup({ group: { key: '2026-05-21', rawValue: '2026-05-21' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add a slot' }));
+    expect(onAddSlot).toHaveBeenCalledWith('2026-05-21');
+  });
+
+  it('renaming the header calls onRenameGroup with old and new keys', () => {
+    const { onRenameGroup } = renderGroup({
+      group: { key: '2026-05-21', rawValue: '2026-05-21', rows: [makeRow()] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Group header.*THU, MAY 21/ }));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2026-05-22' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRenameGroup).toHaveBeenCalledWith('2026-05-21', '2026-05-22');
+  });
+
+  it('shows "Set a date" placeholder for the empty-bucket header on a date group field', () => {
+    renderGroup({
+      group: { key: '__empty__', rawValue: '', rows: [makeRow()] },
+      groupField: makeField({ type: 'date' }),
+    });
+    expect(screen.getByRole('button', { name: /Group header.*Set a date/ })).toBeTruthy();
+  });
+});

--- a/src/components/build-wysiwyg/WysiwygGroup.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { Editable } from './Editable';
+import { WysiwygSlot } from './WysiwygSlot';
+import { prettyHeader } from './prettyHeader';
+import type { GridField, GridRow } from '../build-grid/useGridState';
+
+export type SlotGroup = {
+  /** Stable key — group field value, or `'__empty__'` for the no-value bucket. */
+  key: string;
+  /** Raw group-field value at the time of partitioning ('' for empty bucket). */
+  rawValue: string;
+  rows: GridRow[];
+};
+
+type WysiwygGroupProps = {
+  group: SlotGroup;
+  groupField: GridField | null;
+  timeField: GridField | null;
+  otherFields: GridField[];
+  onAddSlot: (groupKey: string) => void;
+  onRenameGroup: (oldKey: string, newKey: string) => void;
+};
+
+export function WysiwygGroup({
+  group,
+  groupField,
+  timeField,
+  otherFields,
+  onAddSlot,
+  onRenameGroup,
+}: WysiwygGroupProps) {
+  const showHeader = groupField !== null;
+  const display = groupField ? prettyHeader(group.rawValue, groupField.type) : '';
+
+  return (
+    <div>
+      {showHeader && groupField && (
+        <div className="mb-2 -ml-1.5">
+          <Editable
+            value={group.rawValue}
+            display={display}
+            onChange={(next) => onRenameGroup(group.key, next)}
+            placeholder={groupField.type === 'date' ? 'YYYY-MM-DD' : 'Group name'}
+            ariaLabel={`Group header — ${display}`}
+            className="inline-block rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-[0.08em] text-ink-soft"
+          />
+        </div>
+      )}
+      <div className="flex flex-col gap-0 overflow-hidden rounded-xl border border-surface-sunk bg-white">
+        {group.rows.map((row) => (
+          <WysiwygSlot
+            key={row.id}
+            row={row}
+            timeField={timeField}
+            otherFields={otherFields}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={() => onAddSlot(group.key)}
+          className={
+            'inline-flex w-full items-center gap-1.5 px-3.5 py-2.5 text-left text-xs font-medium text-ink-muted ' +
+            'transition-colors duration-180 hover:bg-brand-soft hover:text-brand ' +
+            (group.rows.length > 0 ? 'border-t border-dashed border-surface-sunk' : '')
+          }
+        >
+          <Plus size={12} />
+          Add a slot
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { GridField, GridRow } from '../build-grid/useGridState';
+
+type WysiwygSlotProps = {
+  row: GridRow;
+  timeField: GridField | null;
+  otherFields: GridField[];
+};
+
+/**
+ * Collapsed slot row. Click-to-expand is wired in PR 4.
+ *
+ * Layout:
+ *   [time-or-placeholder]   [other-field summary]            [0/N]
+ *
+ * `timeField` is the primary "what kind of slot is this" anchor on the row.
+ * `otherFields` flow into a muted middle column as " · "-joined values.
+ */
+export function WysiwygSlot({ row, timeField, otherFields }: WysiwygSlotProps) {
+  const timeValue = timeField ? row.values[timeField.ref] : '';
+  const summary = otherFields
+    .map((f) => row.values[f.ref])
+    .filter((v) => v && v.length > 0)
+    .join(' \u00b7 ');
+
+  return (
+    <div
+      data-testid={`wysiwyg-slot-${row.id}`}
+      className="flex items-center justify-between gap-2.5 border-t border-transparent px-3.5 py-2.5 first:border-t-0 hover:bg-surface-raised/50"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        {timeValue ? (
+          <span className="text-sm font-semibold text-ink">{timeValue}</span>
+        ) : timeField ? (
+          <span className="text-sm italic font-normal text-ink-soft">Set a time</span>
+        ) : (
+          <span className="text-sm font-semibold text-ink">Slot</span>
+        )}
+        {summary && (
+          <span className="truncate text-xs text-ink-muted">{summary}</span>
+        )}
+      </div>
+      <span className="shrink-0 font-mono text-[11px] text-ink-soft">
+        0/{row.capacity ?? 1}
+      </span>
+    </div>
+  );
+}

--- a/src/components/build-wysiwyg/prettyHeader.test.ts
+++ b/src/components/build-wysiwyg/prettyHeader.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { prettyHeader } from './prettyHeader';
+
+describe('prettyHeader', () => {
+  it('formats an ISO date into uppercase weekday + month + day', () => {
+    expect(prettyHeader('2026-05-21', 'date')).toBe('THU, MAY 21');
+  });
+
+  it('returns "Set a date" when value is empty and field is date', () => {
+    expect(prettyHeader('', 'date')).toBe('Set a date');
+    expect(prettyHeader(null, 'date')).toBe('Set a date');
+    expect(prettyHeader(undefined, 'date')).toBe('Set a date');
+  });
+
+  it('returns "Set a value" when value is empty and field is not date', () => {
+    expect(prettyHeader('', 'enum')).toBe('Set a value');
+    expect(prettyHeader(null, 'text')).toBe('Set a value');
+  });
+
+  it('passes through non-date field values unchanged', () => {
+    expect(prettyHeader('Main course', 'enum')).toBe('Main course');
+    expect(prettyHeader('Auditorium', 'text')).toBe('Auditorium');
+  });
+
+  it('passes through non-ISO date strings unchanged', () => {
+    expect(prettyHeader('05/21/2026', 'date')).toBe('05/21/2026');
+    expect(prettyHeader('next Tuesday', 'date')).toBe('next Tuesday');
+  });
+});

--- a/src/components/build-wysiwyg/prettyHeader.ts
+++ b/src/components/build-wysiwyg/prettyHeader.ts
@@ -1,0 +1,28 @@
+import type { FieldType } from '@/schemas/slot-fields';
+
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+});
+
+/**
+ * Prettify a group key for display in a WysiwygGroup header.
+ * - ISO dates (YYYY-MM-DD) -> "THU, MAY 21" (uppercase per the design).
+ * - Empty / no-value sentinel -> "Set a date" (date) or "Set a value" (other).
+ * - Anything else -> pass through.
+ */
+export function prettyHeader(rawKey: string | null | undefined, fieldType: FieldType): string {
+  if (!rawKey) {
+    return fieldType === 'date' ? 'Set a date' : 'Set a value';
+  }
+  if (fieldType !== 'date') return rawKey;
+
+  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(rawKey);
+  if (iso) {
+    const [, y, m, d] = iso;
+    const dt = new Date(Number(y), Number(m) - 1, Number(d));
+    if (!Number.isNaN(dt.getTime())) return dateFmt.format(dt).toUpperCase();
+  }
+  return rawKey;
+}


### PR DESCRIPTION
Slice 3 of the B/3 WYSIWYG migration. Read-only render of grouped slots —
inline editing lands in PR 4.

## What's in PR 3

- **WysiwygGroup** — bordered rounded container per group, editable
  header, inline "Add a slot" footer.
- **WysiwygSlot** — collapsed row: time anchor (or "Set a time" italic
  placeholder) + " · "-joined summary + capacity badge.
- **prettyHeader** — pure date prettifier. ISO YYYY-MM-DD → "THU, MAY 21".
- **BuildWysiwyg** partitions rows by the resolved group field; renaming
  a group header rewrites every row in the bucket via the existing
  `editCell` (optimistic + debounced). "Add date" pill renders at the
  sheet bottom only when the group field is a date.
- **useGridState.addRow** now accepts an optional `{ values, capacity }`
  seed so the WYSIWYG can drop a new slot into the right bucket without
  a follow-up PATCH. Backward-compatible — existing zero-arg call sites
  still work.

## Tests

- `prettyHeader.test.ts` — formatting, placeholders per field type,
  pass-through for non-ISO inputs.
- `WysiwygGroup.test.tsx` — one slot per row, prettified header, flat
  mode omits header, "Add a slot" carries the group key, rename fires
  the right callback, empty bucket shows "Set a date" placeholder.

497 unit tests pass; lint + typecheck clean.

## Manual verification (Chrome MCP)

`/app/signups/[id]/build?wysiwyg=1` now shows the live signup's slots
grouped under "MONTGOMERY CAMPUS" with 4 time rows (10:00 / 12:00 /
14:00 / 16:00), date summary as muted text, capacity badges (0/1), and
the "Add a slot" footer.

## What's NOT in PR 3

- Inline slot expansion / editing (PR 4)
- EnumPicker (PR 5)
- Drag reorder of slots (PR 6)
- Responsive (PR 7)
- Cutover (PR 8a/b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)