### PR TITLE
feat(build-wysiwyg): PR 6 — slot drag-reorder with group-aware drop

### DIFF
--- a/src/components/build-grid/useReorderable.test.ts
+++ b/src/components/build-grid/useReorderable.test.ts
@@ -152,3 +152,100 @@ describe('useReorderable', () => {
     expect(result.current.overId).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-group transfer (PR 6 — group-aware drag for the WYSIWYG editor)
+// ---------------------------------------------------------------------------
+
+interface GroupedItem {
+  id: string;
+  group: string;
+}
+
+const groupedItems: GroupedItem[] = [
+  { id: 'a1', group: 'A' },
+  { id: 'a2', group: 'A' },
+  { id: 'b1', group: 'B' },
+  { id: 'b2', group: 'B' },
+];
+
+describe('useReorderable — cross-group transfer', () => {
+  it('fires onReorder for within-group drops (same source + target group)', () => {
+    const onReorder = vi.fn();
+    const onTransfer = vi.fn();
+    const { result } = renderHook(() =>
+      useReorderable<GroupedItem>({
+        items: groupedItems,
+        onReorder,
+        getGroupKey: (it) => it.group,
+        onTransfer,
+      }),
+    );
+
+    act(() => result.current.source('a1').onDragStart(makeDragEvent()));
+    act(() => result.current.target('a2').onDrop(makeDragEvent()));
+
+    expect(onReorder).toHaveBeenCalledWith(0, 1);
+    expect(onTransfer).not.toHaveBeenCalled();
+  });
+
+  it('fires onTransfer for cross-group drops with the target group + index', () => {
+    const onReorder = vi.fn();
+    const onTransfer = vi.fn();
+    const { result } = renderHook(() =>
+      useReorderable<GroupedItem>({
+        items: groupedItems,
+        onReorder,
+        getGroupKey: (it) => it.group,
+        onTransfer,
+      }),
+    );
+
+    // Drag from group A onto an item in group B.
+    act(() => result.current.source('a1').onDragStart(makeDragEvent()));
+    act(() => result.current.target('b1').onDrop(makeDragEvent()));
+
+    expect(onTransfer).toHaveBeenCalledWith('a1', 'B', 2);
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it('treats undefined group keys as their own bucket', () => {
+    const mixed: GroupedItem[] = [
+      { id: 'x', group: '' },
+      { id: 'y', group: 'B' },
+    ];
+    const onReorder = vi.fn();
+    const onTransfer = vi.fn();
+    const { result } = renderHook(() =>
+      useReorderable<GroupedItem>({
+        items: mixed,
+        onReorder,
+        getGroupKey: (it) => (it.group === '' ? undefined : it.group),
+        onTransfer,
+      }),
+    );
+
+    act(() => result.current.source('x').onDragStart(makeDragEvent()));
+    act(() => result.current.target('y').onDrop(makeDragEvent()));
+
+    expect(onTransfer).toHaveBeenCalledWith('x', 'B', 1);
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it('falls back to onReorder when getGroupKey is supplied but onTransfer is not', () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() =>
+      useReorderable<GroupedItem>({
+        items: groupedItems,
+        onReorder,
+        getGroupKey: (it) => it.group,
+      }),
+    );
+
+    act(() => result.current.source('a1').onDragStart(makeDragEvent()));
+    act(() => result.current.target('b1').onDrop(makeDragEvent()));
+
+    // No onTransfer, so even cross-group drops collapse to onReorder.
+    expect(onReorder).toHaveBeenCalledWith(0, 2);
+  });
+});

--- a/src/components/build-grid/useReorderable.ts
+++ b/src/components/build-grid/useReorderable.ts
@@ -27,24 +27,38 @@ export interface UseReorderableResult {
 interface UseReorderableArgs<T extends Reorderable> {
   items: readonly T[];
   onReorder: (fromIdx: number, toIdx: number) => void;
+  /**
+   * Optional group key extractor. When supplied alongside `onTransfer`, a drop
+   * onto an item in a *different* group fires `onTransfer` instead of
+   * `onReorder` — letting the caller rewrite the dragged item's group value
+   * in addition to repositioning it. Within-group drops still fire `onReorder`.
+   *
+   * Omitting both keeps the hook in single-array mode (existing behaviour).
+   */
+  getGroupKey?: (item: T) => string | undefined;
+  /**
+   * Fires when an item is dropped onto a target in a different group. The
+   * receiver is responsible for both the group rewrite (e.g. patching the
+   * row's group-field value) and the positional reorder.
+   */
+  onTransfer?: (itemId: string, toGroupKey: string | undefined, toIdx: number) => void;
 }
 
 /**
- * Tiny HTML5 drag-drop helper for column/row reorder. Mirrors the contract
- * from the Edit Sheet Option A design (`shared.jsx:238`):
- * - `source(id)` props go on the drag handle (type-icon span for columns,
- *   `#` cell for rows).
- * - `target(id)` props go on the whole item container so the drop-indicator
- *   border spans the full cell/row.
- * - `dragId` / `overId` let the consumer paint the drag/drop styling.
+ * HTML5 drag-drop helper. Item reorder within a flat list (default); when
+ * the optional `getGroupKey` + `onTransfer` pair is supplied, drops across
+ * groups route to `onTransfer` so callers can update both the row's group
+ * value and its sort position.
  *
- * `onReorder(from, to)` is called once on a successful drop where the source
- * and target differ. Same-source drop and missing IDs are no-ops. `Esc`
- * cancellation is handled by the browser (no `drop` event fires).
+ * - `source(id)` props go on the drag handle.
+ * - `target(id)` props go on the whole item container.
+ * - `dragId` / `overId` let the consumer paint drag/drop styling.
  */
 export function useReorderable<T extends Reorderable>({
   items,
   onReorder,
+  getGroupKey,
+  onTransfer,
 }: UseReorderableArgs<T>): UseReorderableResult {
   const [dragId, setDragId] = useState<string | null>(null);
   const [overId, setOverId] = useState<string | null>(null);
@@ -57,13 +71,10 @@ export function useReorderable<T extends Reorderable>({
         draggable: true,
         onDragStart: (e) => {
           e.dataTransfer.effectAllowed = 'move';
-          // `setData` can throw under restricted contexts (some test envs,
-          // sandboxed iframes). It's a best-effort signal — state is the
-          // source of truth, so swallow rather than abort the drag.
           try {
             e.dataTransfer.setData('text/plain', id);
           } catch {
-            // ignore
+            // ignore — restricted contexts; state is the source of truth.
           }
           setDragId(id);
         },
@@ -79,8 +90,6 @@ export function useReorderable<T extends Reorderable>({
           if (!dragId) return;
           e.preventDefault();
           if (dragId === id) {
-            // Pointer is back over the source — clear any indicator left on
-            // a previously-hovered target so it doesn't stay painted.
             if (overId !== null) setOverId(null);
             return;
           }
@@ -90,7 +99,23 @@ export function useReorderable<T extends Reorderable>({
           e.preventDefault();
           const from = items.findIndex((i) => i.id === dragId);
           const to = items.findIndex((i) => i.id === id);
-          if (from >= 0 && to >= 0 && from !== to) onReorder(from, to);
+          if (from < 0 || to < 0 || from === to) {
+            setDragId(null);
+            setOverId(null);
+            return;
+          }
+          const source = items[from];
+          const target = items[to];
+          const transferAllowed =
+            typeof getGroupKey === 'function' && typeof onTransfer === 'function';
+          const sourceGroup = transferAllowed && source ? getGroupKey(source) : undefined;
+          const targetGroup = transferAllowed && target ? getGroupKey(target) : undefined;
+          const crossGroup = transferAllowed && sourceGroup !== targetGroup;
+          if (crossGroup && onTransfer && dragId) {
+            onTransfer(dragId, targetGroup, to);
+          } else {
+            onReorder(from, to);
+          }
           setDragId(null);
           setOverId(null);
         },

--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { useGridState, type GridField, type GridRow } from '../build-grid/useGridState';
+import { useReorderable } from '../build-grid/useReorderable';
 import { Editable } from './Editable';
 import { EditingRail } from './EditingRail';
 import { FieldsPopover } from './FieldsPopover';
@@ -82,6 +83,7 @@ export function BuildWysiwyg({
     deleteRow,
     editCell,
     setCapacity,
+    moveRow,
   } = useGridState(
     signupId,
     initialFields,
@@ -108,6 +110,27 @@ export function BuildWysiwyg({
   );
 
   const groups = useMemo(() => partitionRows(state.rows, groupField), [state.rows, groupField]);
+
+  const slotReorder = useReorderable<GridRow>({
+    items: state.rows,
+    onReorder: (fromIdx, toIdx) => { void moveRow(fromIdx, toIdx); },
+    ...(groupField
+      ? {
+          getGroupKey: (row) => {
+            const v = row.values[groupField.ref] ?? '';
+            return v === '' ? EMPTY_GROUP_KEY : v;
+          },
+          onTransfer: (rowId, toGroupKey, toIdx) => {
+            const newGroupValue = toGroupKey === EMPTY_GROUP_KEY ? '' : (toGroupKey ?? '');
+            editCell(rowId, groupField.ref, newGroupValue);
+            const fromIdx = state.rows.findIndex((r) => r.id === rowId);
+            if (fromIdx >= 0 && fromIdx !== toIdx) {
+              void moveRow(fromIdx, toIdx);
+            }
+          },
+        }
+      : {}),
+  });
 
   const handleAddSlot = (groupKey: string) => {
     const seedValues: Record<string, string> = {};
@@ -198,6 +221,7 @@ export function BuildWysiwyg({
                 }}
                 onAddSlot={handleAddSlot}
                 onRenameGroup={handleRenameGroup}
+                reorder={slotReorder}
               />
             ))}
           </div>

--- a/src/components/build-wysiwyg/WysiwygGroup.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.tsx
@@ -4,6 +4,7 @@ import { Plus } from 'lucide-react';
 import { Editable } from './Editable';
 import { WysiwygSlot } from './WysiwygSlot';
 import { prettyHeader } from './prettyHeader';
+import type { UseReorderableResult } from '../build-grid/useReorderable';
 import type { GridField, GridRow } from '../build-grid/useGridState';
 
 export type SlotGroup = {
@@ -29,6 +30,8 @@ type WysiwygGroupProps = {
   onDeleteRow: (rowId: string) => void;
   onAddSlot: (groupKey: string) => void;
   onRenameGroup: (oldKey: string, newKey: string) => void;
+  /** Shared drag-reorder bindings for slot rows. */
+  reorder?: UseReorderableResult;
 };
 
 export function WysiwygGroup({
@@ -46,6 +49,7 @@ export function WysiwygGroup({
   onDeleteRow,
   onAddSlot,
   onRenameGroup,
+  reorder,
 }: WysiwygGroupProps) {
   const showHeader = groupField !== null;
   const display = groupField ? prettyHeader(group.rawValue, groupField.type) : '';
@@ -80,6 +84,7 @@ export function WysiwygGroup({
             onAddEnumOption={onAddEnumOption}
             onDuplicate={() => onDuplicateRow(row.id)}
             onDelete={() => onDeleteRow(row.id)}
+            {...(reorder ? { reorder } : {})}
           />
         ))}
         <button

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Copy, Pencil, Trash2 } from 'lucide-react';
+import { Copy, GripVertical, Pencil, Trash2 } from 'lucide-react';
 import { SlotEditor } from './SlotEditor';
+import type { UseReorderableResult } from '../build-grid/useReorderable';
 import type { GridField, GridRow } from '../build-grid/useGridState';
 
 type WysiwygSlotProps = {
@@ -17,6 +18,8 @@ type WysiwygSlotProps = {
   onAddEnumOption: (fieldId: string, value: string) => void;
   onDuplicate: () => void;
   onDelete: () => void;
+  /** Optional drag-reorder bindings. When omitted, the grip is hidden. */
+  reorder?: UseReorderableResult;
 };
 
 /**
@@ -38,6 +41,7 @@ export function WysiwygSlot({
   onAddEnumOption,
   onDuplicate,
   onDelete,
+  reorder,
 }: WysiwygSlotProps) {
   if (expanded) {
     return (
@@ -65,11 +69,34 @@ export function WysiwygSlot({
     .filter((v) => v && v.length > 0)
     .join(' \u00b7 ');
 
+  const isDragging = reorder?.dragId === row.id;
+  const isDropTarget = reorder?.overId === row.id && reorder?.dragId && reorder?.dragId !== row.id;
+  const dragTargetProps = reorder?.target(row.id) ?? {};
+
   return (
     <div
       data-testid={`wysiwyg-slot-${row.id}`}
-      className="group relative border-t border-transparent first:border-t-0 focus-within:bg-surface-raised/50 hover:bg-surface-raised/50"
+      {...dragTargetProps}
+      className={
+        'group relative border-t first:border-t-0 transition-colors duration-180 ' +
+        (isDragging
+          ? 'border-transparent bg-brand-soft opacity-50'
+          : isDropTarget
+            ? 'border-t-2 border-brand bg-surface-raised'
+            : 'border-transparent focus-within:bg-surface-raised/50 hover:bg-surface-raised/50')
+      }
     >
+      {reorder && (
+        <span
+          {...reorder.source(row.id)}
+          role="button"
+          aria-label="Drag to reorder slot"
+          tabIndex={0}
+          className="absolute -left-1 top-1/2 z-10 inline-flex h-6 w-4 -translate-y-1/2 cursor-grab items-center justify-center text-ink-soft opacity-0 transition-opacity duration-180 group-hover:opacity-95 group-focus-within:opacity-95"
+        >
+          <GripVertical size={11} />
+        </span>
+      )}
       <button
         type="button"
         onClick={onExpand}


### PR DESCRIPTION
Slice 6 — slot rows can now be dragged. Within-group drops reorder sort
order; cross-group drops also rewrite the row's group-field value.

## What's in PR 6

- **useReorderable** gains an optional `getGroupKey` + `onTransfer`
  pair. Backward-compatible: existing call sites (grid column drag,
  row drag, fields modal reorder) are untouched.
- **WysiwygSlot** renders a GripVertical handle at the row's left edge,
  revealed on hover OR focus-within (keyboard parity). Row container
  takes the drop-target props.
- **BuildWysiwyg** owns the single hook. `getGroupKey` reads each row's
  group-field value (with the EMPTY_GROUP_KEY sentinel for blanks).
  `onTransfer(rowId, toGroupKey, toIdx)` issues `editCell` to rewrite
  the group-field value AND `moveRow` for the position change — both
  go through the existing optimistic hook machinery, so the activity
  log entry lands via the same `slot.updated` path.
- When there is no group field (flat mode), the optional options are
  omitted and drops collapse to plain `onReorder`.

## Tests

- New cross-group cases in `useReorderable.test.ts` — within-group ->
  onReorder, cross-group -> onTransfer with target group + index,
  undefined group keys count as their own bucket, missing onTransfer
  falls back to onReorder.

526 unit tests pass; lint + typecheck clean.

## What's NOT in PR 6

- Responsive layout (PR 7)
- Cutover + delete grid (PR 8a / 8b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)