### PR TITLE
fix(signup-header): remove duplicate description from editing page

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/layout.tsx
+++ b/src/app/app/(chrome)/signups/[id]/layout.tsx
@@ -48,7 +48,6 @@ export default async function SignupDetailLayout({ children, params }: LayoutPro
       <SignupHeader
         signupId={id}
         title={sig.title}
-        description={sig.description ?? null}
         status={sig.status as SignupStatus}
         publicUrl={publicSignupUrl(sig.slug)}
         publishAction={publishAction.bind(null, id)}

--- a/src/components/signup/MobileSignupHeader.tsx
+++ b/src/components/signup/MobileSignupHeader.tsx
@@ -10,7 +10,6 @@ import { MobileMoreMenuSheet } from './MobileMoreMenuSheet';
 interface MobileSignupHeaderProps {
   signupId: string;
   title: string;
-  description: string | null;
   status: SignupStatus;
   publicUrl: string;
   publishAction: () => void | Promise<void>;
@@ -20,7 +19,6 @@ interface MobileSignupHeaderProps {
 export function MobileSignupHeader({
   signupId,
   title,
-  description,
   status,
   publicUrl,
   publishAction,
@@ -47,10 +45,6 @@ export function MobileSignupHeader({
             <MoreHorizontal size={20} aria-hidden="true" />
           </button>
         </div>
-
-        {description ? (
-          <p className="text-sm leading-relaxed text-ink-muted">{description}</p>
-        ) : null}
 
         <PublicLinkChip url={publicUrl} />
       </header>

--- a/src/components/signup/SignupHeader.tsx
+++ b/src/components/signup/SignupHeader.tsx
@@ -9,7 +9,6 @@ import { MobileSignupHeader } from './MobileSignupHeader';
 interface SignupHeaderProps {
   signupId: string;
   title: string;
-  description: string | null;
   status: SignupStatus;
   publicUrl: string;
   publishAction: () => void | Promise<void>;
@@ -19,7 +18,6 @@ interface SignupHeaderProps {
 export function SignupHeader({
   signupId,
   title,
-  description,
   status,
   publicUrl,
   publishAction,
@@ -38,7 +36,6 @@ export function SignupHeader({
         <MobileSignupHeader
           signupId={signupId}
           title={title}
-          description={description}
           status={status}
           publicUrl={publicUrl}
           publishAction={publishAction}
@@ -52,9 +49,6 @@ export function SignupHeader({
             <h1 className="truncate text-2xl font-semibold tracking-tight">{title}</h1>
             <StatusPill status={status} />
           </div>
-          {description ? (
-            <p className="text-ink-muted max-w-full text-sm leading-relaxed">{description}</p>
-          ) : null}
         </div>
         <div className={`grid w-full max-w-full shrink-0 ${gridColsClass} gap-x-2 gap-y-3 sm:w-auto sm:max-w-sm`}>
           <Link


### PR DESCRIPTION
## Summary
- Description was shown twice on the signup editing page (in the header and again in the WYSIWYG editor below); removed the header copy.
- Dropped the now-unused `description` prop from `SignupHeader` and `MobileSignupHeader`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (466 passed)
- [x] Visually confirm description no longer appears at the top of `/app/signups/[id]` on desktop and mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)