### PR TITLE
feat(build-wysiwyg): PR 5 — EnumPicker with inline + Add to list

### DIFF
--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -183,6 +183,14 @@ export function BuildWysiwyg({
                 onExpandRow={setExpandedRowId}
                 onEditCell={editCell}
                 onSetCapacity={(rowId, c) => setCapacity(rowId, c)}
+                onAddEnumOption={(fieldId, value) => {
+                  const field = state.fields.find((f) => f.id === fieldId);
+                  if (!field || field.config.fieldType !== 'enum') return;
+                  if (field.config.choices.includes(value)) return;
+                  void updateField(fieldId, {
+                    config: { fieldType: 'enum', choices: [...field.config.choices, value] },
+                  });
+                }}
                 onDuplicateRow={(rowId) => { void duplicateRow(rowId); }}
                 onDeleteRow={(rowId) => {
                   if (expandedRowId === rowId) setExpandedRowId(null);

--- a/src/components/build-wysiwyg/EnumPicker.test.tsx
+++ b/src/components/build-wysiwyg/EnumPicker.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EnumPicker } from './EnumPicker';
+
+function renderPicker(overrides: {
+  value?: string;
+  options?: string[];
+  onChange?: ReturnType<typeof vi.fn>;
+  onAddOption?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const onChange = overrides.onChange ?? vi.fn();
+  const onAddOption = overrides.onAddOption ?? vi.fn();
+  const utils = render(
+    <EnumPicker
+      value={overrides.value ?? ''}
+      options={overrides.options ?? ['Main', 'Side']}
+      ariaLabel="Course value"
+      onChange={onChange}
+      onAddOption={onAddOption}
+    />,
+  );
+  return { ...utils, onChange, onAddOption };
+}
+
+describe('EnumPicker', () => {
+  it('renders a "Choose…" placeholder when value is empty', () => {
+    renderPicker();
+    expect(screen.getByRole('button', { name: 'Course value' }).textContent).toContain('Choose');
+  });
+
+  it('renders the value when set', () => {
+    renderPicker({ value: 'Main' });
+    expect(screen.getByRole('button', { name: 'Course value' }).textContent).toContain('Main');
+  });
+
+  it('opening the menu lists every option', () => {
+    renderPicker({ options: ['A', 'B', 'C'] });
+    fireEvent.click(screen.getByRole('button', { name: 'Course value' }));
+    const listbox = screen.getByRole('listbox', { name: 'Course value' });
+    const opts = listbox.querySelectorAll('[role="option"]');
+    expect(opts).toHaveLength(3);
+    expect(Array.from(opts).map((o) => o.textContent?.trim())).toEqual(['A', 'B', 'C']);
+  });
+
+  it('selecting an option calls onChange and closes the menu', () => {
+    const { onChange } = renderPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'Course value' }));
+    fireEvent.click(screen.getByRole('option', { name: 'Main' }));
+    expect(onChange).toHaveBeenCalledWith('Main');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('"+ Add to list" footer reveals an input that commits via Enter', () => {
+    const { onChange, onAddOption } = renderPicker({ options: ['Main'] });
+    fireEvent.click(screen.getByRole('button', { name: 'Course value' }));
+    fireEvent.click(screen.getByRole('button', { name: /Add to list/ }));
+    const input = screen.getByLabelText('New option name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Dessert' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onAddOption).toHaveBeenCalledWith('Dessert');
+    expect(onChange).toHaveBeenCalledWith('Dessert');
+  });
+
+  it('Escape inside the add-input cancels without saving', () => {
+    const { onChange, onAddOption } = renderPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'Course value' }));
+    fireEvent.click(screen.getByRole('button', { name: /Add to list/ }));
+    const input = screen.getByLabelText('New option name');
+    fireEvent.change(input, { target: { value: 'Dessert' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onAddOption).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('empty options list shows the "No items yet" hint', () => {
+    renderPicker({ options: [] });
+    fireEvent.click(screen.getByRole('button', { name: 'Course value' }));
+    expect(screen.getByText('No items yet.')).toBeTruthy();
+  });
+
+  it('blank add-input commits as a no-op (does not add empty option)', () => {
+    const { onChange, onAddOption } = renderPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'Course value' }));
+    fireEvent.click(screen.getByRole('button', { name: /Add to list/ }));
+    fireEvent.keyDown(screen.getByLabelText('New option name'), { key: 'Enter' });
+    expect(onAddOption).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/build-wysiwyg/EnumPicker.tsx
+++ b/src/components/build-wysiwyg/EnumPicker.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Check, ChevronDown, Plus } from 'lucide-react';
+
+type EnumPickerProps = {
+  value: string;
+  options: string[];
+  ariaLabel: string;
+  onChange: (next: string) => void;
+  /**
+   * Called when the user adds a brand-new option from inside the picker.
+   * Implementations should append the value to the field's `choices` config.
+   */
+  onAddOption: (value: string) => void;
+};
+
+/**
+ * Single-select dropdown with an inline "+ Add to list" footer. Designed to
+ * replace the bare `<input>` for enum fields in SlotEditor — list options
+ * grow as organizers fill in values, instead of needing a separate schema
+ * trip.
+ */
+export function EnumPicker({ value, options, ariaLabel, onChange, onAddOption }: EnumPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState('');
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (adding) inputRef.current?.focus();
+  }, [adding]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        menuRef.current && !menuRef.current.contains(target) &&
+        triggerRef.current && !triggerRef.current.contains(target)
+      ) {
+        close();
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const close = () => {
+    setOpen(false);
+    setAdding(false);
+    setDraft('');
+  };
+
+  const commitNew = () => {
+    const v = draft.trim();
+    if (v) {
+      onAddOption(v);
+      onChange(v);
+    }
+    close();
+  };
+
+  return (
+    <div className="relative" data-testid="enum-picker">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        className={
+          'flex w-full items-center justify-between gap-1.5 rounded-md border bg-white px-2.5 py-1.5 text-left text-[13px] outline-none ' +
+          (open ? 'border-brand' : 'border-surface-sunk') +
+          ' ' +
+          (value ? 'text-ink' : 'text-ink-soft')
+        }
+      >
+        <span className="truncate">{value || 'Choose\u2026'}</span>
+        <ChevronDown size={11} className="shrink-0 text-ink-soft" />
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          role="listbox"
+          aria-label={ariaLabel}
+          className="absolute left-0 right-0 top-[calc(100%+4px)] z-50 max-h-[240px] overflow-y-auto rounded-lg border border-surface-sunk bg-white p-1 shadow-card"
+        >
+          {options.length === 0 && !adding && (
+            <div className="px-2.5 py-1.5 text-[11px] italic text-ink-soft">
+              No items yet.
+            </div>
+          )}
+          {options.map((opt) => {
+            const active = opt === value;
+            return (
+              <button
+                key={opt}
+                type="button"
+                role="option"
+                aria-selected={active}
+                onClick={() => {
+                  onChange(opt);
+                  close();
+                }}
+                className={
+                  'flex w-full items-center gap-2 rounded-md border-none px-2.5 py-1.5 text-left text-xs cursor-pointer ' +
+                  (active
+                    ? 'bg-brand-soft font-semibold text-brand'
+                    : 'bg-transparent font-medium text-ink hover:bg-surface-raised')
+                }
+              >
+                <span className="inline-flex w-3 shrink-0">{active && <Check size={11} />}</span>
+                <span className="flex-1 truncate">{opt}</span>
+              </button>
+            );
+          })}
+          {options.length > 0 && <div className="my-1 h-px bg-surface-sunk" />}
+          {adding ? (
+            <div className="flex items-center gap-1 rounded-md bg-brand-soft px-1.5 py-1">
+              <Plus size={11} className="shrink-0 text-brand" />
+              <input
+                ref={inputRef}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    commitNew();
+                  }
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    close();
+                  }
+                }}
+                onBlur={commitNew}
+                placeholder="New item name"
+                aria-label="New option name"
+                className="min-w-0 flex-1 border-none bg-transparent px-0 py-1 text-xs text-ink outline-none"
+              />
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setAdding(true)}
+              className="flex w-full items-center gap-2 rounded-md border-none bg-transparent px-2.5 py-1.5 text-left text-xs font-medium text-brand cursor-pointer hover:bg-brand-soft"
+            >
+              <Plus size={12} />
+              <span>Add to list</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/build-wysiwyg/SlotEditor.test.tsx
+++ b/src/components/build-wysiwyg/SlotEditor.test.tsx
@@ -31,12 +31,14 @@ function renderEditor(overrides: {
   fields?: GridField[];
   onCellChange?: ReturnType<typeof vi.fn>;
   onCapacity?: ReturnType<typeof vi.fn>;
+  onAddEnumOption?: ReturnType<typeof vi.fn>;
   onDuplicate?: ReturnType<typeof vi.fn>;
   onDelete?: ReturnType<typeof vi.fn>;
   onClose?: ReturnType<typeof vi.fn>;
 } = {}) {
   const onCellChange = overrides.onCellChange ?? vi.fn();
   const onCapacity = overrides.onCapacity ?? vi.fn();
+  const onAddEnumOption = overrides.onAddEnumOption ?? vi.fn();
   const onDuplicate = overrides.onDuplicate ?? vi.fn();
   const onDelete = overrides.onDelete ?? vi.fn();
   const onClose = overrides.onClose ?? vi.fn();
@@ -46,12 +48,13 @@ function renderEditor(overrides: {
       fields={overrides.fields ?? [makeField()]}
       onCellChange={onCellChange}
       onCapacity={onCapacity}
+      onAddEnumOption={onAddEnumOption}
       onDuplicate={onDuplicate}
       onDelete={onDelete}
       onClose={onClose}
     />,
   );
-  return { ...utils, onCellChange, onCapacity, onDuplicate, onDelete, onClose };
+  return { ...utils, onCellChange, onCapacity, onAddEnumOption, onDuplicate, onDelete, onClose };
 }
 
 describe('SlotEditor', () => {

--- a/src/components/build-wysiwyg/SlotEditor.tsx
+++ b/src/components/build-wysiwyg/SlotEditor.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Copy, Hash, Trash2 } from 'lucide-react';
 import { FIELD_TYPE_META } from '../build-grid/fieldTypes';
+import { EnumPicker } from './EnumPicker';
 import type { GridField, GridRow } from '../build-grid/useGridState';
 
 type SlotEditorProps = {
@@ -9,6 +10,8 @@ type SlotEditorProps = {
   fields: GridField[];
   onCellChange: (fieldRef: string, value: string) => void;
   onCapacity: (capacity: number) => void;
+  /** Append `value` to the field's enum choices config. Only called for enum cells. */
+  onAddEnumOption: (fieldId: string, value: string) => void;
   onDuplicate: () => void;
   onDelete: () => void;
   onClose: () => void;
@@ -32,6 +35,7 @@ export function SlotEditor({
   fields,
   onCellChange,
   onCapacity,
+  onAddEnumOption,
   onDuplicate,
   onDelete,
   onClose,
@@ -72,6 +76,8 @@ export function SlotEditor({
       <div className="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-2.5">
         {fields.map((f) => {
           const TypeIcon = FIELD_TYPE_META[f.type].icon;
+          const isEnum = f.type === 'enum' && f.config.fieldType === 'enum';
+          const choices = isEnum && f.config.fieldType === 'enum' ? f.config.choices : [];
           return (
             <label
               key={f.id}
@@ -81,13 +87,23 @@ export function SlotEditor({
                 <TypeIcon size={10} className="text-ink-soft" />
                 {f.name}
               </span>
-              <input
-                value={row.values[f.ref] ?? ''}
-                placeholder={TYPE_PLACEHOLDERS[f.type] ?? ''}
-                onChange={(e) => onCellChange(f.ref, e.target.value)}
-                className="rounded-md border border-surface-sunk bg-white px-2.5 py-1.5 text-[13px] text-ink outline-none focus:border-brand"
-                aria-label={`${f.name} value`}
-              />
+              {isEnum ? (
+                <EnumPicker
+                  value={row.values[f.ref] ?? ''}
+                  options={choices}
+                  ariaLabel={`${f.name} value`}
+                  onChange={(v) => onCellChange(f.ref, v)}
+                  onAddOption={(v) => onAddEnumOption(f.id, v)}
+                />
+              ) : (
+                <input
+                  value={row.values[f.ref] ?? ''}
+                  placeholder={TYPE_PLACEHOLDERS[f.type] ?? ''}
+                  onChange={(e) => onCellChange(f.ref, e.target.value)}
+                  className="rounded-md border border-surface-sunk bg-white px-2.5 py-1.5 text-[13px] text-ink outline-none focus:border-brand"
+                  aria-label={`${f.name} value`}
+                />
+              )}
             </label>
           );
         })}

--- a/src/components/build-wysiwyg/WysiwygGroup.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.test.tsx
@@ -36,6 +36,7 @@ function renderGroup(overrides: {
   onExpandRow?: ReturnType<typeof vi.fn>;
   onEditCell?: ReturnType<typeof vi.fn>;
   onSetCapacity?: ReturnType<typeof vi.fn>;
+  onAddEnumOption?: ReturnType<typeof vi.fn>;
   onDuplicateRow?: ReturnType<typeof vi.fn>;
   onDeleteRow?: ReturnType<typeof vi.fn>;
   onAddSlot?: ReturnType<typeof vi.fn>;
@@ -46,6 +47,7 @@ function renderGroup(overrides: {
   const onExpandRow = overrides.onExpandRow ?? vi.fn();
   const onEditCell = overrides.onEditCell ?? vi.fn();
   const onSetCapacity = overrides.onSetCapacity ?? vi.fn();
+  const onAddEnumOption = overrides.onAddEnumOption ?? vi.fn();
   const onDuplicateRow = overrides.onDuplicateRow ?? vi.fn();
   const onDeleteRow = overrides.onDeleteRow ?? vi.fn();
   const group: SlotGroup = {
@@ -67,13 +69,14 @@ function renderGroup(overrides: {
       onExpandRow={onExpandRow}
       onEditCell={onEditCell}
       onSetCapacity={onSetCapacity}
+      onAddEnumOption={onAddEnumOption}
       onDuplicateRow={onDuplicateRow}
       onDeleteRow={onDeleteRow}
       onAddSlot={onAddSlot}
       onRenameGroup={onRenameGroup}
     />,
   );
-  return { ...utils, onAddSlot, onRenameGroup, onExpandRow, onEditCell, onSetCapacity, onDuplicateRow, onDeleteRow };
+  return { ...utils, onAddSlot, onRenameGroup, onExpandRow, onEditCell, onSetCapacity, onAddEnumOption, onDuplicateRow, onDeleteRow };
 }
 
 describe('WysiwygGroup', () => {

--- a/src/components/build-wysiwyg/WysiwygGroup.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.tsx
@@ -24,6 +24,7 @@ type WysiwygGroupProps = {
   onExpandRow: (rowId: string | null) => void;
   onEditCell: (rowId: string, fieldRef: string, value: string) => void;
   onSetCapacity: (rowId: string, capacity: number) => void;
+  onAddEnumOption: (fieldId: string, value: string) => void;
   onDuplicateRow: (rowId: string) => void;
   onDeleteRow: (rowId: string) => void;
   onAddSlot: (groupKey: string) => void;
@@ -40,6 +41,7 @@ export function WysiwygGroup({
   onExpandRow,
   onEditCell,
   onSetCapacity,
+  onAddEnumOption,
   onDuplicateRow,
   onDeleteRow,
   onAddSlot,
@@ -75,6 +77,7 @@ export function WysiwygGroup({
             onCollapse={() => onExpandRow(null)}
             onEditCell={(ref, v) => onEditCell(row.id, ref, v)}
             onSetCapacity={(c) => onSetCapacity(row.id, c)}
+            onAddEnumOption={onAddEnumOption}
             onDuplicate={() => onDuplicateRow(row.id)}
             onDelete={() => onDeleteRow(row.id)}
           />

--- a/src/components/build-wysiwyg/WysiwygSlot.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.test.tsx
@@ -33,6 +33,7 @@ type RenderProps = {
   onCollapse?: ReturnType<typeof vi.fn>;
   onEditCell?: ReturnType<typeof vi.fn>;
   onSetCapacity?: ReturnType<typeof vi.fn>;
+  onAddEnumOption?: ReturnType<typeof vi.fn>;
   onDuplicate?: ReturnType<typeof vi.fn>;
   onDelete?: ReturnType<typeof vi.fn>;
 };
@@ -42,6 +43,7 @@ function renderSlot(overrides: RenderProps = {}) {
   const onCollapse = overrides.onCollapse ?? vi.fn();
   const onEditCell = overrides.onEditCell ?? vi.fn();
   const onSetCapacity = overrides.onSetCapacity ?? vi.fn();
+  const onAddEnumOption = overrides.onAddEnumOption ?? vi.fn();
   const onDuplicate = overrides.onDuplicate ?? vi.fn();
   const onDelete = overrides.onDelete ?? vi.fn();
   const timeField = makeField({ ref: 'shift', name: 'Shift', type: 'time' });
@@ -57,11 +59,12 @@ function renderSlot(overrides: RenderProps = {}) {
       onCollapse={onCollapse}
       onEditCell={onEditCell}
       onSetCapacity={onSetCapacity}
+      onAddEnumOption={onAddEnumOption}
       onDuplicate={onDuplicate}
       onDelete={onDelete}
     />,
   );
-  return { ...utils, onExpand, onCollapse, onEditCell, onSetCapacity, onDuplicate, onDelete };
+  return { ...utils, onExpand, onCollapse, onEditCell, onSetCapacity, onAddEnumOption, onDuplicate, onDelete };
 }
 
 describe('WysiwygSlot — collapsed', () => {

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -14,6 +14,7 @@ type WysiwygSlotProps = {
   onCollapse: () => void;
   onEditCell: (fieldRef: string, value: string) => void;
   onSetCapacity: (capacity: number) => void;
+  onAddEnumOption: (fieldId: string, value: string) => void;
   onDuplicate: () => void;
   onDelete: () => void;
 };
@@ -34,6 +35,7 @@ export function WysiwygSlot({
   onCollapse,
   onEditCell,
   onSetCapacity,
+  onAddEnumOption,
   onDuplicate,
   onDelete,
 }: WysiwygSlotProps) {
@@ -48,6 +50,7 @@ export function WysiwygSlot({
           fields={fields}
           onCellChange={onEditCell}
           onCapacity={onSetCapacity}
+          onAddEnumOption={onAddEnumOption}
           onDuplicate={onDuplicate}
           onDelete={onDelete}
           onClose={onCollapse}


### PR DESCRIPTION
Slice 5 — enum fields now grow their option list inline from the slot
editor instead of requiring a schema-modal round-trip.

## What's in PR 5

- **EnumPicker** — listbox with options + "+ Add to list" footer. Inline
  input commits on Enter (calls onAddOption + onChange), Escape cancels,
  blur commits, click-outside dismisses. Empty-state hint when no options.
- **SlotEditor** uses EnumPicker for enum fields and the existing bare
  input for text/date/time/number. `onAddEnumOption(fieldId, value)`
  threads up to BuildWysiwyg which patches the field's `choices` via
  the existing updateField hook (duplicates filtered).

## Tests

- `EnumPicker.test.tsx` — placeholder copy, listbox contents, select-then-close,
  add-to-list flow, Escape cancel, blank no-op, empty-state hint.
- Existing SlotEditor / WysiwygSlot / WysiwygGroup test helpers updated.

522 unit tests pass; lint + typecheck clean.

## Manual verification (Chrome MCP)

- Expand a slot → click the Campus cell → listbox opens with the live
  signup's two campus options and an "Add to list" footer.

## What's NOT in PR 5

- Drag reorder of slots (PR 6) incl. group-aware drop
- Responsive layout (PR 7)
- Cutover (PR 8a/b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)