### PR TITLE
Add Playwright e2e foundation: smokes, axe specs, CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Both jobs only read the repo; artifact upload uses its own scope, not the
+# GITHUB_TOKEN. Restricting here covers every job in the workflow.
+permissions:
+  contents: read
+
 jobs:
   lint-type-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,50 @@ jobs:
       - run: pnpm test
       - run: pnpm test:db
       - run: pnpm build
+
+  e2e:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: signup
+          POSTGRES_PASSWORD: signup
+          POSTGRES_DB: signup
+        ports: ['5433:5432']
+        options: >-
+          --health-cmd="pg_isready -U signup"
+          --health-interval=3s
+          --health-timeout=3s
+          --health-retries=10
+    env:
+      DATABASE_URL: postgres://signup:signup@localhost:5433/signup
+      # Deterministic placeholder for CI only — the seeded session and edit
+      # tokens are derived from it inside this job and never leave it.
+      AUTH_SECRET: ci-secret-ci-secret-ci-secret-ci
+      AUTH_URL: http://localhost:3000
+      EMAIL_TRANSPORT: console
+      EMAIL_FROM: 'ci@signup.local'
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      NEXT_PUBLIC_INSTANCE_NAME: OpenSignup (CI)
+      NEXT_PUBLIC_SUPPORT_EMAIL: ci@signup.local
+      NEXT_PUBLIC_SOURCE_URL: https://github.com/richshaw/OpenSignup
+      NEXT_PUBLIC_GOVERNING_LAW: the State of Washington, United States
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm db:migrate
+      - run: pnpm build
+      - run: pnpm test:e2e --project=chromium
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 coverage
 playwright-report
 test-results
+tests/e2e/.seed.json
 .playwright-mcp
 .vscode
 .idea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ From `CONTRIBUTING.md` and the v1 plan:
 
 - `src/**/*.test.ts(x)` — unit, run by `pnpm test`.
 - `src/**/*.db.test.ts` — integration against real Postgres, run by `pnpm test:db` (sequential; needs `docker compose up -d` and migrations applied).
-- `tests/e2e/**` — Playwright (`testDir` in `playwright.config.ts`), run by `pnpm test:e2e`. `@axe-core/playwright` is installed; no axe specs exist yet (planned for `/s/[slug]`).
+- `tests/e2e/**` — Playwright smokes (`testDir` in `playwright.config.ts`), run by `pnpm test:e2e`. Needs Postgres up, migrations applied, and a production build (`pnpm build`) — the config starts `pnpm start` itself; locally an already-running `pnpm dev` on :3000 is reused instead. `tests/e2e/global-setup.ts` reseeds fixture data (organizer + session, published/draft signups, a commitment with edit token) into the database on every run and writes ids/tokens to the gitignored `tests/e2e/.seed.json`. Axe (WCAG A/AA) specs cover `/s/[slug]` and the commit dialog in `tests/e2e/a11y.spec.ts`. CI runs the chromium project in a dedicated job.
 
 ## Recurring mistakes to avoid
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open `http://localhost:3000`, request a magic link with any email, and look at t
 
 ## Self-host
 
-Docker image is published to GHCR on release. See `docker-compose.yml` for the canonical setup (app + db + worker). Configuration is entirely via environment variables — see `.env.example`.
+Build the Docker image from source with the included `Dockerfile` (a prebuilt registry image is planned but not yet published). See `docker-compose.prod.yml` for the canonical setup (app + db + migrate + worker). Configuration is entirely via environment variables — see `.env.example`.
 
 Email transport is pluggable (`console` for dev, `smtp` for generic self-host, `resend` for hosted). No other external accounts required.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -7,10 +9,19 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  globalSetup: './tests/e2e/global-setup.ts',
   use: {
-    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    baseURL,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
+  },
+  webServer: {
+    // Production server: run `pnpm build` first. Locally an already-running
+    // `pnpm dev` on :3000 is reused instead.
+    command: 'pnpm start',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/src/lib/returning-participant.test.ts
+++ b/src/lib/returning-participant.test.ts
@@ -97,18 +97,27 @@ describe('setReturningCommitCookie', () => {
     return { response: { cookies: { set } } as unknown as NextResponse, set };
   }
 
-  it('sets secure:true in production', () => {
-    vi.stubEnv('NODE_ENV', 'production');
+  it('sets secure:true when the app is served over https', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://opensignup.org');
     const { response, set } = mockResponse();
     setReturningCommitCookie(response, 'com_a.tok');
     expect(set).toHaveBeenCalledWith(expect.objectContaining({ secure: true }));
   });
 
-  it('sets secure:false outside production', () => {
-    vi.stubEnv('NODE_ENV', 'test');
+  it('sets secure:false over plain http even in production builds', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'http://localhost:3000');
+    vi.stubEnv('NODE_ENV', 'production');
     const { response, set } = mockResponse();
     setReturningCommitCookie(response, 'com_a.tok');
     expect(set).toHaveBeenCalledWith(expect.objectContaining({ secure: false }));
+  });
+
+  it('falls back to NODE_ENV when NEXT_PUBLIC_APP_URL is unset', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', '');
+    vi.stubEnv('NODE_ENV', 'production');
+    const { response, set } = mockResponse();
+    setReturningCommitCookie(response, 'com_a.tok');
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ secure: true }));
   });
 
   it('always sets httpOnly and sameSite:lax', () => {

--- a/src/lib/returning-participant.ts
+++ b/src/lib/returning-participant.ts
@@ -88,6 +88,19 @@ export function removeReturningCommit(
   );
 }
 
+/**
+ * `Secure` follows the deployment scheme, not NODE_ENV: a production build
+ * served over plain HTTP (intranet self-host, local `next start`, e2e) must
+ * not set Secure or browsers silently drop the cookie — Chromium exempts
+ * localhost, WebKit/Firefox do not. Falls back to NODE_ENV when
+ * NEXT_PUBLIC_APP_URL is unset.
+ */
+function isHttpsDeployment(): boolean {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+  if (appUrl) return appUrl.startsWith('https:');
+  return process.env.NODE_ENV === 'production';
+}
+
 export function setReturningCommitCookie(response: NextResponse, value: string): void {
   // Path `/` — every API route mutating commits needs to read/write this cookie,
   // and SSR filters by signup_id, so cross-signup leakage is impossible.
@@ -99,6 +112,6 @@ export function setReturningCommitCookie(response: NextResponse, value: string):
     maxAge: MAX_AGE_DAYS * 24 * 60 * 60,
     sameSite: 'lax',
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
+    secure: isHttpsDeployment(),
   });
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,7 +14,9 @@ export default {
         ink: {
           DEFAULT: '#0b1220',
           muted: '#5b6474',
-          soft: '#8a93a4',
+          // Lightest tone that still meets WCAG AA 4.5:1 for small text on
+          // both `surface` (#fff) and `surface.raised` (#f7f8fa).
+          soft: '#667085',
         },
         brand: {
           DEFAULT: '#1f6feb',

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -1,0 +1,43 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import { loadSeed } from './helpers/fixtures';
+
+const seed = loadSeed();
+
+test.describe('accessibility', () => {
+  test('public signup page has no WCAG A/AA violations', async ({ page }) => {
+    await page.goto(`/s/${seed.publicSlug}`);
+    await expect(page.getByRole('heading', { name: seed.publicTitle })).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(
+      results.violations.map((v) => ({
+        id: v.id,
+        impact: v.impact,
+        nodes: v.nodes.map((n) => n.target),
+      })),
+    ).toEqual([]);
+  });
+
+  test('commit dialog has no WCAG A/AA violations', async ({ page }) => {
+    await page.goto(`/s/${seed.publicSlug}`);
+    const row = page.locator('li').filter({ hasText: seed.openSlotLabel });
+    await row.getByRole('button', { name: 'Sign up' }).click();
+    await expect(page.getByLabel('Your name')).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    expect(
+      results.violations.map((v) => ({
+        id: v.id,
+        impact: v.impact,
+        nodes: v.nodes.map((n) => n.target),
+      })),
+    ).toEqual([]);
+  });
+});

--- a/tests/e2e/edit-token.spec.ts
+++ b/tests/e2e/edit-token.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+import { loadSeed } from './helpers/fixtures';
+
+const seed = loadSeed();
+
+test.describe('token-gated commitment editing', () => {
+  test('participant edits notes, then cancels their commitment', async ({ page }) => {
+    // Own state per attempt: commit via the API so projects and retries never
+    // edit/cancel the same commitment twice.
+    const name = 'Casey Editor';
+    const created = await page.request.post(`/api/slots/${seed.editSlotId}/commitments`, {
+      data: { name, email: `casey+${Date.now()}@example.test`, quantity: 1 },
+    });
+    expect(created.ok()).toBe(true);
+    const editUrl = (await created.json()).data.editUrl as string;
+
+    await page.goto(editUrl);
+    await expect(page.getByRole('heading', { name: 'Your signup' })).toBeVisible();
+    await expect(page.getByLabel('Name')).toHaveValue(name);
+
+    await page.getByLabel('Notes').fill('Bringing plates');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByRole('status')).toHaveText('Saved.');
+
+    // Two-step cancel: confirm dialog, then redirect back to the public page.
+    await page.getByRole('button', { name: 'Cancel signup' }).click();
+    await expect(page.getByRole('alertdialog', { name: 'Confirm cancellation' })).toBeVisible();
+    await page.getByRole('button', { name: 'Yes, cancel' }).click();
+    await expect(page).toHaveURL(new RegExp(`/s/${seed.editSlug}$`));
+  });
+
+  test('invalid token renders not-found', async ({ page }) => {
+    const response = await page.goto(
+      `/s/${seed.editSlug}/c/${seed.editCommitmentId}?token=invalid-token`,
+    );
+    expect(response?.status()).toBe(404);
+  });
+
+  test('missing token renders not-found', async ({ page }) => {
+    const response = await page.goto(`/s/${seed.editSlug}/c/${seed.editCommitmentId}`);
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,12 @@
+import { config } from 'dotenv';
+import { seedE2E } from './helpers/seed';
+
+export default async function globalSetup(): Promise<void> {
+  // Env first: getEnv() is lazy everywhere, so loading here (before any
+  // seed code runs) is early enough.
+  config({ path: '.env.local' });
+  config({ path: '.env' });
+  await seedE2E();
+  // Close the singleton postgres pool so the setup process can exit cleanly.
+  await globalThis.__signup_pg__?.end({ timeout: 5 });
+}

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,0 +1,20 @@
+import type { BrowserContext } from '@playwright/test';
+import { BASE_URL, loadSeed } from './fixtures';
+
+/**
+ * Authenticates as the seeded organizer by installing the Auth.js database
+ * session cookie directly (session strategy is 'database', so the cookie
+ * value is just the sessions.session_token row seeded in global-setup).
+ */
+export async function loginAsSeededOrganizer(context: BrowserContext): Promise<void> {
+  const seed = loadSeed();
+  await context.addCookies([
+    {
+      name: 'authjs.session-token',
+      value: seed.sessionToken,
+      url: BASE_URL,
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -8,12 +8,16 @@ import { BASE_URL, loadSeed } from './fixtures';
  */
 export async function loginAsSeededOrganizer(context: BrowserContext): Promise<void> {
   const seed = loadSeed();
+  // Auth.js derives useSecureCookies from the app URL scheme: over https the
+  // cookie is renamed `__Secure-authjs.session-token` and must be `secure`.
+  const secure = BASE_URL.startsWith('https://');
   await context.addCookies([
     {
-      name: 'authjs.session-token',
+      name: secure ? '__Secure-authjs.session-token' : 'authjs.session-token',
       value: seed.sessionToken,
       url: BASE_URL,
       httpOnly: true,
+      secure,
       sameSite: 'Lax',
     },
   ]);

--- a/tests/e2e/helpers/fixtures.ts
+++ b/tests/e2e/helpers/fixtures.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { SeedData } from './seed';
+
+/** Reads the data written by global-setup's seed run. */
+export function loadSeed(): SeedData {
+  const file = path.join(process.cwd(), 'tests', 'e2e', '.seed.json');
+  return JSON.parse(readFileSync(file, 'utf8')) as SeedData;
+}
+
+export const BASE_URL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';

--- a/tests/e2e/helpers/seed.ts
+++ b/tests/e2e/helpers/seed.ts
@@ -1,0 +1,190 @@
+import { randomBytes } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { eq } from 'drizzle-orm';
+import { getDb, type Db } from '@/db/client';
+import { sessions } from '@/db/schema/auth';
+import { workspaceMembers } from '@/db/schema/members';
+import { organizers } from '@/db/schema/organizers';
+import { workspaces } from '@/db/schema/workspaces';
+import { makeId } from '@/lib/ids';
+import type { Actor } from '@/lib/policy';
+import { slots } from '@/db/schema/slots';
+import { commitToSlot } from '@/services/commitments';
+import { createSignup, publishSignup } from '@/services/signups';
+import { addSlot } from '@/services/slots';
+
+const E2E_ORGANIZER_EMAIL = 'e2e@example.test';
+const E2E_WORKSPACE_SLUG = 'e2e-workspace';
+
+export const SEED_FILE = path.join(process.cwd(), 'tests', 'e2e', '.seed.json');
+
+export interface SeedData {
+  sessionToken: string;
+  /** Published signup with an open slot ("Cookies") and a full slot ("Brownies"). */
+  publicSlug: string;
+  publicTitle: string;
+  openSlotLabel: string;
+  fullSlotLabel: string;
+  /** Draft signup for the organizer publish flow. */
+  draftSignupId: string;
+  draftTitle: string;
+  /** Published signup with a seeded commitment for the edit-token flow. */
+  editSlug: string;
+  editSlotId: string;
+  editCommitmentId: string;
+  editToken: string;
+}
+
+/** Removes any prior e2e data. Workspace delete cascades signups → slots →
+ *  participants → commitments; organizer delete cascades sessions. */
+async function cleanup(db: Db): Promise<void> {
+  const [org] = await db
+    .select({ id: organizers.id })
+    .from(organizers)
+    .where(eq(organizers.email, E2E_ORGANIZER_EMAIL))
+    .limit(1);
+  await db.delete(workspaces).where(eq(workspaces.slug, E2E_WORKSPACE_SLUG));
+  if (org) await db.delete(organizers).where(eq(organizers.id, org.id));
+}
+
+function unwrap<T>(
+  result: { ok: true; value: T } | { ok: false; error: { message: string } },
+  what: string,
+): T {
+  if (!result.ok) throw new Error(`seed: ${what} failed: ${result.error.message}`);
+  return result.value;
+}
+
+async function makePublishedSignup(
+  db: Db,
+  actor: Actor,
+  workspaceId: string,
+  title: string,
+  slotLabels: { label: string; capacity: number }[],
+): Promise<{ id: string; slug: string; slotIds: string[] }> {
+  const signup = unwrap(
+    await createSignup(db, actor, workspaceId, {
+      title,
+      description: 'Seeded by tests/e2e/helpers/seed.ts',
+      tags: [],
+      visibility: 'unlisted' as const,
+      settings: {},
+    }),
+    `createSignup(${title})`,
+  );
+  // createSignup applies DEFAULT_TEMPLATE: a 'what' text field, a 'date'
+  // field, and one empty slot. Keep the fields, drop the placeholder slot so
+  // the page shows exactly the labeled slots below.
+  await db.delete(slots).where(eq(slots.signupId, signup.id));
+  const slotIds: string[] = [];
+  for (const { label, capacity } of slotLabels) {
+    const slot = unwrap(
+      await addSlot(db, actor, signup.id, { values: { what: label }, capacity }),
+      `addSlot(${label})`,
+    );
+    slotIds.push(slot.id);
+  }
+  unwrap(await publishSignup(db, actor, signup.id), `publishSignup(${title})`);
+  return { id: signup.id, slug: signup.slug, slotIds };
+}
+
+export async function seedE2E(): Promise<SeedData> {
+  const db = getDb();
+  await cleanup(db);
+
+  const organizerId = makeId('org');
+  const workspaceId = makeId('ws');
+  await db.transaction(async (tx) => {
+    await tx.insert(organizers).values({
+      id: organizerId,
+      email: E2E_ORGANIZER_EMAIL,
+      name: 'E2E Organizer',
+      defaultWorkspaceId: workspaceId,
+    });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      slug: E2E_WORKSPACE_SLUG,
+      name: 'E2E Workspace',
+      type: 'personal',
+      plan: 'free',
+    });
+    await tx.insert(workspaceMembers).values({
+      id: makeId('mem'),
+      workspaceId,
+      organizerId,
+      role: 'owner',
+      status: 'active',
+    });
+  });
+
+  const sessionToken = randomBytes(32).toString('hex');
+  await db.insert(sessions).values({
+    sessionToken,
+    userId: organizerId,
+    expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  });
+
+  const actor: Actor = {
+    kind: 'organizer',
+    id: organizerId,
+    email: E2E_ORGANIZER_EMAIL,
+    workspaceIds: [workspaceId],
+    workspaceRoles: { [workspaceId]: 'owner' },
+  };
+
+  // Public signup: one open slot, one full slot.
+  const publicSignup = await makePublishedSignup(db, actor, workspaceId, 'Bake Sale', [
+    { label: 'Cookies', capacity: 5 },
+    { label: 'Brownies', capacity: 1 },
+  ]);
+  unwrap(
+    await commitToSlot(db, publicSignup.slotIds[1]!, {
+      name: 'Robin Baker',
+      email: 'robin@example.test',
+      quantity: 1,
+    }),
+    'commitToSlot(Brownies)',
+  );
+
+  // Edit-token signup: one slot with a seeded commitment.
+  const editSignup = await makePublishedSignup(db, actor, workspaceId, 'Carpool Roster', [
+    { label: 'Saturday drive', capacity: 20 },
+  ]);
+  const editCommit = unwrap(
+    await commitToSlot(db, editSignup.slotIds[0]!, {
+      name: 'Casey Editor',
+      email: 'casey@example.test',
+      quantity: 1,
+    }),
+    'commitToSlot(Saturday drive)',
+  );
+
+  // Draft signup for the organizer publish flow.
+  const draft = unwrap(
+    await createSignup(db, actor, workspaceId, {
+      title: 'Draft Picnic',
+      description: 'Seeded draft for the publish smoke test',
+      tags: [],
+      visibility: 'unlisted' as const,
+      settings: {},
+    }),
+    'createSignup(Draft Picnic)',
+  );
+
+  const data: SeedData = {
+    sessionToken,
+    publicSlug: publicSignup.slug,
+    publicTitle: 'Bake Sale',
+    openSlotLabel: 'Cookies',
+    fullSlotLabel: 'Brownies',
+    draftSignupId: draft.id,
+    draftTitle: 'Draft Picnic',
+    editSlug: editSignup.slug,
+    editSlotId: editSignup.slotIds[0]!,
+    editCommitmentId: editCommit.commitment.id,
+    editToken: editCommit.editToken,
+  };
+  writeFileSync(SEED_FILE, JSON.stringify(data, null, 2));
+  return data;
+}

--- a/tests/e2e/organizer.spec.ts
+++ b/tests/e2e/organizer.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+import { loginAsSeededOrganizer } from './helpers/auth';
+import { loadSeed } from './helpers/fixtures';
+
+const seed = loadSeed();
+
+test.describe('organizer flow', () => {
+  test.beforeEach(async ({ context }) => {
+    await loginAsSeededOrganizer(context);
+  });
+
+  test('dashboard lists workspace signups', async ({ page }) => {
+    await page.goto('/app');
+    await expect(page.getByRole('heading', { name: 'Your signups' })).toBeVisible();
+    await expect(page.getByText(seed.publicTitle)).toBeVisible();
+    await expect(page.getByText(seed.draftTitle)).toBeVisible();
+  });
+
+  test('organizer publishes a draft signup', async ({ page }) => {
+    // Create a fresh draft via the API (session cookie carries auth) so the
+    // test owns its state — projects and retries never compete over one draft.
+    const created = await page.request.post('/api/signups', {
+      data: {
+        title: `Publish flow ${Date.now()}`,
+        description: '',
+        tags: [],
+        visibility: 'unlisted',
+        settings: {},
+      },
+    });
+    expect(created.ok()).toBe(true);
+    const draftId = (await created.json()).data.id as string;
+
+    await page.goto(`/app/signups/${draftId}/build`);
+    // Desktop header shows Publish directly; mobile tucks it behind the
+    // "More actions" sheet.
+    const desktopPublish = page.getByRole('button', { name: 'Publish', exact: true });
+    if (await desktopPublish.isVisible()) {
+      await desktopPublish.click();
+    } else {
+      await page.getByRole('button', { name: 'More actions' }).click();
+      await page.getByRole('button', { name: 'Publish signup' }).click();
+    }
+    await expect(page.getByText('Signup published')).toBeVisible();
+  });
+
+  test('unauthenticated visitor is redirected to login', async ({ browser }) => {
+    const anonContext = await browser.newContext();
+    const page = await anonContext.newPage();
+    await page.goto('/app');
+    await expect(page).toHaveURL(/\/login/);
+    await anonContext.close();
+  });
+});

--- a/tests/e2e/public-commit.spec.ts
+++ b/tests/e2e/public-commit.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import { loadSeed } from './helpers/fixtures';
+
+const seed = loadSeed();
+
+test.describe('public commit flow', () => {
+  test('participant signs up for an open slot and gets an edit link', async ({ page }) => {
+    await page.goto(`/s/${seed.publicSlug}`);
+    await expect(page.getByRole('heading', { name: seed.publicTitle })).toBeVisible();
+
+    const row = page.locator('li').filter({ hasText: seed.openSlotLabel });
+    await row.getByRole('button', { name: 'Sign up' }).click();
+
+    // Unique email per attempt so CI retries don't trip the duplicate-commit
+    // conflict check.
+    const email = `pat+${Date.now()}@example.test`;
+    await page.getByLabel('Your name').fill('Pat Tester');
+    await page.getByLabel('Email').fill(email);
+    await page.getByRole('button', { name: 'Confirm' }).click();
+
+    await expect(page.getByRole('heading', { name: "You're in." })).toBeVisible();
+    const editLink = page.getByRole('link', {
+      name: new RegExp(`/s/${seed.publicSlug}/c/`),
+    });
+    await expect(editLink).toBeVisible();
+
+    // Closing the dialog refreshes; the cookie marks the row as ours.
+    await page.getByRole('button', { name: 'Done' }).click();
+    await expect(row.getByRole('link', { name: 'Edit' })).toBeVisible();
+  });
+
+  test('full slot shows Full and no sign-up affordance', async ({ page }) => {
+    await page.goto(`/s/${seed.publicSlug}`);
+    const row = page.locator('li').filter({ hasText: seed.fullSlotLabel });
+    await expect(row.getByText('Full')).toBeVisible();
+    await expect(row.getByRole('button', { name: 'Sign up' })).toHaveCount(0);
+    await expect(row.getByText('1/1')).toBeVisible();
+  });
+
+  test('unknown slug renders not-found', async ({ page }) => {
+    const response = await page.goto('/s/this-slug-does-not-exist');
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules", ".next", "dist", "playwright-report"]
 }


### PR DESCRIPTION
PR 1 of the engineering-integrity roadmap.

## Why

`tests/e2e/` was referenced by `playwright.config.ts` and CLAUDE.md ("UI covered by Playwright smokes") but **never existed** — the participant commit flow, organizer UI, and edit-token flow had zero browser-level coverage, and `@axe-core/playwright` sat unused since install.

## What

- **E2E suite** (11 specs, run on chromium + mobile-safari):
  - `public-commit.spec.ts` — commit happy path through the dialog (name/email/confirm → "You're in." + edit link → row flips to Edit), capacity-full state, unknown-slug 404.
  - `organizer.spec.ts` — seeded-session dashboard, publish flow (desktop button + mobile "More actions" sheet), unauthenticated redirect to login.
  - `edit-token.spec.ts` — token-gated edit + two-step cancel, invalid/missing token → 404.
  - `a11y.spec.ts` — axe WCAG A/AA scans of `/s/[slug]` and the open commit dialog (v1-plan task 9.7).
- **Deterministic seeding**: `global-setup.ts` wipes + reseeds an e2e workspace through the real services (`createSignup`/`addSlot`/`publishSignup`/`commitToSlot`), inserts an Auth.js DB session row, and hands ids/tokens to specs via gitignored `.seed.json`. Specs that mutate state create it via the API per attempt, so projects/retries never collide.
- **CI**: new `e2e` job (postgres service, chromium only, playwright-report artifact on failure).
- **Bug fix (found by the suite)**: the returning-participant cookie set `Secure` from `NODE_ENV`, so production builds served over plain HTTP (intranet self-hosts, local `next start`) silently lost the cookie in WebKit/Firefox — Chromium exempts localhost, they don't. `Secure` now follows the `NEXT_PUBLIC_APP_URL` scheme with a NODE_ENV fallback; unit tests updated.
- **Bug fix (found by the axe specs)**: `ink.soft` `#8a93a4` failed AA contrast (3.1:1) on the public-page footer, "Full"/"Closed" labels, and slot meta. Darkened to `#667085` (≥4.7:1 on every surface it's used on; it never appears on dark backgrounds).
- **Docs truth-up**: README no longer claims a GHCR image is published on release (no such workflow exists); CLAUDE.md test-layout section now describes the real e2e setup.

## Verification

- `pnpm lint` ✓, `pnpm typecheck` ✓ (now includes `tests/`), `pnpm test` 517 ✓, `pnpm test:db` 94 ✓
- `pnpm test:e2e` — 22/22 passed (11 specs × chromium + mobile-safari) against a production build
- Reseed verified idempotent across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)