### PR TITLE
feat(telemetry): record landing.viewed activity event on marketing home

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -73,6 +73,17 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 | `reminder.sent` | system | `{ commitmentId, channel }` | `jobs/reminders.ts` |
 | `reminder.failed` | system | `{ commitmentId, error }` | `jobs/reminders.ts` |
 
+### Marketing / acquisition
+
+| event | actor | payload | fired from |
+|---|---|---|---|
+| `landing.viewed` | system | `{ uaClass, refererHost }` | RSC at `/` (marketing home) |
+
+`landing.viewed` rows have both `signup_id` and `workspace_id` set to `NULL`
+— the page is tenant-independent. It is the top of the organizer funnel
+(`landing.viewed` → `auth.magic_link_sent` → `auth.signed_in` →
+`signup.draft_started` → `signup.created`).
+
 ### Auth & workspace
 
 | event | actor | payload | fired from |
@@ -88,8 +99,8 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 
 ## Privacy guarantees
 
-The `signup.viewed` and `commitment.edit_link_followed` events are
-deliberately minimal:
+The `landing.viewed`, `signup.viewed`, and `commitment.edit_link_followed`
+events are deliberately minimal:
 
 - **No IP address.** Postgres receives no client IP for view events.
 - **No request body, form input, or email address** (in view events).
@@ -218,9 +229,9 @@ GROUP BY 1;
 
 ### Volume
 
-Pageview-shaped events (`signup.editor_opened`, `signup.previewed`,
-`signup.viewed`, `signup.draft_started`, `commitment.edit_link_followed`)
-fire on every RSC render. Refreshes count. The activity table grows mostly
+Pageview-shaped events (`landing.viewed`, `signup.editor_opened`,
+`signup.previewed`, `signup.viewed`, `signup.draft_started`,
+`commitment.edit_link_followed`) fire on every RSC render. Refreshes count. The activity table grows mostly
 with these events. All dashboard queries should filter on `event_type` so
 read performance scales with the queried subset, not the table size.
 

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
     <>
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Privacy policy</h1>
-        <p className="text-ink-muted text-sm">Last updated: 24 May 2026</p>
+        <p className="text-ink-muted text-sm">Last updated: 25 May 2026</p>
       </header>
 
       <section className="space-y-3">
@@ -56,8 +56,8 @@ export default function PrivacyPage() {
             your signups, and reminder dispatches. This exists so an organizer
             can audit what happened in their own workspace and so the operator
             can investigate abuse. The same log records anonymous view telemetry
-            on your public signup pages (see &ldquo;Logs and rate-limiting&rdquo;
-            below).
+            on the marketing home page and on your public signup pages (see
+            &ldquo;Logs and rate-limiting&rdquo; below).
           </li>
         </ul>
         <p>No password is ever stored — authentication is magic-link only.</p>
@@ -104,7 +104,9 @@ export default function PrivacyPage() {
           participant on that signup. We do not record your IP address on this
           entry. Bot traffic and requests carrying a Do Not Track or Global
           Privacy Control signal are skipped. The same applies when you follow
-          an &ldquo;edit your commitment&rdquo; link.
+          an &ldquo;edit your commitment&rdquo; link, and when you load the
+          marketing home page (where we record only the user-agent class and
+          the referring host).
         </p>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,16 @@
+import { headers } from 'next/headers';
 import Link from 'next/link';
+import { after } from 'next/server';
 import { SiteFooter } from '@/components/site-footer';
 import { INSTANCE_NAME } from '@/lib/site-config';
+import { readRequestSignals, recordLandingView } from '@/lib/view-tracker';
 import { HomeExampleCard } from './_components/HomeExampleCard';
 
-export default function LandingPage() {
+export default async function LandingPage() {
   const demoUrl = process.env.NEXT_PUBLIC_DEMO_URL;
+
+  const signals = readRequestSignals(await headers());
+  after(() => recordLandingView({ signals }));
 
   return (
     <div className="bg-surface text-ink flex min-h-[100svh] flex-col">

--- a/src/db/schema/activity.ts
+++ b/src/db/schema/activity.ts
@@ -55,6 +55,7 @@ export const ACTIVITY_EVENTS = [
   'auth.magic_link_sent',
   'auth.signed_in',
   'workspace.created',
+  'landing.viewed',
 ] as const;
 
 export type ActivityEvent = (typeof ACTIVITY_EVENTS)[number];

--- a/src/lib/view-tracker.db.test.ts
+++ b/src/lib/view-tracker.db.test.ts
@@ -9,6 +9,7 @@ import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
 import {
   recordEditLinkFollowed,
+  recordLandingView,
   recordOrganizerView,
   recordPublicView,
   type RequestSignals,
@@ -217,6 +218,73 @@ describe('view-tracker (db)', () => {
         .select()
         .from(activity)
         .where(eq(activity.signupId, signupId));
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('recordLandingView', () => {
+    // Landing rows have NULL signup_id/workspace_id, so the per-test cleanup
+    // above (scoped to signupId) won't clear them. Wipe by event_type here;
+    // db tests run sequentially (fileParallelism: false) so this is safe.
+    beforeEach(async () => {
+      await db.delete(activity).where(eq(activity.eventType, 'landing.viewed'));
+    });
+
+    it('writes a landing.viewed row with NULL signup/workspace for a browser UA', async () => {
+      await recordLandingView({
+        signals: browserSignals({ referer: 'https://news.ycombinator.com/foo' }),
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.viewed'));
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row.actorType).toBe('system');
+      expect(row.actorId).toBeNull();
+      expect(row.signupId).toBeNull();
+      expect(row.workspaceId).toBeNull();
+      const payload = row.payload as Record<string, unknown>;
+      expect(payload).toEqual({
+        uaClass: 'browser',
+        refererHost: 'news.ycombinator.com',
+      });
+    });
+
+    it('records uaClass=unknown when UA is missing', async () => {
+      await recordLandingView({
+        signals: { userAgent: null, referer: null, dnt: false },
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.viewed'));
+      expect(rows).toHaveLength(1);
+      const payload = rows[0]!.payload as Record<string, unknown>;
+      expect(payload.uaClass).toBe('unknown');
+      expect(payload.refererHost).toBeNull();
+    });
+
+    it('does not write when DNT/GPC is set', async () => {
+      await recordLandingView({ signals: browserSignals({ dnt: true }) });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.viewed'));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('does not write for a Googlebot UA', async () => {
+      await recordLandingView({
+        signals: browserSignals({
+          userAgent:
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        }),
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.viewed'));
       expect(rows).toHaveLength(0);
     });
   });

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -98,6 +98,28 @@ export async function recordPublicView(args: {
   }
 }
 
+export async function recordLandingView(args: {
+  signals: RequestSignals;
+}): Promise<void> {
+  try {
+    if (args.signals.dnt) return;
+    const uaClass = classifyUa(args.signals.userAgent);
+    if (uaClass === 'bot') return;
+    await writeActivity({
+      signupId: null,
+      workspaceId: null,
+      actor: { actorId: null, actorType: 'system' },
+      eventType: 'landing.viewed',
+      payload: {
+        uaClass,
+        refererHost: refererHost(args.signals.referer),
+      },
+    });
+  } catch (err) {
+    log.warn({ err }, 'recordLandingView failed');
+  }
+}
+
 export async function recordEditLinkFollowed(args: {
   signupId: string;
   workspaceId: string | null;


### PR DESCRIPTION
## Summary
- Adds a new `landing.viewed` activity event fired server-side from `src/app/page.tsx` via `after()`, mirroring the existing `recordPublicView` pattern (DNT/GPC respected, bots filtered, errors logged not thrown).
- Payload is intentionally minimal: `{ uaClass, refererHost }`. No `signupId`, `workspaceId`, or IP. Actor is `system`.
- Broadens the privacy policy disclosure to cover the marketing home page and bumps the "Last updated" date, per the "trust docs reflect the code" rule in CLAUDE.md.

## Why
The marketing root was the only conspicuous public surface still uninstrumented — every other page (`/s/[slug]`, edit-link follows, organizer views) already emits an activity event. Adding `landing.viewed` closes the top-of-funnel gap so we can later correlate landings with `auth.magic_link_sent`, `auth.signed_in`, and `signup.draft_started`.

## Notes
- `event_type` is `text` (not a PG enum), so no migration is needed — just an append to the `ACTIVITY_EVENTS` const union, which keeps `ActivityEvent` type-safe at compile time.
- Reading `headers()` flips `/` from static to dynamic. Intentional and consistent with `/s/[slug]`.
- CTA-click tracking deliberately out of scope this pass; downstream events already give us a usable funnel via referer.

## Test plan
- [x] `pnpm lint` ✓
- [x] `pnpm typecheck` ✓
- [x] `pnpm test` ✓ (490/490)
- [x] Manual smoke: hit `http://localhost:3000/`, then `select event_type, payload, occurred_at from activity where event_type = 'landing.viewed' order by occurred_at desc limit 5;` — one row per visit with `payload.uaClass = 'browser'`.
- [x] `curl -H 'DNT: 1' http://localhost:3000/` — no new row.
- [x] `curl -A 'Googlebot/2.1' http://localhost:3000/` — no new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)