### PR TITLE
Add landing-page CTA click telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OpenSignup are documented here. Format follows [Keep a Ch
 ## [Unreleased]
 
 ### Added
+- Landing-page CTA click telemetry (`landing.cta_clicked` activity event).
 - Initial v1 scaffolding: Next.js 15 + TypeScript + Drizzle + Auth.js v5 + pg-boss.
 - Full entity schema (workspaces, organizers, members, signups, slot groups, slots, participants, commitments, activity, magic links, claims).
 - Zod schemas as source of truth with discriminated union on `slot_type`.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -78,11 +78,15 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 | event | actor | payload | fired from |
 |---|---|---|---|
 | `landing.viewed` | system | `{ uaClass, refererHost }` | RSC at `/` (marketing home) |
+| `landing.cta_clicked` | system | `{ uaClass, refererHost }` | client beacon from the "Start a signup" CTA on `/`, via `POST /api/telemetry/landing-cta-clicked` |
 
-`landing.viewed` rows have both `signup_id` and `workspace_id` set to `NULL`
-— the page is tenant-independent. It is the top of the organizer funnel
-(`landing.viewed` → `auth.magic_link_sent` → `auth.signed_in` →
-`signup.draft_started` → `signup.created`).
+Both rows have `signup_id` and `workspace_id` set to `NULL` — the page is
+tenant-independent. Together they form the top of the organizer funnel
+(`landing.viewed` → `landing.cta_clicked` → `auth.magic_link_sent` →
+`auth.signed_in` → `signup.draft_started` → `signup.created`).
+`landing.cta_clicked` is the only client-emitted event in the catalogue;
+all others fire server-side. The beacon reads UA/referer/DNT from request
+headers server-side — no client-supplied data is trusted.
 
 ### Auth & workspace
 
@@ -99,8 +103,8 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 
 ## Privacy guarantees
 
-The `landing.viewed`, `signup.viewed`, and `commitment.edit_link_followed`
-events are deliberately minimal:
+The `landing.viewed`, `landing.cta_clicked`, `signup.viewed`, and
+`commitment.edit_link_followed` events are deliberately minimal:
 
 - **No IP address.** Postgres receives no client IP for view events.
 - **No request body, form input, or email address** (in view events).

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
     <>
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Privacy policy</h1>
-        <p className="text-ink-muted text-sm">Last updated: 25 May 2026</p>
+        <p className="text-ink-muted text-sm">Last updated: 28 May 2026</p>
       </header>
 
       <section className="space-y-3">
@@ -104,9 +104,10 @@ export default function PrivacyPage() {
           participant on that signup. We do not record your IP address on this
           entry. Bot traffic and requests carrying a Do Not Track or Global
           Privacy Control signal are skipped. The same applies when you follow
-          an &ldquo;edit your commitment&rdquo; link, and when you load the
-          marketing home page (where we record only the user-agent class and
-          the referring host).
+          an &ldquo;edit your commitment&rdquo; link, when you load the
+          marketing home page, and when you click the &ldquo;Start a
+          signup&rdquo; button on it (where we record only the user-agent class
+          and the referring host).
         </p>
       </section>
 

--- a/src/app/_components/StartSignupCta.tsx
+++ b/src/app/_components/StartSignupCta.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+const TELEMETRY_URL = '/api/telemetry/landing-cta-clicked';
+
+function emit(): void {
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const ok = navigator.sendBeacon(TELEMETRY_URL, new Blob([], { type: 'text/plain' }));
+      if (ok) return;
+    }
+    void fetch(TELEMETRY_URL, { method: 'POST', keepalive: true }).catch(() => {});
+  } catch {
+    // Telemetry must never break the click.
+  }
+}
+
+export function StartSignupCta({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Link href={href} className={className} onClick={emit}>
+      {children}
+    </Link>
+  );
+}

--- a/src/app/api/telemetry/landing-cta-clicked/route.test.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let currentHeaders: Headers;
+
+vi.mock('next/headers', () => ({
+  headers: () => Promise.resolve(currentHeaders),
+}));
+
+vi.mock('@/lib/view-tracker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/view-tracker')>();
+  return { ...actual, recordLandingCtaClicked: vi.fn(async () => {}) };
+});
+
+import { recordLandingCtaClicked } from '@/lib/view-tracker';
+import { POST } from './route';
+
+const browserUa =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+describe('POST /api/telemetry/landing-cta-clicked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 204 with an empty body and forwards header-derived signals', async () => {
+    currentHeaders = new Headers({
+      'user-agent': browserUa,
+      referer: 'https://opensignup.org/',
+    });
+
+    const res = await POST();
+
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe('');
+    expect(recordLandingCtaClicked).toHaveBeenCalledTimes(1);
+    expect(recordLandingCtaClicked).toHaveBeenCalledWith({
+      signals: { userAgent: browserUa, referer: 'https://opensignup.org/', dnt: false },
+    });
+  });
+
+  it('derives dnt=true from the DNT header (signals come from headers, not a body)', async () => {
+    currentHeaders = new Headers({ 'user-agent': browserUa, dnt: '1' });
+
+    const res = await POST();
+
+    expect(res.status).toBe(204);
+    expect(recordLandingCtaClicked).toHaveBeenCalledWith({
+      signals: { userAgent: browserUa, referer: null, dnt: true },
+    });
+  });
+});

--- a/src/app/api/telemetry/landing-cta-clicked/route.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.ts
@@ -1,0 +1,14 @@
+import { headers } from 'next/headers';
+import { handle } from '@/lib/api-response';
+import { readRequestSignals, recordLandingCtaClicked } from '@/lib/view-tracker';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  return handle(async () => {
+    const signals = readRequestSignals(await headers());
+    await recordLandingCtaClicked({ signals });
+    return new Response(null, { status: 204 });
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { SiteFooter } from '@/components/site-footer';
 import { INSTANCE_NAME } from '@/lib/site-config';
 import { readRequestSignals, recordLandingView } from '@/lib/view-tracker';
 import { HomeExampleCard } from './_components/HomeExampleCard';
+import { StartSignupCta } from './_components/StartSignupCta';
 
 export default async function LandingPage() {
   const demoUrl = process.env.NEXT_PUBLIC_DEMO_URL;
@@ -40,7 +41,7 @@ export default async function LandingPage() {
           </p>
 
           <div className="flex flex-col gap-3 lg:flex-row lg:flex-wrap">
-            <Link
+            <StartSignupCta
               href="/app/signups/new"
               className="bg-brand inline-flex items-center justify-center gap-2 rounded-[14px] px-5 py-3 text-base font-semibold text-white transition hover:brightness-110 lg:text-[15px]"
             >
@@ -58,7 +59,7 @@ export default async function LandingPage() {
               >
                 <path d="M5 12h14M13 5l7 7-7 7" />
               </svg>
-            </Link>
+            </StartSignupCta>
             {demoUrl ? (
               <a
                 href={demoUrl}

--- a/src/db/schema/activity.ts
+++ b/src/db/schema/activity.ts
@@ -56,6 +56,7 @@ export const ACTIVITY_EVENTS = [
   'auth.signed_in',
   'workspace.created',
   'landing.viewed',
+  'landing.cta_clicked',
 ] as const;
 
 export type ActivityEvent = (typeof ACTIVITY_EVENTS)[number];

--- a/src/lib/view-tracker.db.test.ts
+++ b/src/lib/view-tracker.db.test.ts
@@ -9,6 +9,7 @@ import { workspaces } from '@/db/schema/workspaces';
 import { makeId } from '@/lib/ids';
 import {
   recordEditLinkFollowed,
+  recordLandingCtaClicked,
   recordLandingView,
   recordOrganizerView,
   recordPublicView,
@@ -285,6 +286,72 @@ describe('view-tracker (db)', () => {
         .select()
         .from(activity)
         .where(eq(activity.eventType, 'landing.viewed'));
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('recordLandingCtaClicked', () => {
+    // Like landing.viewed, these rows have NULL signup_id/workspace_id, so the
+    // suite-level cleanup (scoped to signupId) won't clear them. Wipe by
+    // event_type; db tests run sequentially (fileParallelism: false).
+    beforeEach(async () => {
+      await db.delete(activity).where(eq(activity.eventType, 'landing.cta_clicked'));
+    });
+
+    it('writes a landing.cta_clicked row with NULL signup/workspace for a browser UA', async () => {
+      await recordLandingCtaClicked({
+        signals: browserSignals({ referer: 'https://opensignup.org/' }),
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.cta_clicked'));
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+      expect(row.actorType).toBe('system');
+      expect(row.actorId).toBeNull();
+      expect(row.signupId).toBeNull();
+      expect(row.workspaceId).toBeNull();
+      expect(row.payload).toEqual({
+        uaClass: 'browser',
+        refererHost: 'opensignup.org',
+      });
+    });
+
+    it('records uaClass=unknown when UA is missing', async () => {
+      await recordLandingCtaClicked({
+        signals: { userAgent: null, referer: null, dnt: false },
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.cta_clicked'));
+      expect(rows).toHaveLength(1);
+      const payload = rows[0]!.payload as Record<string, unknown>;
+      expect(payload.uaClass).toBe('unknown');
+      expect(payload.refererHost).toBeNull();
+    });
+
+    it('does not write when DNT/GPC is set', async () => {
+      await recordLandingCtaClicked({ signals: browserSignals({ dnt: true }) });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.cta_clicked'));
+      expect(rows).toHaveLength(0);
+    });
+
+    it('does not write for a Googlebot UA', async () => {
+      await recordLandingCtaClicked({
+        signals: browserSignals({
+          userAgent:
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+        }),
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.cta_clicked'));
       expect(rows).toHaveLength(0);
     });
   });

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -120,6 +120,28 @@ export async function recordLandingView(args: {
   }
 }
 
+export async function recordLandingCtaClicked(args: {
+  signals: RequestSignals;
+}): Promise<void> {
+  try {
+    if (args.signals.dnt) return;
+    const uaClass = classifyUa(args.signals.userAgent);
+    if (uaClass === 'bot') return;
+    await writeActivity({
+      signupId: null,
+      workspaceId: null,
+      actor: { actorId: null, actorType: 'system' },
+      eventType: 'landing.cta_clicked',
+      payload: {
+        uaClass,
+        refererHost: refererHost(args.signals.referer),
+      },
+    });
+  } catch (err) {
+    log.warn({ err }, 'recordLandingCtaClicked failed');
+  }
+}
+
 export async function recordEditLinkFollowed(args: {
   signupId: string;
   workspaceId: string | null;


### PR DESCRIPTION
## Summary

Adds telemetry tracking for "Start a signup" button clicks on the marketing landing page. This captures user engagement with the primary call-to-action without requiring authentication or creating any user records.

## Changes

- **New activity event type**: `landing.cta_clicked` records when users click the CTA button, capturing user-agent class and referring host (respects DNT/GPC signals and filters bot traffic)
- **New API endpoint**: `POST /api/telemetry/landing-cta-clicked` accepts header-derived signals (user-agent, referer, DNT) and delegates to `recordLandingCtaClicked`
- **Client-side tracking**: `StartSignupCta` component wraps the CTA link with `navigator.sendBeacon` (fallback to fetch) to emit telemetry on click without blocking navigation
- **Landing page integration**: Replaced the plain `Link` for "Start a signup" with `StartSignupCta` to enable tracking
- **Database schema**: Added `landing.cta_clicked` to `ACTIVITY_EVENTS`
- **Tests**: Comprehensive test coverage for the new function and API endpoint, including DNT/bot filtering and signal parsing
- **Documentation**: Updated privacy policy to disclose CTA click tracking alongside existing landing-page telemetry

## Implementation details

- Follows the same pattern as `recordLandingView`: writes to activity log with `signupId` and `workspaceId` as NULL, actor type `system`
- Respects privacy signals: skips recording if DNT/GPC is set or user-agent is a bot
- Uses `sendBeacon` for reliability (survives page unload); falls back to fetch with `keepalive: true`
- Telemetry errors are caught and logged but never break the click action
- DB tests use event-type-scoped cleanup since these rows have NULL signup/workspace IDs

https://claude.ai/code/session_019yxuLzbVB1KerU76RE1x7E