### PR TITLE
feat(build-wysiwyg): PR 8a — cutover (render BuildWysiwyg by default)

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/build/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/build/page.tsx
@@ -3,20 +3,15 @@ import { after } from 'next/server';
 import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { recordOrganizerView } from '@/lib/view-tracker';
-import { BuildGrid } from '@/components/build-grid';
 import { BuildWysiwyg } from '@/components/build-wysiwyg/BuildWysiwyg';
 import { AiDraftBanner } from '@/components/magic-compose/AiDraftBanner';
 import { PublishedBanner } from '@/components/signup/PublishedBanner';
 import { SignupSettingsSchema, type SignupStatus } from '@/schemas/signups';
 
-type PageParams = {
-  params: Promise<{ id: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-};
+type PageParams = { params: Promise<{ id: string }> };
 
-export default async function BuildTab({ params, searchParams }: PageParams) {
+export default async function BuildTab({ params }: PageParams) {
   const { id } = await params;
-  const sp = await searchParams;
   const session = await getOrganizerSession();
   if (!session) redirect(`/login?callbackUrl=/app/signups/${id}/build`);
   const result = await loadSignupForOrganizer(toActor(session), id);
@@ -30,21 +25,6 @@ export default async function BuildTab({ params, searchParams }: PageParams) {
       eventType: 'signup.viewed',
     }),
   );
-  // Dev-only toggle while B/3 is in flight; removed at the PR 8a cutover.
-  const useWysiwyg = sp['wysiwyg'] === '1';
-  const meta = {
-    title: sig.title,
-    description: sig.description,
-    status: sig.status as SignupStatus,
-    slug: sig.slug,
-  };
-  const slots = sig.slots.map((s) => ({
-    id: s.id,
-    capacity: s.capacity ?? null,
-    sortOrder: s.sortOrder,
-    values: (s.values ?? {}) as Record<string, unknown>,
-  }));
-  const settings = SignupSettingsSchema.parse(sig.settings ?? {});
   return (
     <>
       <PublishedBanner signupStatus={sig.status} />
@@ -54,23 +34,23 @@ export default async function BuildTab({ params, searchParams }: PageParams) {
         fieldsCount={sig.fields.length}
         slotsCount={sig.slots.length}
       />
-      {useWysiwyg ? (
-        <BuildWysiwyg
-          signupId={id}
-          signupMeta={meta}
-          initialFields={sig.fields}
-          initialSlots={slots}
-          initialSettings={settings}
-        />
-      ) : (
-        <BuildGrid
-          signupId={id}
-          signupMeta={meta}
-          initialFields={sig.fields}
-          initialSlots={slots}
-          initialSettings={settings}
-        />
-      )}
+      <BuildWysiwyg
+        signupId={id}
+        signupMeta={{
+          title: sig.title,
+          description: sig.description,
+          status: sig.status as SignupStatus,
+          slug: sig.slug,
+        }}
+        initialFields={sig.fields}
+        initialSlots={sig.slots.map((s) => ({
+          id: s.id,
+          capacity: s.capacity ?? null,
+          sortOrder: s.sortOrder,
+          values: (s.values ?? {}) as Record<string, unknown>,
+        }))}
+        initialSettings={SignupSettingsSchema.parse(sig.settings ?? {})}
+      />
     </>
   );
 }


### PR DESCRIPTION
The user-facing cutover. \`build/page.tsx\` now renders \`BuildWysiwyg\`
for everyone — no query param, no fallback. Mechanical file deletions
land in PR 8b.

## What's in PR 8a

- \`src/app/app/(chrome)/signups/[id]/build/page.tsx\`:
  - Removed the dev-only \`?wysiwyg=1\` branch and the \`searchParams\`
    plumbing it required.
  - Removed the \`BuildGrid\` import.
  - Renders \`BuildWysiwyg\` unconditionally with the same props.

## Tests

- 528 unit tests pass; lint + typecheck clean.
- Chrome MCP smoke at \`/app/signups/[id]/build\` (no query param)
  confirms the WYSIWYG sheet mounts, EditingRail is present, and no
  legacy grid columns render.

## What's NOT in PR 8a

- Deletion of the grid components and their tests (PR 8b)
- Relocation of the kept hooks (\`useGridState\`, \`useReorderable\`,
  \`fieldTypes\`, \`SaveStatus\`) — also deferred to 8b or a later cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)