### PR TITLE
feat(landing): inline demo video modal + CTA telemetry discriminator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,18 +45,11 @@ LLM_MODEL=
 # large drafts can take >60s on some providers; bump higher if needed.
 LLM_TIMEOUT_MS=
 
-# Optional homepage demo video.
-#
-# Two modes for the "Watch demo" CTA on the landing page:
-#   1. NEXT_PUBLIC_DEMO_VIDEO_URL — direct URL to an .mp4/.webm file
-#      (e.g. a Tigris/R2/Cloudflare-hosted asset). When set, the CTA opens
-#      a modal with an inline <video> element. Takes precedence over
-#      NEXT_PUBLIC_DEMO_URL.
-#   2. NEXT_PUBLIC_DEMO_URL — external URL (YouTube, Loom, etc.). When set
-#      and no video URL is configured, the CTA is a plain link-out.
-#
-# Both are public. Read at runtime by the landing page (dynamic route),
-# so they do NOT need build-arg wiring in fly.toml / Dockerfile.
+# Optional homepage "Watch demo" CTA on the landing page. Pick one:
+#   - NEXT_PUBLIC_DEMO_VIDEO_URL: direct URL to an .mp4/.webm file. Opens
+#     an inline modal with a <video> element. Takes precedence.
+#   - NEXT_PUBLIC_DEMO_URL: external URL (YouTube, Loom, etc.). CTA is a
+#     plain link-out when no video URL is set.
 NEXT_PUBLIC_DEMO_URL=
 NEXT_PUBLIC_DEMO_VIDEO_URL=
 # Optional poster image shown before the video plays.

--- a/.env.example
+++ b/.env.example
@@ -45,10 +45,22 @@ LLM_MODEL=
 # large drafts can take >60s on some providers; bump higher if needed.
 LLM_TIMEOUT_MS=
 
-# Optional homepage demo video. When set, the home page shows a
-# "Watch 30-sec demo" secondary CTA that links here. Public (inlined at
-# build time) — must be prefixed NEXT_PUBLIC_ so it ships to the client.
+# Optional homepage demo video.
+#
+# Two modes for the "Watch demo" CTA on the landing page:
+#   1. NEXT_PUBLIC_DEMO_VIDEO_URL — direct URL to an .mp4/.webm file
+#      (e.g. a Tigris/R2/Cloudflare-hosted asset). When set, the CTA opens
+#      a modal with an inline <video> element. Takes precedence over
+#      NEXT_PUBLIC_DEMO_URL.
+#   2. NEXT_PUBLIC_DEMO_URL — external URL (YouTube, Loom, etc.). When set
+#      and no video URL is configured, the CTA is a plain link-out.
+#
+# Both are public. Read at runtime by the landing page (dynamic route),
+# so they do NOT need build-arg wiring in fly.toml / Dockerfile.
 NEXT_PUBLIC_DEMO_URL=
+NEXT_PUBLIC_DEMO_VIDEO_URL=
+# Optional poster image shown before the video plays.
+NEXT_PUBLIC_DEMO_VIDEO_POSTER=
 
 # --- Instance branding (used by footer + legal pages) ---
 # REQUIRED before deploying. The build fails loudly if any required value

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -78,7 +78,7 @@ shape or add an event, update both the `ACTIVITY_EVENTS` tuple and this table.
 | event | actor | payload | fired from |
 |---|---|---|---|
 | `landing.viewed` | system | `{ uaClass, refererHost }` | RSC at `/` (marketing home) |
-| `landing.cta_clicked` | system | `{ uaClass, refererHost }` | client beacon from the "Start a signup" CTA on `/`, via `POST /api/telemetry/landing-cta-clicked` |
+| `landing.cta_clicked` | system | `{ cta, uaClass, refererHost }` | client beacon from a landing-page CTA on `/`, via `POST /api/telemetry/landing-cta-clicked?cta=…`. `cta` discriminates which CTA fired: `start_signup` \| `demo_video` |
 
 Both rows have `signup_id` and `workspace_id` set to `NULL` — the page is
 tenant-independent. Together they form the top of the organizer funnel

--- a/fly.toml
+++ b/fly.toml
@@ -39,6 +39,10 @@ primary_region = "iad"
   NODE_ENV = "production"
   PORT = "3000"
   NEXT_TELEMETRY_DISABLED = "1"
+  # Public landing-page demo asset for the opensignup.org instance.
+  # Read at request time by the dynamic landing page — no Dockerfile
+  # build-arg wiring needed. Self-hosters override or omit.
+  NEXT_PUBLIC_DEMO_VIDEO_URL = "https://opensignup-public.t3.tigrisfiles.io/demo.mp4"
 
 [http_service]
   internal_port = 3000

--- a/fly.toml
+++ b/fly.toml
@@ -39,9 +39,6 @@ primary_region = "iad"
   NODE_ENV = "production"
   PORT = "3000"
   NEXT_TELEMETRY_DISABLED = "1"
-  # Public landing-page demo asset for the opensignup.org instance.
-  # Read at request time by the dynamic landing page — no Dockerfile
-  # build-arg wiring needed. Self-hosters override or omit.
   NEXT_PUBLIC_DEMO_VIDEO_URL = "https://opensignup-public.t3.tigrisfiles.io/demo.mp4"
 
 [http_service]

--- a/src/app/_components/DemoVideoCta.tsx
+++ b/src/app/_components/DemoVideoCta.tsx
@@ -11,6 +11,8 @@ interface DemoVideoCtaProps {
 export function DemoVideoCta({ videoUrl, posterUrl }: DemoVideoCtaProps) {
   const [open, setOpen] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
 
   const openModal = useCallback(() => {
     emitLandingCtaClicked('demo_video');
@@ -24,10 +26,12 @@ export function DemoVideoCta({ videoUrl, posterUrl }: DemoVideoCtaProps) {
       video.currentTime = 0;
     }
     setOpen(false);
+    triggerRef.current?.focus();
   }, []);
 
   useEffect(() => {
     if (!open) return;
+    closeRef.current?.focus();
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') close();
     }
@@ -38,6 +42,7 @@ export function DemoVideoCta({ videoUrl, posterUrl }: DemoVideoCtaProps) {
   return (
     <>
       <button
+        ref={triggerRef}
         type="button"
         onClick={openModal}
         className="bg-surface border-surface-sunk text-ink hover:bg-surface-raised inline-flex items-center justify-center gap-2 rounded-[14px] border px-5 py-3 text-base font-medium transition lg:text-[15px]"
@@ -60,6 +65,7 @@ export function DemoVideoCta({ videoUrl, posterUrl }: DemoVideoCtaProps) {
         >
           <div className="relative w-full max-w-3xl">
             <button
+              ref={closeRef}
               type="button"
               onClick={close}
               aria-label="Close video"
@@ -89,9 +95,7 @@ export function DemoVideoCta({ videoUrl, posterUrl }: DemoVideoCtaProps) {
                 playsInline
                 preload="metadata"
                 className="h-full w-full"
-              >
-                <track kind="captions" />
-              </video>
+              />
             </div>
           </div>
         </div>

--- a/src/app/_components/DemoVideoCta.tsx
+++ b/src/app/_components/DemoVideoCta.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { emitLandingCtaClicked } from './landingCtaTelemetry';
+
+interface DemoVideoCtaProps {
+  videoUrl: string;
+  posterUrl?: string;
+}
+
+export function DemoVideoCta({ videoUrl, posterUrl }: DemoVideoCtaProps) {
+  const [open, setOpen] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  const openModal = useCallback(() => {
+    emitLandingCtaClicked('demo_video');
+    setOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      video.currentTime = 0;
+    }
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') close();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openModal}
+        className="bg-surface border-surface-sunk text-ink hover:bg-surface-raised inline-flex items-center justify-center gap-2 rounded-[14px] border px-5 py-3 text-base font-medium transition lg:text-[15px]"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
+          <polygon points="6 4 20 12 6 20 6 4" fill="currentColor" />
+        </svg>
+        Watch demo
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Product demo video"
+          className="bg-ink/60 fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) close();
+          }}
+        >
+          <div className="relative w-full max-w-3xl">
+            <button
+              type="button"
+              onClick={close}
+              aria-label="Close video"
+              className="bg-surface text-ink hover:bg-surface-raised absolute -top-12 right-0 inline-flex h-9 w-9 items-center justify-center rounded-full shadow-md transition"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M6 6l12 12M6 18L18 6" />
+              </svg>
+            </button>
+            <div className="aspect-video overflow-hidden rounded-2xl bg-black shadow-2xl">
+              <video
+                ref={videoRef}
+                src={videoUrl}
+                poster={posterUrl}
+                controls
+                autoPlay
+                playsInline
+                preload="metadata"
+                className="h-full w-full"
+              >
+                <track kind="captions" />
+              </video>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/_components/StartSignupCta.tsx
+++ b/src/app/_components/StartSignupCta.tsx
@@ -2,20 +2,7 @@
 
 import Link from 'next/link';
 import type { ReactNode } from 'react';
-
-const TELEMETRY_URL = '/api/telemetry/landing-cta-clicked';
-
-function emit(): void {
-  try {
-    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
-      const ok = navigator.sendBeacon(TELEMETRY_URL, new Blob([], { type: 'text/plain' }));
-      if (ok) return;
-    }
-    void fetch(TELEMETRY_URL, { method: 'POST', keepalive: true }).catch(() => {});
-  } catch {
-    // Telemetry must never break the click.
-  }
-}
+import { emitLandingCtaClicked } from './landingCtaTelemetry';
 
 export function StartSignupCta({
   href,
@@ -27,7 +14,7 @@ export function StartSignupCta({
   children: ReactNode;
 }) {
   return (
-    <Link href={href} className={className} onClick={emit}>
+    <Link href={href} className={className} onClick={() => emitLandingCtaClicked('start_signup')}>
       {children}
     </Link>
   );

--- a/src/app/_components/landingCtaTelemetry.ts
+++ b/src/app/_components/landingCtaTelemetry.ts
@@ -1,4 +1,4 @@
-export type LandingCta = 'start_signup' | 'demo_video';
+import type { LandingCta } from '@/lib/landing-cta';
 
 const TELEMETRY_PATH = '/api/telemetry/landing-cta-clicked';
 

--- a/src/app/_components/landingCtaTelemetry.ts
+++ b/src/app/_components/landingCtaTelemetry.ts
@@ -1,0 +1,16 @@
+export type LandingCta = 'start_signup' | 'demo_video';
+
+const TELEMETRY_PATH = '/api/telemetry/landing-cta-clicked';
+
+export function emitLandingCtaClicked(cta: LandingCta): void {
+  const url = `${TELEMETRY_PATH}?cta=${cta}`;
+  try {
+    if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const ok = navigator.sendBeacon(url, new Blob([], { type: 'text/plain' }));
+      if (ok) return;
+    }
+    void fetch(url, { method: 'POST', keepalive: true }).catch(() => {});
+  } catch {
+    // Telemetry must never break the click.
+  }
+}

--- a/src/app/api/telemetry/landing-cta-clicked/route.test.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.test.ts
@@ -17,34 +17,63 @@ import { POST } from './route';
 const browserUa =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
+function request(query = ''): Request {
+  return new Request(`http://localhost/api/telemetry/landing-cta-clicked${query}`, {
+    method: 'POST',
+  });
+}
+
 describe('POST /api/telemetry/landing-cta-clicked', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns 204 with an empty body and forwards header-derived signals', async () => {
+  it('returns 204 with an empty body, forwards header-derived signals, and defaults cta=start_signup', async () => {
     currentHeaders = new Headers({
       'user-agent': browserUa,
       referer: 'https://opensignup.org/',
     });
 
-    const res = await POST();
+    const res = await POST(request());
 
     expect(res.status).toBe(204);
     expect(await res.text()).toBe('');
     expect(recordLandingCtaClicked).toHaveBeenCalledTimes(1);
     expect(recordLandingCtaClicked).toHaveBeenCalledWith({
+      cta: 'start_signup',
       signals: { userAgent: browserUa, referer: 'https://opensignup.org/', dnt: false },
     });
+  });
+
+  it('forwards an explicit cta=demo_video query param', async () => {
+    currentHeaders = new Headers({ 'user-agent': browserUa });
+
+    const res = await POST(request('?cta=demo_video'));
+
+    expect(res.status).toBe(204);
+    expect(recordLandingCtaClicked).toHaveBeenCalledWith({
+      cta: 'demo_video',
+      signals: { userAgent: browserUa, referer: null, dnt: false },
+    });
+  });
+
+  it('rejects unknown cta values with a 400', async () => {
+    currentHeaders = new Headers({ 'user-agent': browserUa });
+
+    const res = await POST(request('?cta=mystery'));
+
+    expect(res.status).toBe(400);
+    expect(recordLandingCtaClicked).not.toHaveBeenCalled();
   });
 
   it('derives dnt=true from the DNT header (signals come from headers, not a body)', async () => {
     currentHeaders = new Headers({ 'user-agent': browserUa, dnt: '1' });
 
-    const res = await POST();
+    const res = await POST(request());
 
     expect(res.status).toBe(204);
     expect(recordLandingCtaClicked).toHaveBeenCalledWith({
+      cta: 'start_signup',
       signals: { userAgent: browserUa, referer: null, dnt: true },
     });
   });

--- a/src/app/api/telemetry/landing-cta-clicked/route.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.ts
@@ -1,12 +1,13 @@
 import { headers } from 'next/headers';
 import { z } from 'zod';
 import { handle } from '@/lib/api-response';
+import { LANDING_CTAS } from '@/lib/landing-cta';
 import { readRequestSignals, recordLandingCtaClicked } from '@/lib/view-tracker';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const ctaSchema = z.enum(['start_signup', 'demo_video']).default('start_signup');
+const ctaSchema = z.enum(LANDING_CTAS).default('start_signup');
 
 export async function POST(request: Request) {
   return handle(async () => {

--- a/src/app/api/telemetry/landing-cta-clicked/route.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.ts
@@ -1,14 +1,19 @@
 import { headers } from 'next/headers';
+import { z } from 'zod';
 import { handle } from '@/lib/api-response';
 import { readRequestSignals, recordLandingCtaClicked } from '@/lib/view-tracker';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-export async function POST() {
+const ctaSchema = z.enum(['start_signup', 'demo_video']).default('start_signup');
+
+export async function POST(request: Request) {
   return handle(async () => {
+    const url = new URL(request.url);
+    const cta = ctaSchema.parse(url.searchParams.get('cta') ?? undefined);
     const signals = readRequestSignals(await headers());
-    await recordLandingCtaClicked({ signals });
+    await recordLandingCtaClicked({ cta, signals });
     return new Response(null, { status: 204 });
   });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,14 @@ import { after } from 'next/server';
 import { SiteFooter } from '@/components/site-footer';
 import { INSTANCE_NAME } from '@/lib/site-config';
 import { readRequestSignals, recordLandingView } from '@/lib/view-tracker';
+import { DemoVideoCta } from './_components/DemoVideoCta';
 import { HomeExampleCard } from './_components/HomeExampleCard';
 import { StartSignupCta } from './_components/StartSignupCta';
 
 export default async function LandingPage() {
   const demoUrl = process.env.NEXT_PUBLIC_DEMO_URL;
+  const demoVideoUrl = process.env.NEXT_PUBLIC_DEMO_VIDEO_URL;
+  const demoVideoPoster = process.env.NEXT_PUBLIC_DEMO_VIDEO_POSTER;
 
   const signals = readRequestSignals(await headers());
   after(() => recordLandingView({ signals }));
@@ -60,7 +63,9 @@ export default async function LandingPage() {
                 <path d="M5 12h14M13 5l7 7-7 7" />
               </svg>
             </StartSignupCta>
-            {demoUrl ? (
+            {demoVideoUrl ? (
+              <DemoVideoCta videoUrl={demoVideoUrl} posterUrl={demoVideoPoster} />
+            ) : demoUrl ? (
               <a
                 href={demoUrl}
                 className="bg-surface border-surface-sunk text-ink hover:bg-surface-raised inline-flex items-center justify-center gap-2 rounded-[14px] border px-5 py-3 text-base font-medium transition lg:text-[15px]"
@@ -68,7 +73,7 @@ export default async function LandingPage() {
                 <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
                   <polygon points="6 4 20 12 6 20 6 4" fill="currentColor" />
                 </svg>
-                Watch 30-sec demo
+                Watch demo
               </a>
             ) : null}
           </div>

--- a/src/lib/landing-cta.ts
+++ b/src/lib/landing-cta.ts
@@ -1,0 +1,3 @@
+export const LANDING_CTAS = ['start_signup', 'demo_video'] as const;
+
+export type LandingCta = (typeof LANDING_CTAS)[number];

--- a/src/lib/view-tracker.db.test.ts
+++ b/src/lib/view-tracker.db.test.ts
@@ -300,6 +300,7 @@ describe('view-tracker (db)', () => {
 
     it('writes a landing.cta_clicked row with NULL signup/workspace for a browser UA', async () => {
       await recordLandingCtaClicked({
+        cta: 'start_signup',
         signals: browserSignals({ referer: 'https://opensignup.org/' }),
       });
       const rows = await db
@@ -313,13 +314,29 @@ describe('view-tracker (db)', () => {
       expect(row.signupId).toBeNull();
       expect(row.workspaceId).toBeNull();
       expect(row.payload).toEqual({
+        cta: 'start_signup',
         uaClass: 'browser',
         refererHost: 'opensignup.org',
       });
     });
 
+    it('persists the cta discriminator (demo_video)', async () => {
+      await recordLandingCtaClicked({
+        cta: 'demo_video',
+        signals: browserSignals({}),
+      });
+      const rows = await db
+        .select()
+        .from(activity)
+        .where(eq(activity.eventType, 'landing.cta_clicked'));
+      expect(rows).toHaveLength(1);
+      const payload = rows[0]!.payload as Record<string, unknown>;
+      expect(payload.cta).toBe('demo_video');
+    });
+
     it('records uaClass=unknown when UA is missing', async () => {
       await recordLandingCtaClicked({
+        cta: 'start_signup',
         signals: { userAgent: null, referer: null, dnt: false },
       });
       const rows = await db
@@ -333,7 +350,10 @@ describe('view-tracker (db)', () => {
     });
 
     it('does not write when DNT/GPC is set', async () => {
-      await recordLandingCtaClicked({ signals: browserSignals({ dnt: true }) });
+      await recordLandingCtaClicked({
+        cta: 'start_signup',
+        signals: browserSignals({ dnt: true }),
+      });
       const rows = await db
         .select()
         .from(activity)
@@ -343,6 +363,7 @@ describe('view-tracker (db)', () => {
 
     it('does not write for a Googlebot UA', async () => {
       await recordLandingCtaClicked({
+        cta: 'start_signup',
         signals: browserSignals({
           userAgent:
             'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -120,7 +120,10 @@ export async function recordLandingView(args: {
   }
 }
 
+export type LandingCta = 'start_signup' | 'demo_video';
+
 export async function recordLandingCtaClicked(args: {
+  cta: LandingCta;
   signals: RequestSignals;
 }): Promise<void> {
   try {
@@ -133,6 +136,7 @@ export async function recordLandingCtaClicked(args: {
       actor: { actorId: null, actorType: 'system' },
       eventType: 'landing.cta_clicked',
       payload: {
+        cta: args.cta,
         uaClass,
         refererHost: refererHost(args.signals.referer),
       },

--- a/src/lib/view-tracker.ts
+++ b/src/lib/view-tracker.ts
@@ -1,6 +1,7 @@
 import type { ActivityEvent } from '@/db/schema/activity';
 import { getDb } from '@/db/client';
 import { recordActivity, type ActivityActor } from '@/lib/activity';
+import type { LandingCta } from '@/lib/landing-cta';
 import { log } from '@/lib/log';
 
 const BOT_RE =
@@ -119,8 +120,6 @@ export async function recordLandingView(args: {
     log.warn({ err }, 'recordLandingView failed');
   }
 }
-
-export type LandingCta = 'start_signup' | 'demo_video';
 
 export async function recordLandingCtaClicked(args: {
   cta: LandingCta;


### PR DESCRIPTION
## Summary
- Replaces the link-out **Watch demo** CTA with an in-page modal containing a native `<video controls autoPlay playsInline>` element. Reads the mp4 URL from `NEXT_PUBLIC_DEMO_VIDEO_URL` (with an optional `NEXT_PUBLIC_DEMO_VIDEO_POSTER`). When the new var is unset, falls back to the existing `NEXT_PUBLIC_DEMO_URL` link-out, so self-hosters keep the prior behaviour without code changes.
- Adds a `cta` discriminator (`start_signup` | `demo_video`) on the existing `landing.cta_clicked` activity event so the two landing CTAs can be measured independently. The shared `sendBeacon` logic moves into `landingCtaTelemetry.ts` and is reused by `StartSignupCta` and the new `DemoVideoCta`.
- Privacy page already covers this generically ("anonymous view telemetry on the marketing home page"); adding a discriminator doesn't expand what's collected, so no copy change there.

Both new env vars are read at request time on the dynamic landing page (it already calls `headers()`), so they ship as plain Fly secrets — no `fly.toml` / `Dockerfile` build-arg wiring needed.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 494 passed, including 4 cases on the route (default cta, explicit `demo_video`, rejects unknown cta, DNT)
- [x] `pnpm test:db src/lib/view-tracker.db.test.ts` — 18 passed, including a new case that asserts `cta: 'demo_video'` is persisted in the activity payload
- [x] Manual: set `NEXT_PUBLIC_DEMO_VIDEO_URL` locally, run `pnpm dev`, click **Watch demo** on `/` — modal opens, video autoplays, Escape and backdrop close, video pauses + resets to 0 on close
- [x] Manual: confirm activity row written with `payload.cta = 'demo_video'`
- [x] Manual: with only `NEXT_PUBLIC_DEMO_URL` set (no video URL), CTA falls back to link-out