### PR TITLE
feat(build-wysiwyg): PR 4 — inline SlotEditor + hover toolbar + duplicate

### DIFF
--- a/src/components/build-grid/useGridState.test.ts
+++ b/src/components/build-grid/useGridState.test.ts
@@ -876,6 +876,77 @@ describe('useGridState mount-time showPreview default', () => {
 });
 
 // ---------------------------------------------------------------------------
+// useGridState duplicateRow
+// ---------------------------------------------------------------------------
+
+describe('useGridState duplicateRow', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the source values + capacity to /api/signups/[id]/slots', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ data: { id: 'new', capacity: 3, sortOrder: 99, values: {} } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    // Inject an initial row by seeding via the hook.
+    const { result } = renderHook(() =>
+      useGridState(
+        'sig_test',
+        [],
+        [{ id: 'src', capacity: 3, sortOrder: 0, values: { name: 'Jane' } }],
+        defaultSettings,
+      ),
+    );
+    await act(async () => {
+      await result.current.duplicateRow('src');
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('/api/signups/sig_test/slots');
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse(String((init as RequestInit).body)) as {
+      values: Record<string, string>;
+      capacity: number;
+    };
+    expect(body.values).toEqual({ name: 'Jane' });
+    expect(body.capacity).toBe(3);
+  });
+
+  it('is a no-op when the source row is missing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useGridState('sig_test', [], [], defaultSettings));
+    await act(async () => {
+      await result.current.duplicateRow('does-not-exist');
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back capacity to 1 when source had null capacity', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ data: { id: 'new', capacity: 1, sortOrder: 99, values: {} } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() =>
+      useGridState(
+        'sig_test',
+        [],
+        [{ id: 'src', capacity: null, sortOrder: 0, values: {} }],
+        defaultSettings,
+      ),
+    );
+    await act(async () => {
+      await result.current.duplicateRow('src');
+    });
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+      capacity: number;
+    };
+    expect(body.capacity).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // gridReducer OPTIMISTIC_UPDATE_META
 // ---------------------------------------------------------------------------
 

--- a/src/components/build-grid/useGridState.ts
+++ b/src/components/build-grid/useGridState.ts
@@ -452,6 +452,20 @@ export function useGridState(
     }
   }, [signupId]);
 
+  const duplicateRow = useCallback(async (rowId: string): Promise<void> => {
+    const source = stateRef.current.rows.find((r) => r.id === rowId);
+    if (!source) return;
+    // Clone values verbatim (already string-typed; addRow re-serializes for
+    // the API). Capacity falls back to 1 when the source was uncapped — the
+    // grid uses null to mean "no limit", but new slots ship with capacity 1
+    // to stay safe and consistent with the bare addRow contract.
+    const seedValues: Record<string, unknown> = { ...source.values };
+    await addRow({
+      values: seedValues,
+      capacity: source.capacity ?? 1,
+    });
+  }, [addRow]);
+
   const deleteRow = useCallback(async (rowId: string): Promise<void> => {
     markSaving();
     try {
@@ -774,6 +788,7 @@ export function useGridState(
     moveField,
     setFieldWidth,
     addRow,
+    duplicateRow,
     deleteRow,
     moveRowUp,
     moveRowDown,

--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -78,7 +78,10 @@ export function BuildWysiwyg({
     moveField,
     setGroupBy,
     addRow,
+    duplicateRow,
+    deleteRow,
     editCell,
+    setCapacity,
   } = useGridState(
     signupId,
     initialFields,
@@ -93,6 +96,7 @@ export function BuildWysiwyg({
   );
 
   const [fieldsOpen, setFieldsOpen] = useState(false);
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
   const publicHref = `/s/${signupMeta.slug}`;
 
   const groupField = state.groupByFieldRef
@@ -174,6 +178,16 @@ export function BuildWysiwyg({
                 groupField={groupField}
                 timeField={timeField}
                 otherFields={otherFields}
+                fields={state.fields}
+                expandedRowId={expandedRowId}
+                onExpandRow={setExpandedRowId}
+                onEditCell={editCell}
+                onSetCapacity={(rowId, c) => setCapacity(rowId, c)}
+                onDuplicateRow={(rowId) => { void duplicateRow(rowId); }}
+                onDeleteRow={(rowId) => {
+                  if (expandedRowId === rowId) setExpandedRowId(null);
+                  void deleteRow(rowId);
+                }}
                 onAddSlot={handleAddSlot}
                 onRenameGroup={handleRenameGroup}
               />

--- a/src/components/build-wysiwyg/SlotEditor.test.tsx
+++ b/src/components/build-wysiwyg/SlotEditor.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SlotEditor } from './SlotEditor';
+import type { GridField, GridRow } from '../build-grid/useGridState';
+
+function makeField(overrides: Partial<GridField> = {}): GridField {
+  return {
+    id: 'f1',
+    ref: 'name',
+    name: 'Name',
+    type: 'text',
+    config: { fieldType: 'text', maxLength: 200 },
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function makeRow(overrides: Partial<GridRow> = {}): GridRow {
+  return {
+    id: 'r1',
+    capacity: 2,
+    sortOrder: 0,
+    values: {},
+    ...overrides,
+  };
+}
+
+function renderEditor(overrides: {
+  row?: GridRow;
+  fields?: GridField[];
+  onCellChange?: ReturnType<typeof vi.fn>;
+  onCapacity?: ReturnType<typeof vi.fn>;
+  onDuplicate?: ReturnType<typeof vi.fn>;
+  onDelete?: ReturnType<typeof vi.fn>;
+  onClose?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const onCellChange = overrides.onCellChange ?? vi.fn();
+  const onCapacity = overrides.onCapacity ?? vi.fn();
+  const onDuplicate = overrides.onDuplicate ?? vi.fn();
+  const onDelete = overrides.onDelete ?? vi.fn();
+  const onClose = overrides.onClose ?? vi.fn();
+  const utils = render(
+    <SlotEditor
+      row={overrides.row ?? makeRow({ values: { name: 'Existing' } })}
+      fields={overrides.fields ?? [makeField()]}
+      onCellChange={onCellChange}
+      onCapacity={onCapacity}
+      onDuplicate={onDuplicate}
+      onDelete={onDelete}
+      onClose={onClose}
+    />,
+  );
+  return { ...utils, onCellChange, onCapacity, onDuplicate, onDelete, onClose };
+}
+
+describe('SlotEditor', () => {
+  it('renders one input per field plus a capacity input', () => {
+    renderEditor({
+      fields: [
+        makeField({ id: 'f1', ref: 'name', name: 'Name' }),
+        makeField({ id: 'f2', ref: 'date', name: 'Date', type: 'date', config: { fieldType: 'date' } }),
+      ],
+      row: makeRow({ values: { name: 'Jane', date: '2026-05-21' } }),
+    });
+    expect((screen.getByLabelText('Name value') as HTMLInputElement).value).toBe('Jane');
+    expect((screen.getByLabelText('Date value') as HTMLInputElement).value).toBe('2026-05-21');
+    expect(screen.getByLabelText('Capacity')).toBeTruthy();
+  });
+
+  it('typing into a field calls onCellChange with the field ref + value', () => {
+    const { onCellChange } = renderEditor({
+      fields: [makeField({ ref: 'name', name: 'Name' })],
+      row: makeRow({ values: { name: '' } }),
+    });
+    fireEvent.change(screen.getByLabelText('Name value'), { target: { value: 'New' } });
+    expect(onCellChange).toHaveBeenCalledWith('name', 'New');
+  });
+
+  it('capacity input clamps to >= 1 and rejects NaN', () => {
+    const { onCapacity } = renderEditor({ row: makeRow({ capacity: 3 }) });
+    const cap = screen.getByLabelText('Capacity') as HTMLInputElement;
+    fireEvent.change(cap, { target: { value: '5' } });
+    expect(onCapacity).toHaveBeenLastCalledWith(5);
+    fireEvent.change(cap, { target: { value: '-2' } });
+    expect(onCapacity).toHaveBeenLastCalledWith(1);
+    fireEvent.change(cap, { target: { value: 'abc' } });
+    expect(onCapacity).toHaveBeenLastCalledWith(1);
+  });
+
+  it('Done button calls onClose', () => {
+    const { onClose } = renderEditor();
+    fireEvent.click(screen.getByRole('button', { name: /Done/ }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Delete button calls onDelete', () => {
+    const { onDelete } = renderEditor();
+    fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  it('Duplicate button calls onDuplicate', () => {
+    const { onDuplicate } = renderEditor();
+    fireEvent.click(screen.getByRole('button', { name: /Duplicate/ }));
+    expect(onDuplicate).toHaveBeenCalled();
+  });
+});

--- a/src/components/build-wysiwyg/SlotEditor.tsx
+++ b/src/components/build-wysiwyg/SlotEditor.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Check, Copy, Hash, Trash2 } from 'lucide-react';
+import { FIELD_TYPE_META } from '../build-grid/fieldTypes';
+import type { GridField, GridRow } from '../build-grid/useGridState';
+
+type SlotEditorProps = {
+  row: GridRow;
+  fields: GridField[];
+  onCellChange: (fieldRef: string, value: string) => void;
+  onCapacity: (capacity: number) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+};
+
+const TYPE_PLACEHOLDERS: Record<string, string> = {
+  text: 'e.g. Bring napkins',
+  date: 'YYYY-MM-DD',
+  time: 'e.g. 09:00',
+  number: 'e.g. 12',
+  enum: 'Pick from list',
+};
+
+/**
+ * Inline accordion editor for a single slot. Auto-fit grid keeps small
+ * schemas tight while letting wider schemas wrap naturally; capacity rides
+ * along as the trailing cell so it lives in the same visual band.
+ */
+export function SlotEditor({
+  row,
+  fields,
+  onCellChange,
+  onCapacity,
+  onDuplicate,
+  onDelete,
+  onClose,
+}: SlotEditorProps) {
+  return (
+    <div className="px-3.5 pb-3.5 pt-3" data-testid={`slot-editor-${row.id}`}>
+      <div className="mb-2.5 flex items-center justify-between">
+        <span className="text-[10px] font-bold uppercase tracking-[0.08em] text-ink-soft">
+          Editing slot
+        </span>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={onDuplicate}
+            className="inline-flex items-center gap-1 rounded-md border-none bg-transparent px-1.5 py-1 text-[11px] font-medium text-ink-muted hover:bg-surface-raised hover:text-ink"
+          >
+            <Copy size={11} />
+            Duplicate
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="inline-flex items-center gap-1 rounded-md border-none bg-transparent px-1.5 py-1 text-[11px] font-medium text-danger hover:bg-danger/10"
+          >
+            <Trash2 size={11} />
+            Delete
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center gap-1 rounded-md border-none bg-transparent px-1.5 py-1 text-[11px] font-medium text-brand hover:bg-brand-soft"
+          >
+            <Check size={11} />
+            Done
+          </button>
+        </div>
+      </div>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-2.5">
+        {fields.map((f) => {
+          const TypeIcon = FIELD_TYPE_META[f.type].icon;
+          return (
+            <label
+              key={f.id}
+              className="flex flex-col gap-1 text-[11px] text-ink-muted"
+            >
+              <span className="inline-flex items-center gap-1">
+                <TypeIcon size={10} className="text-ink-soft" />
+                {f.name}
+              </span>
+              <input
+                value={row.values[f.ref] ?? ''}
+                placeholder={TYPE_PLACEHOLDERS[f.type] ?? ''}
+                onChange={(e) => onCellChange(f.ref, e.target.value)}
+                className="rounded-md border border-surface-sunk bg-white px-2.5 py-1.5 text-[13px] text-ink outline-none focus:border-brand"
+                aria-label={`${f.name} value`}
+              />
+            </label>
+          );
+        })}
+        <label className="flex flex-col gap-1 text-[11px] text-ink-muted">
+          <span className="inline-flex items-center gap-1">
+            <Hash size={10} className="text-ink-soft" />
+            Capacity
+          </span>
+          <input
+            type="number"
+            min={1}
+            value={row.capacity ?? 1}
+            onChange={(e) => {
+              const parsed = parseInt(e.target.value, 10);
+              onCapacity(Math.max(1, Number.isFinite(parsed) ? parsed : 1));
+            }}
+            aria-label="Capacity"
+            className="w-20 rounded-md border border-surface-sunk bg-white px-2.5 py-1.5 text-[13px] text-ink outline-none focus:border-brand"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/build-wysiwyg/WysiwygGroup.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.test.tsx
@@ -31,11 +31,23 @@ function renderGroup(overrides: {
   groupField?: GridField | null;
   timeField?: GridField | null;
   otherFields?: GridField[];
+  fields?: GridField[];
+  expandedRowId?: string | null;
+  onExpandRow?: ReturnType<typeof vi.fn>;
+  onEditCell?: ReturnType<typeof vi.fn>;
+  onSetCapacity?: ReturnType<typeof vi.fn>;
+  onDuplicateRow?: ReturnType<typeof vi.fn>;
+  onDeleteRow?: ReturnType<typeof vi.fn>;
   onAddSlot?: ReturnType<typeof vi.fn>;
   onRenameGroup?: ReturnType<typeof vi.fn>;
 } = {}) {
   const onAddSlot = overrides.onAddSlot ?? vi.fn();
   const onRenameGroup = overrides.onRenameGroup ?? vi.fn();
+  const onExpandRow = overrides.onExpandRow ?? vi.fn();
+  const onEditCell = overrides.onEditCell ?? vi.fn();
+  const onSetCapacity = overrides.onSetCapacity ?? vi.fn();
+  const onDuplicateRow = overrides.onDuplicateRow ?? vi.fn();
+  const onDeleteRow = overrides.onDeleteRow ?? vi.fn();
   const group: SlotGroup = {
     key: '2026-05-21',
     rawValue: '2026-05-21',
@@ -50,11 +62,18 @@ function renderGroup(overrides: {
       groupField={groupField}
       timeField={overrides.timeField ?? null}
       otherFields={overrides.otherFields ?? []}
+      fields={overrides.fields ?? (groupField ? [groupField] : [])}
+      expandedRowId={overrides.expandedRowId ?? null}
+      onExpandRow={onExpandRow}
+      onEditCell={onEditCell}
+      onSetCapacity={onSetCapacity}
+      onDuplicateRow={onDuplicateRow}
+      onDeleteRow={onDeleteRow}
       onAddSlot={onAddSlot}
       onRenameGroup={onRenameGroup}
     />,
   );
-  return { ...utils, onAddSlot, onRenameGroup };
+  return { ...utils, onAddSlot, onRenameGroup, onExpandRow, onEditCell, onSetCapacity, onDuplicateRow, onDeleteRow };
 }
 
 describe('WysiwygGroup', () => {

--- a/src/components/build-wysiwyg/WysiwygGroup.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.tsx
@@ -19,6 +19,13 @@ type WysiwygGroupProps = {
   groupField: GridField | null;
   timeField: GridField | null;
   otherFields: GridField[];
+  fields: GridField[];
+  expandedRowId: string | null;
+  onExpandRow: (rowId: string | null) => void;
+  onEditCell: (rowId: string, fieldRef: string, value: string) => void;
+  onSetCapacity: (rowId: string, capacity: number) => void;
+  onDuplicateRow: (rowId: string) => void;
+  onDeleteRow: (rowId: string) => void;
   onAddSlot: (groupKey: string) => void;
   onRenameGroup: (oldKey: string, newKey: string) => void;
 };
@@ -28,6 +35,13 @@ export function WysiwygGroup({
   groupField,
   timeField,
   otherFields,
+  fields,
+  expandedRowId,
+  onExpandRow,
+  onEditCell,
+  onSetCapacity,
+  onDuplicateRow,
+  onDeleteRow,
   onAddSlot,
   onRenameGroup,
 }: WysiwygGroupProps) {
@@ -53,8 +67,16 @@ export function WysiwygGroup({
           <WysiwygSlot
             key={row.id}
             row={row}
+            fields={fields}
             timeField={timeField}
             otherFields={otherFields}
+            expanded={expandedRowId === row.id}
+            onExpand={() => onExpandRow(row.id)}
+            onCollapse={() => onExpandRow(null)}
+            onEditCell={(ref, v) => onEditCell(row.id, ref, v)}
+            onSetCapacity={(c) => onSetCapacity(row.id, c)}
+            onDuplicate={() => onDuplicateRow(row.id)}
+            onDelete={() => onDeleteRow(row.id)}
           />
         ))}
         <button

--- a/src/components/build-wysiwyg/WysiwygSlot.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WysiwygSlot } from './WysiwygSlot';
+import type { GridField, GridRow } from '../build-grid/useGridState';
+
+function makeField(overrides: Partial<GridField> = {}): GridField {
+  return {
+    id: 'f1',
+    ref: 'shift',
+    name: 'Shift',
+    type: 'time',
+    config: { fieldType: 'time' },
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function makeRow(overrides: Partial<GridRow> = {}): GridRow {
+  return {
+    id: 'r1',
+    capacity: 2,
+    sortOrder: 0,
+    values: { shift: '09:00', notes: 'Bring sunscreen' },
+    ...overrides,
+  };
+}
+
+type RenderProps = {
+  expanded?: boolean;
+  row?: GridRow;
+  onExpand?: ReturnType<typeof vi.fn>;
+  onCollapse?: ReturnType<typeof vi.fn>;
+  onEditCell?: ReturnType<typeof vi.fn>;
+  onSetCapacity?: ReturnType<typeof vi.fn>;
+  onDuplicate?: ReturnType<typeof vi.fn>;
+  onDelete?: ReturnType<typeof vi.fn>;
+};
+
+function renderSlot(overrides: RenderProps = {}) {
+  const onExpand = overrides.onExpand ?? vi.fn();
+  const onCollapse = overrides.onCollapse ?? vi.fn();
+  const onEditCell = overrides.onEditCell ?? vi.fn();
+  const onSetCapacity = overrides.onSetCapacity ?? vi.fn();
+  const onDuplicate = overrides.onDuplicate ?? vi.fn();
+  const onDelete = overrides.onDelete ?? vi.fn();
+  const timeField = makeField({ ref: 'shift', name: 'Shift', type: 'time' });
+  const otherField = makeField({ id: 'f2', ref: 'notes', name: 'Notes', type: 'text', config: { fieldType: 'text', maxLength: 200 } });
+  const utils = render(
+    <WysiwygSlot
+      row={overrides.row ?? makeRow()}
+      fields={[timeField, otherField]}
+      timeField={timeField}
+      otherFields={[otherField]}
+      expanded={overrides.expanded ?? false}
+      onExpand={onExpand}
+      onCollapse={onCollapse}
+      onEditCell={onEditCell}
+      onSetCapacity={onSetCapacity}
+      onDuplicate={onDuplicate}
+      onDelete={onDelete}
+    />,
+  );
+  return { ...utils, onExpand, onCollapse, onEditCell, onSetCapacity, onDuplicate, onDelete };
+}
+
+describe('WysiwygSlot — collapsed', () => {
+  it('renders time, summary, and capacity', () => {
+    renderSlot();
+    expect(screen.getByText('09:00')).toBeTruthy();
+    expect(screen.getByText('Bring sunscreen')).toBeTruthy();
+    expect(screen.getByText('0/2')).toBeTruthy();
+  });
+
+  it('falls back to "Set a time" placeholder when the time field is empty', () => {
+    renderSlot({ row: makeRow({ values: { shift: '', notes: '' } }) });
+    expect(screen.getByText('Set a time')).toBeTruthy();
+  });
+
+  it('clicking the row body calls onExpand', () => {
+    const { onExpand } = renderSlot();
+    fireEvent.click(screen.getByRole('button', { name: /Edit slot at 09:00/ }));
+    expect(onExpand).toHaveBeenCalled();
+  });
+
+  it('toolbar Edit button calls onExpand', () => {
+    const { onExpand } = renderSlot();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(onExpand).toHaveBeenCalled();
+  });
+
+  it('toolbar Duplicate calls onDuplicate and stops propagation (no expand)', () => {
+    const { onExpand, onDuplicate } = renderSlot();
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    expect(onDuplicate).toHaveBeenCalled();
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  it('toolbar Delete calls onDelete and stops propagation', () => {
+    const { onExpand, onDelete } = renderSlot();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onDelete).toHaveBeenCalled();
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+});
+
+describe('WysiwygSlot — expanded', () => {
+  it('renders a SlotEditor with the row\'s values', () => {
+    renderSlot({ expanded: true });
+    expect(screen.getByText('Editing slot')).toBeTruthy();
+    expect((screen.getByLabelText('Shift value') as HTMLInputElement).value).toBe('09:00');
+    expect((screen.getByLabelText('Notes value') as HTMLInputElement).value).toBe('Bring sunscreen');
+  });
+
+  it('Done in the expanded editor calls onCollapse', () => {
+    const { onCollapse } = renderSlot({ expanded: true });
+    fireEvent.click(screen.getByRole('button', { name: /Done/ }));
+    expect(onCollapse).toHaveBeenCalled();
+  });
+});

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -1,23 +1,61 @@
 'use client';
 
+import { Copy, Pencil, Trash2 } from 'lucide-react';
+import { SlotEditor } from './SlotEditor';
 import type { GridField, GridRow } from '../build-grid/useGridState';
 
 type WysiwygSlotProps = {
   row: GridRow;
+  fields: GridField[];
   timeField: GridField | null;
   otherFields: GridField[];
+  expanded: boolean;
+  onExpand: () => void;
+  onCollapse: () => void;
+  onEditCell: (fieldRef: string, value: string) => void;
+  onSetCapacity: (capacity: number) => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
 };
 
 /**
- * Collapsed slot row. Click-to-expand is wired in PR 4.
- *
- * Layout:
- *   [time-or-placeholder]   [other-field summary]            [0/N]
- *
- * `timeField` is the primary "what kind of slot is this" anchor on the row.
- * `otherFields` flow into a muted middle column as " · "-joined values.
+ * Slot row. Collapsed by default; clicking expands into a SlotEditor.
+ * Hover or focus-within on the collapsed row reveals a floating toolbar
+ * with Edit / Duplicate / Delete affordances (keyboard parity via
+ * focus-within, per the design's "one mode cue" feedback).
  */
-export function WysiwygSlot({ row, timeField, otherFields }: WysiwygSlotProps) {
+export function WysiwygSlot({
+  row,
+  fields,
+  timeField,
+  otherFields,
+  expanded,
+  onExpand,
+  onCollapse,
+  onEditCell,
+  onSetCapacity,
+  onDuplicate,
+  onDelete,
+}: WysiwygSlotProps) {
+  if (expanded) {
+    return (
+      <div
+        data-testid={`wysiwyg-slot-${row.id}`}
+        className="border-t border-b border-surface-sunk bg-surface-raised first:border-t-0"
+      >
+        <SlotEditor
+          row={row}
+          fields={fields}
+          onCellChange={onEditCell}
+          onCapacity={onSetCapacity}
+          onDuplicate={onDuplicate}
+          onDelete={onDelete}
+          onClose={onCollapse}
+        />
+      </div>
+    );
+  }
+
   const timeValue = timeField ? row.values[timeField.ref] : '';
   const summary = otherFields
     .map((f) => row.values[f.ref])
@@ -27,23 +65,74 @@ export function WysiwygSlot({ row, timeField, otherFields }: WysiwygSlotProps) {
   return (
     <div
       data-testid={`wysiwyg-slot-${row.id}`}
-      className="flex items-center justify-between gap-2.5 border-t border-transparent px-3.5 py-2.5 first:border-t-0 hover:bg-surface-raised/50"
+      className="group relative border-t border-transparent first:border-t-0 focus-within:bg-surface-raised/50 hover:bg-surface-raised/50"
     >
-      <div className="flex min-w-0 flex-1 items-center gap-2.5">
-        {timeValue ? (
-          <span className="text-sm font-semibold text-ink">{timeValue}</span>
-        ) : timeField ? (
-          <span className="text-sm italic font-normal text-ink-soft">Set a time</span>
-        ) : (
-          <span className="text-sm font-semibold text-ink">Slot</span>
-        )}
-        {summary && (
-          <span className="truncate text-xs text-ink-muted">{summary}</span>
-        )}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-label={`Edit slot${timeValue ? ` at ${timeValue}` : ''}`}
+        className="flex w-full items-center justify-between gap-2.5 border-none bg-transparent px-3.5 py-2.5 text-left"
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2.5">
+          {timeValue ? (
+            <span className="text-sm font-semibold text-ink">{timeValue}</span>
+          ) : timeField ? (
+            <span className="text-sm italic font-normal text-ink-soft">Set a time</span>
+          ) : (
+            <span className="text-sm font-semibold text-ink">Slot</span>
+          )}
+          {summary && (
+            <span className="truncate text-xs text-ink-muted">{summary}</span>
+          )}
+        </div>
+        <span className="shrink-0 font-mono text-[11px] text-ink-soft">
+          0/{row.capacity ?? 1}
+        </span>
+      </button>
+      <div
+        className="absolute right-2 top-1.5 flex gap-px rounded-md border border-surface-sunk bg-white p-0.5 opacity-0 shadow-sm transition-opacity duration-180 group-hover:opacity-100 group-focus-within:opacity-100"
+        aria-hidden={false}
+      >
+        <ToolbarButton label="Edit" onClick={onExpand}>
+          <Pencil size={11} />
+        </ToolbarButton>
+        <ToolbarButton label="Duplicate" onClick={onDuplicate}>
+          <Copy size={11} />
+        </ToolbarButton>
+        <ToolbarButton label="Delete" danger onClick={onDelete}>
+          <Trash2 size={11} />
+        </ToolbarButton>
       </div>
-      <span className="shrink-0 font-mono text-[11px] text-ink-soft">
-        0/{row.capacity ?? 1}
-      </span>
     </div>
+  );
+}
+
+function ToolbarButton({
+  label,
+  danger,
+  onClick,
+  children,
+}: {
+  label: string;
+  danger?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={(e) => {
+        // Don't bubble into the parent expand-on-click button.
+        e.stopPropagation();
+        onClick();
+      }}
+      className={
+        'inline-flex h-6 w-6 items-center justify-center rounded border-none bg-transparent text-ink-soft transition-colors duration-180 ' +
+        (danger ? 'hover:bg-danger/10 hover:text-danger' : 'hover:bg-surface-raised hover:text-ink')
+      }
+    >
+      {children}
+    </button>
   );
 }


### PR DESCRIPTION
Slice 4 of the B/3 WYSIWYG migration. Clicking a slot expands inline into
a full editor; a hover/focus-within toolbar surfaces Edit / Duplicate /
Delete on collapsed rows.

## What's in PR 4

- **SlotEditor** — auto-fit `minmax(160px, 1fr)` grid. One input per
  field + a capacity stepper (clamped to >=1). Done / Duplicate / Delete
  toolbar pinned to the top of the editor.
- **WysiwygSlot** — toggles between collapsed and expanded; floating
  toolbar appears on hover OR focus-within so keyboard users have parity.
  Toolbar buttons `stopPropagation` so they don't also fire the row's
  expand-on-click.
- **WysiwygGroup** owns the active expandedRowId via parent props.
- **useGridState.duplicateRow** clones the source's values + capacity
  (fallback 1) through the existing `addRow`. Positional reorder lands
  with PR 6's group-aware drag.

## Tests

- `SlotEditor.test.tsx`, `WysiwygSlot.test.tsx`, `useGridState.duplicateRow`
  cases, helper update in `WysiwygGroup.test.tsx`.

514 unit tests pass; lint + typecheck clean.

## Manual verification (Chrome MCP)

- Click a slot row -> expands inline with all field inputs + capacity.
- Editing slot label shows; Done collapses back to the summary row.
- Toolbar Duplicate/Delete on hover don't double-fire expand.

## What's NOT in PR 4

- EnumPicker with "+ Add to list" (PR 5)
- Drag reorder of slots (PR 6)
- Responsive layout (PR 7)
- Cutover (PR 8a/b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)