### PR TITLE
fix(build-wysiwyg): use first field value as collapsed slot label

### DIFF
--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -114,9 +114,8 @@ export function BuildWysiwyg({
   const groupField = state.groupByFieldRef
     ? state.fields.find((f) => f.ref === state.groupByFieldRef) ?? null
     : null;
-  // Fields shown on the collapsed slot row, in the organizer's chosen order.
-  // The first entry becomes the row's primary anchor; the rest form the summary.
-  // No type-based preference — order is what the organizer set in the Fields panel.
+  // Non-group fields in organizer order. WysiwygSlot treats index 0 as the
+  // collapsed row's anchor — order matters, no type-based promotion here.
   const displayFields = state.fields.filter((f) => f.ref !== groupField?.ref);
 
   const groups = useMemo(() => partitionRows(state.rows, groupField), [state.rows, groupField]);

--- a/src/components/build-wysiwyg/BuildWysiwyg.tsx
+++ b/src/components/build-wysiwyg/BuildWysiwyg.tsx
@@ -114,10 +114,10 @@ export function BuildWysiwyg({
   const groupField = state.groupByFieldRef
     ? state.fields.find((f) => f.ref === state.groupByFieldRef) ?? null
     : null;
-  const timeField = state.fields.find((f) => f.config.fieldType === 'time') ?? null;
-  const otherFields = state.fields.filter(
-    (f) => f.ref !== groupField?.ref && f.ref !== timeField?.ref,
-  );
+  // Fields shown on the collapsed slot row, in the organizer's chosen order.
+  // The first entry becomes the row's primary anchor; the rest form the summary.
+  // No type-based preference — order is what the organizer set in the Fields panel.
+  const displayFields = state.fields.filter((f) => f.ref !== groupField?.ref);
 
   const groups = useMemo(() => partitionRows(state.rows, groupField), [state.rows, groupField]);
 
@@ -208,8 +208,7 @@ export function BuildWysiwyg({
                 key={g.key}
                 group={g}
                 groupField={groupField}
-                timeField={timeField}
-                otherFields={otherFields}
+                displayFields={displayFields}
                 fields={state.fields}
                 expandedRowId={expandedRowId}
                 onExpandRow={setExpandedRowId}

--- a/src/components/build-wysiwyg/WysiwygGroup.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.test.tsx
@@ -28,8 +28,7 @@ function makeField(overrides: Partial<GridField> = {}): GridField {
 function renderGroup(overrides: {
   group?: Partial<SlotGroup>;
   groupField?: GridField | null;
-  timeField?: GridField | null;
-  otherFields?: GridField[];
+  displayFields?: GridField[];
   fields?: GridField[];
   expandedRowId?: string | null;
   onExpandRow?: ReturnType<typeof vi.fn>;
@@ -61,8 +60,7 @@ function renderGroup(overrides: {
     <WysiwygGroup
       group={group}
       groupField={groupField}
-      timeField={overrides.timeField ?? null}
-      otherFields={overrides.otherFields ?? []}
+      displayFields={overrides.displayFields ?? []}
       fields={overrides.fields ?? (groupField ? [groupField] : [])}
       expandedRowId={overrides.expandedRowId ?? null}
       onExpandRow={onExpandRow}

--- a/src/components/build-wysiwyg/WysiwygGroup.tsx
+++ b/src/components/build-wysiwyg/WysiwygGroup.tsx
@@ -18,8 +18,11 @@ export type SlotGroup = {
 type WysiwygGroupProps = {
   group: SlotGroup;
   groupField: GridField | null;
-  timeField: GridField | null;
-  otherFields: GridField[];
+  /**
+   * All non-group fields in organizer-chosen order. The first becomes the
+   * collapsed row's primary anchor; the rest form the summary.
+   */
+  displayFields: GridField[];
   fields: GridField[];
   expandedRowId: string | null;
   onExpandRow: (rowId: string | null) => void;
@@ -38,8 +41,7 @@ type WysiwygGroupProps = {
 export function WysiwygGroup({
   group,
   groupField,
-  timeField,
-  otherFields,
+  displayFields,
   fields,
   expandedRowId,
   onExpandRow,
@@ -75,8 +77,7 @@ export function WysiwygGroup({
             key={row.id}
             row={row}
             fields={fields}
-            timeField={timeField}
-            otherFields={otherFields}
+            displayFields={displayFields}
             expanded={expandedRowId === row.id}
             onExpand={() => onExpandRow(row.id)}
             onCollapse={() => onExpandRow(null)}

--- a/src/components/build-wysiwyg/WysiwygSlot.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.test.tsx
@@ -28,8 +28,7 @@ function makeRow(overrides: Partial<GridRow> = {}): GridRow {
 type RenderProps = {
   expanded?: boolean;
   row?: GridRow;
-  timeField?: GridField | null;
-  otherFields?: GridField[];
+  displayFields?: GridField[];
   onExpand?: ReturnType<typeof vi.fn>;
   onCollapse?: ReturnType<typeof vi.fn>;
   onEditCell?: ReturnType<typeof vi.fn>;
@@ -47,22 +46,21 @@ function renderSlot(overrides: RenderProps = {}) {
   const onAddEnumOption = overrides.onAddEnumOption ?? vi.fn();
   const onDuplicate = overrides.onDuplicate ?? vi.fn();
   const onDelete = overrides.onDelete ?? vi.fn();
-  const defaultTimeField = makeField({ ref: 'shift', name: 'Shift' });
-  const defaultOtherField = makeField({
-    id: 'f2',
-    ref: 'notes',
-    name: 'Notes',
-    config: { fieldType: 'text', maxLength: 200 },
-  });
-  const timeField = overrides.timeField === undefined ? defaultTimeField : overrides.timeField;
-  const otherFields = overrides.otherFields ?? [defaultOtherField];
-  const fields = [...(timeField ? [timeField] : []), ...otherFields];
+  const defaultDisplayFields: GridField[] = [
+    makeField({ ref: 'shift', name: 'Shift' }),
+    makeField({
+      id: 'f2',
+      ref: 'notes',
+      name: 'Notes',
+      config: { fieldType: 'text', maxLength: 200 },
+    }),
+  ];
+  const displayFields = overrides.displayFields ?? defaultDisplayFields;
   const utils = render(
     <WysiwygSlot
       row={overrides.row ?? makeRow()}
-      fields={fields}
-      timeField={timeField}
-      otherFields={otherFields}
+      fields={displayFields}
+      displayFields={displayFields}
       expanded={overrides.expanded ?? false}
       onExpand={onExpand}
       onCollapse={onCollapse}
@@ -84,7 +82,7 @@ describe('WysiwygSlot — collapsed', () => {
     expect(screen.getByText('0/2')).toBeTruthy();
   });
 
-  it('falls back to "Set a time" placeholder when the time field is empty', () => {
+  it('falls back to "Set a time" placeholder when the anchor is a time field with no value', () => {
     renderSlot({ row: makeRow({ values: { shift: '', notes: '' } }) });
     expect(screen.getByText('Set a time')).toBeTruthy();
   });
@@ -120,7 +118,25 @@ describe('WysiwygSlot — collapsed', () => {
     expect(onExpand).not.toHaveBeenCalled();
   });
 
-  describe('no time field', () => {
+  describe('anchor = first field by order', () => {
+    const date = makeField({
+      id: 'f-date',
+      ref: 'date',
+      name: 'Date',
+      config: { fieldType: 'date' },
+    });
+    const category = makeField({
+      id: 'f-cat',
+      ref: 'category',
+      name: 'Item Category',
+      config: { fieldType: 'enum', choices: ['Mains', 'Sides'] },
+    });
+    const time = makeField({
+      id: 'f-time',
+      ref: 'time',
+      name: 'Time',
+      config: { fieldType: 'time' },
+    });
     const activity = makeField({
       id: 'f-act',
       ref: 'activity',
@@ -134,10 +150,20 @@ describe('WysiwygSlot — collapsed', () => {
       config: { fieldType: 'text', maxLength: 200 },
     });
 
-    it('promotes the first other field value to the primary label and drops it from the summary', () => {
+    it('uses the first field by order as the anchor, even when a later field is time-typed', () => {
+      // Regression: Potluck signup (Date, Item Category, Time) used to highlight
+      // Time because of the type-based promotion. Now Date — field 0 — wins.
       renderSlot({
-        timeField: null,
-        otherFields: [activity, location],
+        displayFields: [date, category, time],
+        row: makeRow({ values: { date: '2026-05-29', category: 'Mains', time: '17:00' } }),
+      });
+      expect(screen.getByText('2026-05-29')).toBeTruthy();
+      expect(screen.getByText('Mains \u00b7 17:00')).toBeTruthy();
+    });
+
+    it('promotes the first field value and drops it from the summary', () => {
+      renderSlot({
+        displayFields: [activity, location],
         row: makeRow({ values: { activity: 'Surfing', location: 'Cordoba' } }),
       });
       expect(screen.getByText('Surfing')).toBeTruthy();
@@ -146,10 +172,9 @@ describe('WysiwygSlot — collapsed', () => {
       expect(screen.queryByText('Slot')).toBeNull();
     });
 
-    it('shows "Set ${name}" placeholder when the first other field is empty', () => {
+    it('shows "Set ${name}" placeholder when the anchor (non-time) is empty', () => {
       renderSlot({
-        timeField: null,
-        otherFields: [activity],
+        displayFields: [activity],
         row: makeRow({ values: { activity: '' } }),
       });
       expect(screen.getByText('Set Activity')).toBeTruthy();
@@ -158,8 +183,7 @@ describe('WysiwygSlot — collapsed', () => {
 
     it('keeps the index-0 placeholder even when later fields have values (no skip-to-next-non-empty)', () => {
       renderSlot({
-        timeField: null,
-        otherFields: [activity, location],
+        displayFields: [activity, location],
         row: makeRow({ values: { activity: '', location: 'Cordoba' } }),
       });
       expect(screen.getByText('Set Activity')).toBeTruthy();
@@ -168,17 +192,15 @@ describe('WysiwygSlot — collapsed', () => {
 
     it('falls back to literal "Slot" when there are no fields at all', () => {
       renderSlot({
-        timeField: null,
-        otherFields: [],
+        displayFields: [],
         row: makeRow({ values: {} }),
       });
       expect(screen.getByText('Slot')).toBeTruthy();
     });
 
-    it('aria-label on the expand button reflects the promoted value', () => {
+    it('aria-label reflects the promoted non-time value with em-dash separator', () => {
       renderSlot({
-        timeField: null,
-        otherFields: [activity],
+        displayFields: [activity],
         row: makeRow({ values: { activity: 'Surfing' } }),
       });
       expect(screen.getByRole('button', { name: 'Edit slot \u2014 Surfing' })).toBeTruthy();

--- a/src/components/build-wysiwyg/WysiwygSlot.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.test.tsx
@@ -205,6 +205,22 @@ describe('WysiwygSlot — collapsed', () => {
       });
       expect(screen.getByRole('button', { name: 'Edit slot \u2014 Surfing' })).toBeTruthy();
     });
+
+    it('aria-label includes the placeholder when the anchor is empty (a11y parity with visible label)', () => {
+      renderSlot({
+        displayFields: [activity],
+        row: makeRow({ values: { activity: '' } }),
+      });
+      expect(screen.getByRole('button', { name: 'Edit slot \u2014 Set Activity' })).toBeTruthy();
+    });
+
+    it('aria-label uses "Set a time" placeholder when the anchor is an empty time field', () => {
+      renderSlot({
+        displayFields: [time],
+        row: makeRow({ values: { time: '' } }),
+      });
+      expect(screen.getByRole('button', { name: 'Edit slot \u2014 Set a time' })).toBeTruthy();
+    });
   });
 });
 

--- a/src/components/build-wysiwyg/WysiwygSlot.test.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.test.tsx
@@ -28,6 +28,8 @@ function makeRow(overrides: Partial<GridRow> = {}): GridRow {
 type RenderProps = {
   expanded?: boolean;
   row?: GridRow;
+  timeField?: GridField | null;
+  otherFields?: GridField[];
   onExpand?: ReturnType<typeof vi.fn>;
   onCollapse?: ReturnType<typeof vi.fn>;
   onEditCell?: ReturnType<typeof vi.fn>;
@@ -45,14 +47,22 @@ function renderSlot(overrides: RenderProps = {}) {
   const onAddEnumOption = overrides.onAddEnumOption ?? vi.fn();
   const onDuplicate = overrides.onDuplicate ?? vi.fn();
   const onDelete = overrides.onDelete ?? vi.fn();
-  const timeField = makeField({ ref: 'shift', name: 'Shift' });
-  const otherField = makeField({ id: 'f2', ref: 'notes', name: 'Notes', config: { fieldType: 'text', maxLength: 200 } });
+  const defaultTimeField = makeField({ ref: 'shift', name: 'Shift' });
+  const defaultOtherField = makeField({
+    id: 'f2',
+    ref: 'notes',
+    name: 'Notes',
+    config: { fieldType: 'text', maxLength: 200 },
+  });
+  const timeField = overrides.timeField === undefined ? defaultTimeField : overrides.timeField;
+  const otherFields = overrides.otherFields ?? [defaultOtherField];
+  const fields = [...(timeField ? [timeField] : []), ...otherFields];
   const utils = render(
     <WysiwygSlot
       row={overrides.row ?? makeRow()}
-      fields={[timeField, otherField]}
+      fields={fields}
       timeField={timeField}
-      otherFields={[otherField]}
+      otherFields={otherFields}
       expanded={overrides.expanded ?? false}
       onExpand={onExpand}
       onCollapse={onCollapse}
@@ -108,6 +118,71 @@ describe('WysiwygSlot — collapsed', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
     expect(onDelete).toHaveBeenCalled();
     expect(onExpand).not.toHaveBeenCalled();
+  });
+
+  describe('no time field', () => {
+    const activity = makeField({
+      id: 'f-act',
+      ref: 'activity',
+      name: 'Activity',
+      config: { fieldType: 'text', maxLength: 200 },
+    });
+    const location = makeField({
+      id: 'f-loc',
+      ref: 'location',
+      name: 'Location',
+      config: { fieldType: 'text', maxLength: 200 },
+    });
+
+    it('promotes the first other field value to the primary label and drops it from the summary', () => {
+      renderSlot({
+        timeField: null,
+        otherFields: [activity, location],
+        row: makeRow({ values: { activity: 'Surfing', location: 'Cordoba' } }),
+      });
+      expect(screen.getByText('Surfing')).toBeTruthy();
+      expect(screen.getByText('Cordoba')).toBeTruthy();
+      expect(screen.queryByText(/Surfing \u00b7 Cordoba/)).toBeNull();
+      expect(screen.queryByText('Slot')).toBeNull();
+    });
+
+    it('shows "Set ${name}" placeholder when the first other field is empty', () => {
+      renderSlot({
+        timeField: null,
+        otherFields: [activity],
+        row: makeRow({ values: { activity: '' } }),
+      });
+      expect(screen.getByText('Set Activity')).toBeTruthy();
+      expect(screen.queryByText('Slot')).toBeNull();
+    });
+
+    it('keeps the index-0 placeholder even when later fields have values (no skip-to-next-non-empty)', () => {
+      renderSlot({
+        timeField: null,
+        otherFields: [activity, location],
+        row: makeRow({ values: { activity: '', location: 'Cordoba' } }),
+      });
+      expect(screen.getByText('Set Activity')).toBeTruthy();
+      expect(screen.getByText('Cordoba')).toBeTruthy();
+    });
+
+    it('falls back to literal "Slot" when there are no fields at all', () => {
+      renderSlot({
+        timeField: null,
+        otherFields: [],
+        row: makeRow({ values: {} }),
+      });
+      expect(screen.getByText('Slot')).toBeTruthy();
+    });
+
+    it('aria-label on the expand button reflects the promoted value', () => {
+      renderSlot({
+        timeField: null,
+        otherFields: [activity],
+        row: makeRow({ values: { activity: 'Surfing' } }),
+      });
+      expect(screen.getByRole('button', { name: 'Edit slot \u2014 Surfing' })).toBeTruthy();
+    });
   });
 });
 

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -74,8 +74,8 @@ export function WysiwygSlot({
     );
   }
 
-  // Anchor = first field in the organizer's chosen order (no type-based promotion).
-  // The remaining fields form the summary so the anchor's value isn't shown twice.
+  // Anchor = first field in the organizer's chosen order. No type-based
+  // promotion: a time field later in the list must not win over field 0.
   const anchorField = displayFields[0] ?? null;
   const anchorValue = anchorField ? row.values[anchorField.ref] : '';
   const summary = displayFields
@@ -84,16 +84,14 @@ export function WysiwygSlot({
     .filter((v) => v && v.length > 0)
     .join(' \u00b7 ');
 
-  // "Set a time" is the long-standing copy for empty time fields; keep it.
-  // Other field types use the generic "Set ${name}" pattern.
-  const anchorPlaceholder =
-    anchorField?.config.fieldType === 'time' ? 'Set a time' : `Set ${anchorField?.name ?? ''}`;
+  // Time anchors keep the long-standing "Set a time" / "at HH:MM" copy;
+  // everything else uses the generic name-based pattern.
+  const isTimeAnchor = anchorField?.config.fieldType === 'time';
 
-  const ariaLabel = anchorValue
-    ? anchorField?.config.fieldType === 'time'
-      ? `Edit slot at ${anchorValue}`
-      : `Edit slot \u2014 ${anchorValue}`
-    : 'Edit slot';
+  let ariaLabel = 'Edit slot';
+  if (anchorValue) {
+    ariaLabel = isTimeAnchor ? `Edit slot at ${anchorValue}` : `Edit slot \u2014 ${anchorValue}`;
+  }
 
   const isDragging = reorder?.dragId === row.id;
   const isDropTarget = reorder?.overId === row.id && reorder?.dragId && reorder?.dragId !== row.id;
@@ -142,7 +140,7 @@ export function WysiwygSlot({
             </span>
           ) : anchorField ? (
             <span className="text-sm italic font-normal text-ink-soft">
-              {anchorPlaceholder}
+              {isTimeAnchor ? 'Set a time' : `Set ${anchorField.name}`}
             </span>
           ) : (
             <span className="text-sm font-semibold text-ink">Slot</span>

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -9,8 +9,12 @@ import type { GridField, GridRow } from '../build-grid/useGridState';
 type WysiwygSlotProps = {
   row: GridRow;
   fields: GridField[];
-  timeField: GridField | null;
-  otherFields: GridField[];
+  /**
+   * All non-group fields in organizer-chosen order. `displayFields[0]` becomes
+   * the collapsed row's primary anchor (large, bold). The rest form the summary
+   * shown next to it.
+   */
+  displayFields: GridField[];
   expanded: boolean;
   onExpand: () => void;
   onCollapse: () => void;
@@ -33,8 +37,7 @@ type WysiwygSlotProps = {
 export function WysiwygSlot({
   row,
   fields,
-  timeField,
-  otherFields,
+  displayFields,
   expanded,
   onExpand,
   onCollapse,
@@ -71,21 +74,26 @@ export function WysiwygSlot({
     );
   }
 
-  const timeValue = timeField ? row.values[timeField.ref] : '';
-  // When the signup has no time field, the first non-time/non-group field acts
-  // as the row's primary anchor (mirroring the role the time value plays). The
-  // promoted field is dropped from the summary so its value isn't shown twice.
-  const firstOtherField = !timeField ? (otherFields[0] ?? null) : null;
-  const firstOtherValue = firstOtherField ? row.values[firstOtherField.ref] : '';
-  const summaryFields = firstOtherField ? otherFields.slice(1) : otherFields;
-  const summary = summaryFields
+  // Anchor = first field in the organizer's chosen order (no type-based promotion).
+  // The remaining fields form the summary so the anchor's value isn't shown twice.
+  const anchorField = displayFields[0] ?? null;
+  const anchorValue = anchorField ? row.values[anchorField.ref] : '';
+  const summary = displayFields
+    .slice(1)
     .map((f) => row.values[f.ref])
     .filter((v) => v && v.length > 0)
     .join(' \u00b7 ');
 
-  let ariaLabel = 'Edit slot';
-  if (timeValue) ariaLabel = `Edit slot at ${timeValue}`;
-  else if (firstOtherValue) ariaLabel = `Edit slot \u2014 ${firstOtherValue}`;
+  // "Set a time" is the long-standing copy for empty time fields; keep it.
+  // Other field types use the generic "Set ${name}" pattern.
+  const anchorPlaceholder =
+    anchorField?.config.fieldType === 'time' ? 'Set a time' : `Set ${anchorField?.name ?? ''}`;
+
+  const ariaLabel = anchorValue
+    ? anchorField?.config.fieldType === 'time'
+      ? `Edit slot at ${anchorValue}`
+      : `Edit slot \u2014 ${anchorValue}`
+    : 'Edit slot';
 
   const isDragging = reorder?.dragId === row.id;
   const isDropTarget = reorder?.overId === row.id && reorder?.dragId && reorder?.dragId !== row.id;
@@ -128,17 +136,13 @@ export function WysiwygSlot({
         className="flex w-full items-center justify-between gap-2.5 border-none bg-transparent px-3.5 py-2.5 text-left"
       >
         <div className="flex min-w-0 flex-1 items-center gap-2.5">
-          {timeValue ? (
-            <span className="text-sm font-semibold text-ink">{timeValue}</span>
-          ) : timeField ? (
-            <span className="text-sm italic font-normal text-ink-soft">Set a time</span>
-          ) : firstOtherValue ? (
+          {anchorValue ? (
             <span className="min-w-0 truncate text-sm font-semibold text-ink">
-              {firstOtherValue}
+              {anchorValue}
             </span>
-          ) : firstOtherField ? (
+          ) : anchorField ? (
             <span className="text-sm italic font-normal text-ink-soft">
-              Set {firstOtherField.name}
+              {anchorPlaceholder}
             </span>
           ) : (
             <span className="text-sm font-semibold text-ink">Slot</span>

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -87,10 +87,20 @@ export function WysiwygSlot({
   // Time anchors keep the long-standing "Set a time" / "at HH:MM" copy;
   // everything else uses the generic name-based pattern.
   const isTimeAnchor = anchorField?.config.fieldType === 'time';
+  const placeholder = anchorField
+    ? isTimeAnchor
+      ? 'Set a time'
+      : `Set ${anchorField.name}`
+    : null;
 
+  // aria-label must mirror the visible primary label — including the empty-state
+  // placeholder — so multiple empty rows aren't exposed as identical "Edit slot"
+  // to assistive tech. (aria-label overrides the button's text content.)
   let ariaLabel = 'Edit slot';
   if (anchorValue) {
     ariaLabel = isTimeAnchor ? `Edit slot at ${anchorValue}` : `Edit slot \u2014 ${anchorValue}`;
+  } else if (placeholder) {
+    ariaLabel = `Edit slot \u2014 ${placeholder}`;
   }
 
   const isDragging = reorder?.dragId === row.id;
@@ -138,9 +148,9 @@ export function WysiwygSlot({
             <span className="min-w-0 truncate text-sm font-semibold text-ink">
               {anchorValue}
             </span>
-          ) : anchorField ? (
+          ) : placeholder ? (
             <span className="text-sm italic font-normal text-ink-soft">
-              {isTimeAnchor ? 'Set a time' : `Set ${anchorField.name}`}
+              {placeholder}
             </span>
           ) : (
             <span className="text-sm font-semibold text-ink">Slot</span>

--- a/src/components/build-wysiwyg/WysiwygSlot.tsx
+++ b/src/components/build-wysiwyg/WysiwygSlot.tsx
@@ -72,10 +72,20 @@ export function WysiwygSlot({
   }
 
   const timeValue = timeField ? row.values[timeField.ref] : '';
-  const summary = otherFields
+  // When the signup has no time field, the first non-time/non-group field acts
+  // as the row's primary anchor (mirroring the role the time value plays). The
+  // promoted field is dropped from the summary so its value isn't shown twice.
+  const firstOtherField = !timeField ? (otherFields[0] ?? null) : null;
+  const firstOtherValue = firstOtherField ? row.values[firstOtherField.ref] : '';
+  const summaryFields = firstOtherField ? otherFields.slice(1) : otherFields;
+  const summary = summaryFields
     .map((f) => row.values[f.ref])
     .filter((v) => v && v.length > 0)
     .join(' \u00b7 ');
+
+  let ariaLabel = 'Edit slot';
+  if (timeValue) ariaLabel = `Edit slot at ${timeValue}`;
+  else if (firstOtherValue) ariaLabel = `Edit slot \u2014 ${firstOtherValue}`;
 
   const isDragging = reorder?.dragId === row.id;
   const isDropTarget = reorder?.overId === row.id && reorder?.dragId && reorder?.dragId !== row.id;
@@ -114,7 +124,7 @@ export function WysiwygSlot({
       <button
         type="button"
         onClick={onExpand}
-        aria-label={`Edit slot${timeValue ? ` at ${timeValue}` : ''}`}
+        aria-label={ariaLabel}
         className="flex w-full items-center justify-between gap-2.5 border-none bg-transparent px-3.5 py-2.5 text-left"
       >
         <div className="flex min-w-0 flex-1 items-center gap-2.5">
@@ -122,6 +132,14 @@ export function WysiwygSlot({
             <span className="text-sm font-semibold text-ink">{timeValue}</span>
           ) : timeField ? (
             <span className="text-sm italic font-normal text-ink-soft">Set a time</span>
+          ) : firstOtherValue ? (
+            <span className="min-w-0 truncate text-sm font-semibold text-ink">
+              {firstOtherValue}
+            </span>
+          ) : firstOtherField ? (
+            <span className="text-sm italic font-normal text-ink-soft">
+              Set {firstOtherField.name}
+            </span>
           ) : (
             <span className="text-sm font-semibold text-ink">Slot</span>
           )}


### PR DESCRIPTION
## Summary

On the Build (WYSIWYG) tab, the collapsed slot row's primary anchor was being picked by **field type** (any time-typed field won), not by the organizer's field order. That produced two bad outcomes:

1. **Time-less signups** (item-list, role, quantity) rendered every row as the literal word **"Slot"**.
2. **Mixed signups** like the Grade 3 Potluck (fields ordered Date → Item Category → Time) bolded `17:00` and buried the meaningful Mains/Sides/Desserts/Drinks discriminator in the summary — even though Date is field 0 and every row has the same time.

Now: **anchor = first field in the organizer's chosen order** (`displayFields[0]`), no type-based promotion. The remaining fields form the summary so the anchor's value isn't shown twice.

### Label decision table

| Condition                  | Display                                                           |
| -------------------------- | ----------------------------------------------------------------- |
| Anchor field has a value   | the value (bold, truncate if long)                                |
| Anchor field is empty      | italic placeholder — `Set a time` for time fields, `Set ${name}` for everything else |
| No fields at all           | literal `Slot` (last-resort fallback)                             |

`aria-label` on the expand button mirrors the visible label: `Edit slot at ${value}` when the anchor is a time field, `Edit slot — ${value}` otherwise, `Edit slot` when empty.

### Refactor scope

The type-based `timeField` split is gone from `BuildWysiwyg.tsx`. `WysiwygGroup` and `WysiwygSlot` now take a single ordered `displayFields` prop (all non-group fields in order) instead of `timeField` + `otherFields`.

### Explicit non-goals

- **Anchor stays at index 0 even when empty.** If `displayFields[0]` is empty but `displayFields[1]` has a value, the row still shows the `Set ${name}` placeholder for field 0 (and field 1's value appears in the summary). Avoids the label hopping between fields as data changes.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 472 passing (+6 new in `WysiwygSlot.test.tsx`, including a regression test for the Potluck case)
- [ ] Manual smoke on `/app/signups/<id>/build` for a signup whose first field is time-typed — rows look identical to before
- [ ] Manual smoke on `/app/signups/sig_033LtLWrudSA4LntWVjf5V/build` (Potluck: Date, Item Category, Time) — Date is the bold anchor; Item Category + Time appear in the summary
- [ ] Manual smoke on `/app/signups/sig_033Hs379Os9IzwHFYuRBOq/build` (no time field) — rows show the first field's value or `Set ${name}` placeholder, not "Slot"
- [ ] Keyboard: tab to a collapsed row, confirm screen-reader name matches the visible label

🤖 Generated with [Claude Code](https://claude.com/claude-code)