### PR TITLE
style(build-wysiwyg): make grey body flush with tabs

### DIFF
--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -171,14 +171,9 @@ export function BuildWysiwyg({
   };
 
   return (
-    <div className="min-h-[calc(100vh-12rem)] bg-surface-raised">
+    <div className="-mt-6 -mb-8 min-h-[calc(100vh-12rem)] bg-surface-raised pt-6 pb-24 md:pt-10 md:pb-32">
       <div
-        className={
-          'mx-auto w-full my-3 mb-24 md:my-6 md:mb-32 ' +
-          'rounded-none md:rounded-xl border border-surface-sunk border-t-[3px] border-t-brand bg-white shadow-card ' +
-          'transition-[max-width] duration-180 ease-emphasized ' +
-          sheetMaxWidthClass(state.fields.length)
-        }
+        className={`mx-auto w-full rounded-none border border-surface-sunk border-t-[3px] border-t-brand bg-white shadow-card transition-[max-width] duration-180 ease-emphasized md:rounded-xl ${sheetMaxWidthClass(state.fields.length)}`}
       >
         <EditingRail
           fieldCount={state.fields.length}


### PR DESCRIPTION
## Summary
- The build tab's grey background had a white gap above it because the sheet's `my-*` margin was collapsing through the wrapper (which had no `padding-top`), leaking that gap upward
- Moved the spacing to `pt-*`/`pb-*` on the grey wrapper (padding doesn't collapse) and paired it with `-mt-6`/`-mb-8` to absorb the surrounding `space-y-6`/`py-8`, so the grey now sits flush against the tabs and fills the bottom gutter
- Collapsed the sheet's split-string `className` into a single template literal while in there

## Test plan
- [x] On `/app/signups/[id]/build`, confirm grey extends right up to the tabs (no white band)
- [x] Confirm grey horizontal width matches the tabs/header (does not overflow)
- [ ] Confirm the white sheet has ~24px (mobile) / ~40px (desktop) breathing room inside the grey
- [x] `pnpm lint && pnpm typecheck && pnpm test` ✅ (466 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)