### PR TITLE
style(signup-layout): move banners above tabs for consistent placement

### DIFF
--- a/src/app/app/(chrome)/signups/[id]/build/page.tsx
+++ b/src/app/app/(chrome)/signups/[id]/build/page.tsx
@@ -4,8 +4,6 @@ import { getOrganizerSession, toActor } from '@/auth/session';
 import { loadSignupForOrganizer } from '@/services/signups.cached';
 import { recordOrganizerView } from '@/lib/view-tracker';
 import { BuildWysiwyg } from '@/components/build-wysiwyg/BuildWysiwyg';
-import { AiDraftBanner } from '@/components/magic-compose/AiDraftBanner';
-import { PublishedBanner } from '@/components/signup/PublishedBanner';
 import { SignupSettingsSchema, type SignupStatus } from '@/schemas/signups';
 
 type PageParams = { params: Promise<{ id: string }> };
@@ -27,13 +25,6 @@ export default async function BuildTab({ params }: PageParams) {
   );
   return (
     <>
-      <PublishedBanner signupStatus={sig.status} />
-      <AiDraftBanner
-        signupId={sig.id}
-        signupStatus={sig.status}
-        fieldsCount={sig.fields.length}
-        slotsCount={sig.slots.length}
-      />
       <BuildWysiwyg
         signupId={id}
         signupMeta={{

--- a/src/app/app/(chrome)/signups/[id]/layout.tsx
+++ b/src/app/app/(chrome)/signups/[id]/layout.tsx
@@ -7,6 +7,8 @@ import { countCommitmentsForSignup } from '@/services/commitments';
 import { publicSignupUrl } from '@/lib/links';
 import { SignupHeader } from '@/components/signup/SignupHeader';
 import { TabsNav } from '@/components/signup/TabsNav';
+import { AiDraftBanner } from '@/components/magic-compose/AiDraftBanner';
+import { PublishedBanner } from '@/components/signup/PublishedBanner';
 import type { SignupStatus } from '@/schemas/signups';
 import { closeAction, publishAction } from './actions';
 
@@ -52,6 +54,13 @@ export default async function SignupDetailLayout({ children, params }: LayoutPro
         publicUrl={publicSignupUrl(sig.slug)}
         publishAction={publishAction.bind(null, id)}
         closeAction={closeAction.bind(null, id)}
+      />
+      <PublishedBanner signupStatus={sig.status} />
+      <AiDraftBanner
+        signupId={id}
+        signupStatus={sig.status}
+        fieldsCount={sig.fields.length}
+        slotsCount={sig.slots.length}
       />
       <TabsNav
         signupId={id}

--- a/src/components/magic-compose/AiDraftBanner.tsx
+++ b/src/components/magic-compose/AiDraftBanner.tsx
@@ -44,7 +44,7 @@ export function AiDraftBanner({
   };
 
   return (
-    <div className="mb-4 flex flex-col gap-3">
+    <div className="flex flex-col gap-3">
       <Banner
         kind="aiDraft"
         title={`Here's your draft, ${fieldsCount} ${

--- a/src/components/signup/PublishedBanner.tsx
+++ b/src/components/signup/PublishedBanner.tsx
@@ -22,13 +22,11 @@ export function PublishedBanner({ signupStatus }: { signupStatus: string }) {
   };
 
   return (
-    <div className="mb-4">
-      <Banner
-        kind="published"
-        title="Signup published"
-        body="Your signup is live. Share the public link to start collecting responses."
-        onDismiss={onDismiss}
-      />
-    </div>
+    <Banner
+      kind="published"
+      title="Signup published"
+      body="Your signup is live. Share the public link to start collecting responses."
+      onDismiss={onDismiss}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Hoist `PublishedBanner` and `AiDraftBanner` from the Build tab into the shared signup layout so they render above `TabsNav` regardless of which banner fires.
- Drop the leftover `mb-4` from each banner wrapper now that the layout's `space-y-6` controls the surrounding spacing, leaving equal gaps above and below.

## Test plan
- [x] Visit a draft signup via Magic Compose (`?aiDraft=1`) and confirm the banner sits between the header and the tabs.
- [x] Publish a signup and confirm the \"Signup published\" banner appears above the tabs.
- [x] Switch tabs while a banner is active and confirm it stays in the same position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)