### PR TITLE
feat(build-wysiwyg): PR 7 — responsive sheet (unify mobile)

### DIFF
--- a/src/components/build-wysiwyg/BuildWysiwyg.test.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { BuildWysiwyg } from './BuildWysiwyg';
+import type { SignupSettings } from '@/schemas/signups';
+
+const settings: SignupSettings = {
+  requireEmail: true,
+  allowNotes: true,
+  showWhoSignedUp: true,
+  lockoutHoursBeforeSlot: 0,
+  sendReminders: true,
+  groupByFieldRefs: [],
+};
+
+const baseProps = {
+  signupId: 'sig_t',
+  signupMeta: {
+    title: 'Sample',
+    description: 'd',
+    slug: 'sample',
+    status: 'draft' as const,
+  },
+  initialFields: [],
+  initialSlots: [],
+  initialSettings: settings,
+};
+
+function findSheet(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('div[class*="border-t-brand"]');
+}
+
+describe('BuildWysiwyg — responsive sheet layout', () => {
+  it('applies mobile-first full-bleed + md-clamp classes', () => {
+    const { container } = render(<BuildWysiwyg {...baseProps} />);
+    const sheet = findSheet(container);
+    expect(sheet).toBeTruthy();
+    const cls = sheet!.className;
+    // Mobile: full-bleed, square corners.
+    expect(cls).toMatch(/\bw-full\b/);
+    expect(cls).toMatch(/\brounded-none\b/);
+    // Desktop: max-width clamp + rounded corners.
+    expect(cls).toMatch(/md:max-w-\[580px\]/);
+    expect(cls).toMatch(/\bmd:rounded-xl\b/);
+    // mx-auto for desktop centring.
+    expect(cls).toMatch(/\bmx-auto\b/);
+  });
+
+  it('grows the desktop max-width with field count', () => {
+    const make = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: `f${i}`,
+        ref: `f${i}`,
+        label: `F${i}`,
+        fieldType: 'text' as const,
+        sortOrder: i,
+        config: { fieldType: 'text' as const, maxLength: 200 },
+      }));
+    const four = render(<BuildWysiwyg {...baseProps} initialFields={make(4)} />);
+    expect(findSheet(four.container)!.className).toMatch(/md:max-w-\[720px\]/);
+    four.unmount();
+
+    const six = render(<BuildWysiwyg {...baseProps} initialFields={make(6)} />);
+    expect(findSheet(six.container)!.className).toMatch(/md:max-w-\[960px\]/);
+  });
+});

--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -27,11 +27,15 @@ type BuildWysiwygProps = {
 
 const EMPTY_GROUP_KEY = '__empty__';
 
-/** Maximum sheet width grows with field count — keeps small schemas tight, wide ones legible. */
+/**
+ * Maximum sheet width grows with field count above the `md` breakpoint —
+ * keeps small schemas tight, wide ones legible. Below `md` the sheet goes
+ * full-bleed so cramped phone screens don't waste margins.
+ */
 function sheetMaxWidthClass(fieldCount: number): string {
-  if (fieldCount <= 3) return 'max-w-[580px]';
-  if (fieldCount === 4) return 'max-w-[720px]';
-  return 'max-w-[960px]';
+  if (fieldCount <= 3) return 'md:max-w-[580px]';
+  if (fieldCount === 4) return 'md:max-w-[720px]';
+  return 'md:max-w-[960px]';
 }
 
 /** Bucket rows by the group field's value. Empty / missing values go into `__empty__`. */
@@ -163,7 +167,12 @@ export function BuildWysiwyg({
   return (
     <div className="min-h-[calc(100vh-12rem)] bg-surface-raised">
       <div
-        className={`mx-auto w-full ${sheetMaxWidthClass(state.fields.length)} my-6 mb-32 rounded-xl border border-surface-sunk border-t-[3px] border-t-brand bg-white shadow-card transition-[max-width] duration-180 ease-emphasized`}
+        className={
+          'mx-auto w-full my-3 mb-24 md:my-6 md:mb-32 ' +
+          'rounded-none md:rounded-xl border border-surface-sunk border-t-[3px] border-t-brand bg-white shadow-card ' +
+          'transition-[max-width] duration-180 ease-emphasized ' +
+          sheetMaxWidthClass(state.fields.length)
+        }
       >
         <EditingRail
           fieldCount={state.fields.length}
@@ -173,7 +182,7 @@ export function BuildWysiwyg({
           saveStatus={state.saveStatus}
         />
 
-        <div className="px-7 pt-5 pb-6">
+        <div className="px-4 pt-4 pb-5 md:px-7 md:pt-5 md:pb-6">
           <Editable
             value={state.title}
             onChange={(next) => updateSignupMeta({ title: next })}
@@ -193,7 +202,7 @@ export function BuildWysiwyg({
             />
           </div>
 
-          <div className="mt-6 flex flex-col gap-5">
+          <div className="mt-5 flex flex-col gap-4 md:mt-6 md:gap-5">
             {groups.map((g) => (
               <WysiwygGroup
                 key={g.key}


### PR DESCRIPTION
Slice 7 — one B/3 layout for both desktop and mobile.

## What's in PR 7

- Sheet collapses to full-bleed below the `md` breakpoint (768px):
  `w-full rounded-none my-3 mb-24`.
- Above `md`, the original dynamic max-width clamp returns
  (`md:max-w-[580px] / [720px] / [960px]` based on field count) with
  rounded corners + larger margins.
- Sheet-body padding tightens on narrow viewports (`px-4 pt-4 pb-5`)
  and the group gap shrinks (`mt-5 gap-4`).
- FieldsPopover modal already uses `max-w-[calc(100%-2rem)]` so it
  fits a 360px viewport unchanged.

## Tests

- `BuildWysiwyg.test.tsx` — asserts both mobile (`w-full`,
  `rounded-none`) and desktop (`md:rounded-xl`,
  `md:max-w-[580/720/960]px`) variants are composed correctly.

528 unit tests pass; lint + typecheck clean.

## What's NOT in PR 7

- Cutover + delete grid + MobileBuildGrid (PR 8a / 8b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)