### PR TITLE
Rate-limit unauthenticated endpoints, harden health checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Helpers used by every service:
 - `src/lib/parse.ts` — wraps Zod parsing into a `Result`.
 - `src/lib/activity.ts` — `recordActivity(tx, …)` writes to the append-only activity log **inside the same transaction** as the mutation it describes. Telemetry-only events (no describing mutation) write outside a tx; see `src/lib/view-tracker.ts` and `safeRecordAttemptFailed` in `src/services/commitments.ts`.
 - `src/lib/ids.ts` — UUIDv7 + base62 + 3–4 char type prefix (`sig_`, `slot_`, `org_`, `ws_`, `mem_`, `com_`, `par_`).
-- `src/lib/idempotency.ts`, `src/lib/rate-limit.ts` — Postgres-backed (no Redis); applied at API boundaries.
+- `src/lib/idempotency.ts`, `src/lib/rate-limit.ts` — Postgres-backed (no Redis); applied at API boundaries. Rate-limited surfaces: magic link (per email + per IP), public commit POST (per IP), `/api/commitments/[id]` token ops (per IP), signup create + Magic Compose (per organizer), landing telemetry (per IP). Every unauthenticated write endpoint must consume a rate limit before doing any work.
 
 ### Schemas: Zod is the source of truth
 
@@ -78,7 +78,7 @@ Helpers used by every service:
 
 ### Jobs
 
-pg-boss runs against the same Postgres (schema `pgboss`). The Next.js server **does not** run the worker — `pnpm worker` (`src/jobs/worker.ts`) is a separate process. Two queues: `reminderDispatch` (cron every 10 min, scans the 48h window) and `reminderSend` (per-commitment send with retries). On commit, schedule with `singletonKey: commitmentId` so swap/edit replaces the prior job.
+pg-boss runs against the same Postgres (schema `pgboss`). The Next.js server **does not** run the worker — `pnpm worker` (`src/jobs/worker.ts`) is a separate process. Two queues: `reminderDispatch` (cron every 10 min, scans the 48h window) and `reminderSend` (per-commitment send with retries). On commit, schedule with `singletonKey: commitmentId` so swap/edit replaces the prior job. Worker liveness is observable from the web process: `GET /api/public/health` reports `worker: ok | stale | unknown` by checking `pgboss.job` for a recent dispatch completion (`src/lib/worker-health.ts`) — informational only, never fails the HTTP check.
 
 ### Magic Compose (AI-drafted signups)
 

--- a/fly.toml
+++ b/fly.toml
@@ -55,6 +55,15 @@ primary_region = "iad"
     soft_limit = 200
     hard_limit = 250
 
+  # Restarts the web machine when the app can't serve or reach Postgres.
+  # A stale worker is reported in the body but never fails this check.
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/api/public/health"
+
 [[vm]]
   size = "shared-cpu-1x"
   memory = "1gb"

--- a/src/app/api/commitments/[id]/route.db.test.ts
+++ b/src/app/api/commitments/[id]/route.db.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+import { getDb, type Db } from '@/db/client';
+import { commitments } from '@/db/schema/commitments';
+import { workspaceMembers } from '@/db/schema/members';
+import { organizers } from '@/db/schema/organizers';
+import { workspaces } from '@/db/schema/workspaces';
+import { makeId } from '@/lib/ids';
+import type { Actor } from '@/lib/policy';
+import { RateLimits } from '@/lib/rate-limit';
+import { commitToSlot } from '@/services/commitments';
+import { createSignup, publishSignup } from '@/services/signups';
+import { addSlot } from '@/services/slots';
+import { DELETE, GET, PATCH } from './route';
+
+interface Fixture {
+  db: Db;
+  workspaceId: string;
+  organizerId: string;
+  actor: Actor;
+  slotId: string;
+}
+
+// Each request gets a unique source IP so the per-IP limiter never throttles
+// unrelated assertions; the rate-limit test pins one IP deliberately.
+let ipCounter = 0;
+function nextIp(): string {
+  ipCounter += 1;
+  return `198.51.100.${ipCounter % 254 || 1}`;
+}
+
+function makeRequest(
+  commitmentId: string,
+  opts: {
+    method?: 'GET' | 'PATCH' | 'DELETE';
+    token?: string | undefined;
+    tokenVia?: 'query' | 'header';
+    body?: unknown;
+    ip?: string;
+  } = {},
+): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const { method = 'GET', token, tokenVia = 'query', body, ip } = opts;
+  const query = token && tokenVia === 'query' ? `?token=${encodeURIComponent(token)}` : '';
+  const headers: Record<string, string> = { 'x-forwarded-for': ip ?? nextIp() };
+  if (token && tokenVia === 'header') headers['x-edit-token'] = token;
+  if (body !== undefined) headers['content-type'] = 'application/json';
+  const req = new NextRequest(`http://localhost/api/commitments/${commitmentId}${query}`, {
+    method,
+    headers,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  return { req, ctx: { params: Promise.resolve({ id: commitmentId }) } };
+}
+
+async function setupFixture(): Promise<Fixture> {
+  const db = getDb();
+  const organizerId = makeId('org');
+  const workspaceId = makeId('ws');
+  const slug = `cr-${workspaceId.slice(-8).toLowerCase()}`;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(organizers).values({ id: organizerId, email: `${slug}@example.test` });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      slug,
+      name: 'Commit Route Test',
+      type: 'personal',
+      plan: 'free',
+    });
+    await tx.insert(workspaceMembers).values({
+      id: makeId('mem'),
+      workspaceId,
+      organizerId,
+      role: 'owner',
+      status: 'active',
+    });
+  });
+
+  const actor: Actor = {
+    kind: 'organizer',
+    id: organizerId,
+    email: `${slug}@example.test`,
+    workspaceIds: [workspaceId],
+    workspaceRoles: { [workspaceId]: 'owner' },
+  };
+
+  const signup = await createSignup(db, actor, workspaceId, {
+    title: 'Commit route test',
+    description: '',
+    tags: [],
+    visibility: 'unlisted' as const,
+    settings: {},
+  });
+  if (!signup.ok) throw new Error(signup.error.message);
+  const slot = await addSlot(db, actor, signup.value.id, { values: {}, capacity: 50 });
+  if (!slot.ok) throw new Error(slot.error.message);
+  const pub = await publishSignup(db, actor, signup.value.id);
+  if (!pub.ok) throw new Error(pub.error.message);
+
+  return { db, workspaceId, organizerId, actor, slotId: slot.value.id };
+}
+
+async function makeCommitment(fx: Fixture): Promise<{ id: string; token: string }> {
+  const result = await commitToSlot(fx.db, fx.slotId, {
+    name: 'Route Tester',
+    email: `route-${makeId('com').slice(-8).toLowerCase()}@example.test`,
+    quantity: 1,
+  });
+  if (!result.ok) throw new Error(result.error.message);
+  return { id: result.value.commitment.id, token: result.value.editToken };
+}
+
+describe('/api/commitments/[id] (db)', () => {
+  let fx: Fixture;
+
+  beforeAll(async () => {
+    fx = await setupFixture();
+  });
+
+  afterAll(async () => {
+    await fx.db.delete(workspaces).where(eq(workspaces.id, fx.workspaceId));
+    await fx.db.delete(organizers).where(eq(organizers.id, fx.organizerId));
+  });
+
+  it('GET accepts the token from the query string', async () => {
+    const c = await makeCommitment(fx);
+    const { req, ctx } = makeRequest(c.id, { token: c.token });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.data.id).toBe(c.id);
+    expect(payload.data.participantName).toBe('Route Tester');
+  });
+
+  it('GET accepts the token from the x-edit-token header', async () => {
+    const c = await makeCommitment(fx);
+    const { req, ctx } = makeRequest(c.id, { token: c.token, tokenVia: 'header' });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('GET without a token returns 403', async () => {
+    const c = await makeCommitment(fx);
+    const { req, ctx } = makeRequest(c.id, {});
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(403);
+    const payload = await res.json();
+    expect(payload.error.code).toBe('forbidden');
+  });
+
+  it('GET with a wrong token returns 403', async () => {
+    const c = await makeCommitment(fx);
+    const { req, ctx } = makeRequest(c.id, { token: 'not-the-token' });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('PATCH updates notes with a valid token', async () => {
+    const c = await makeCommitment(fx);
+    const { req, ctx } = makeRequest(c.id, {
+      method: 'PATCH',
+      token: c.token,
+      body: { notes: 'updated by route test' },
+    });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const [row] = await fx.db
+      .select({ notes: commitments.notes })
+      .from(commitments)
+      .where(eq(commitments.id, c.id))
+      .limit(1);
+    expect(row?.notes).toBe('updated by route test');
+  });
+
+  it('DELETE cancels the commitment and rewrites the returning cookie', async () => {
+    const c = await makeCommitment(fx);
+    const { req, ctx } = makeRequest(c.id, { method: 'DELETE', token: c.token });
+    const res = await DELETE(req, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toContain('os_commit=');
+    const [row] = await fx.db
+      .select({ status: commitments.status })
+      .from(commitments)
+      .where(eq(commitments.id, c.id))
+      .limit(1);
+    expect(row?.status).toBe('cancelled');
+  });
+
+  it('throttles a single IP after the per-minute ceiling, before token checks', async () => {
+    const c = await makeCommitment(fx);
+    const ip = '198.51.100.250';
+    const max = RateLimits.commitmentTokenOpsPerIp.max;
+    // Token-less requests: proves the limiter runs before the token check.
+    // 2*max+2 attempts guarantee one fixed window absorbs >max requests even
+    // if the loop happens to straddle a window boundary.
+    let limited: Response | null = null;
+    for (let i = 0; i < 2 * max + 2 && !limited; i += 1) {
+      const { req, ctx } = makeRequest(c.id, { ip });
+      const res = await GET(req, ctx);
+      expect([403, 429]).toContain(res.status);
+      if (res.status === 429) limited = res;
+    }
+    expect(limited).not.toBeNull();
+    expect(limited!.headers.get('Retry-After')).toMatch(/^\d+$/);
+    const payload = await limited!.json();
+    expect(payload.error.code).toBe('rate_limited');
+  });
+});

--- a/src/app/api/commitments/[id]/route.ts
+++ b/src/app/api/commitments/[id]/route.ts
@@ -1,17 +1,16 @@
 import type { NextRequest } from 'next/server';
 import { getDb } from '@/db/client';
+import type { Db } from '@/db/client';
+import { extractClientIp } from '@/auth/request-context';
 import { fail, handle, respond } from '@/lib/api-response';
 import { serviceError } from '@/lib/errors';
+import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
 import {
   COMMIT_COOKIE_NAME,
   removeReturningCommit,
   setReturningCommitCookie,
 } from '@/lib/returning-participant';
-import {
-  cancelOwnCommitment,
-  getOwnCommitment,
-  updateOwnCommitment,
-} from '@/services/commitments';
+import { cancelOwnCommitment, getOwnCommitment, updateOwnCommitment } from '@/services/commitments';
 
 function readToken(req: NextRequest): string | null {
   const url = new URL(req.url);
@@ -21,42 +20,46 @@ function readToken(req: NextRequest): string | null {
   return header ?? null;
 }
 
-export async function GET(
-  req: NextRequest,
-  ctx: { params: Promise<{ id: string }> },
-) {
+/** Anonymous, token-authenticated endpoint: meter per IP before any token
+ *  verification or DB lookup happens. */
+async function limitTokenOps(db: Db, req: NextRequest): Promise<void> {
+  const clientIp = extractClientIp(req.headers);
+  await consumeRateLimit(db, RateLimits.commitmentTokenOpsPerIp, clientIp ?? 'unknown');
+}
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   return handle(async () => {
     const { id } = await ctx.params;
+    const db = getDb();
+    await limitTokenOps(db, req);
     const token = readToken(req);
     if (!token) return fail(serviceError('forbidden', 'edit token required', { field: 'token' }));
-    const result = await getOwnCommitment(getDb(), id, token);
+    const result = await getOwnCommitment(db, id, token);
     return respond(result);
   });
 }
 
-export async function PATCH(
-  req: NextRequest,
-  ctx: { params: Promise<{ id: string }> },
-) {
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   return handle(async () => {
     const { id } = await ctx.params;
+    const db = getDb();
+    await limitTokenOps(db, req);
     const token = readToken(req);
     if (!token) return fail(serviceError('forbidden', 'edit token required', { field: 'token' }));
     const body = await req.json().catch(() => ({}));
-    const result = await updateOwnCommitment(getDb(), id, token, body);
+    const result = await updateOwnCommitment(db, id, token, body);
     return respond(result);
   });
 }
 
-export async function DELETE(
-  req: NextRequest,
-  ctx: { params: Promise<{ id: string }> },
-) {
+export async function DELETE(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   return handle(async () => {
     const { id } = await ctx.params;
+    const db = getDb();
+    await limitTokenOps(db, req);
     const token = readToken(req);
     if (!token) return fail(serviceError('forbidden', 'edit token required', { field: 'token' }));
-    const result = await cancelOwnCommitment(getDb(), id, token);
+    const result = await cancelOwnCommitment(db, id, token);
     const response = respond(result);
     if (result.ok) {
       const next = removeReturningCommit(req.cookies.get(COMMIT_COOKIE_NAME)?.value, id);

--- a/src/app/api/public/health/route.ts
+++ b/src/app/api/public/health/route.ts
@@ -1,17 +1,23 @@
 import { sql } from 'drizzle-orm';
 import { getDb } from '@/db/client';
 import { NextResponse } from 'next/server';
+import { log } from '@/lib/log';
+import { getWorkerStatus } from '@/lib/worker-health';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
+  const db = getDb();
   try {
-    await getDb().execute(sql`select 1`);
-    return NextResponse.json({ ok: true, status: 'healthy' });
+    await db.execute(sql`select 1`);
   } catch (err) {
-    return NextResponse.json(
-      { ok: false, status: 'db_unreachable', error: (err as Error).message },
-      { status: 503 },
-    );
+    // Generic body only: this endpoint is unauthenticated and raw driver
+    // errors can leak hosts/credentials. Details go to the server log.
+    log.error({ err }, 'health: database unreachable');
+    return NextResponse.json({ ok: false, status: 'db_unreachable' }, { status: 503 });
   }
+  // Informational only — a stale worker must not fail the HTTP check, or the
+  // platform would restart the healthy web process to fix the worker.
+  const worker = await getWorkerStatus(db);
+  return NextResponse.json({ ok: true, status: 'healthy', worker });
 }

--- a/src/app/api/telemetry/landing-cta-clicked/route.test.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.test.ts
@@ -11,15 +11,27 @@ vi.mock('@/lib/view-tracker', async (importOriginal) => {
   return { ...actual, recordLandingCtaClicked: vi.fn(async () => {}) };
 });
 
+vi.mock('@/db/client', () => ({
+  getDb: () => ({}) as unknown,
+}));
+
+vi.mock('@/lib/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/rate-limit')>();
+  return { ...actual, consumeRateLimit: vi.fn(async () => {}) };
+});
+
 import { recordLandingCtaClicked } from '@/lib/view-tracker';
+import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
+import { serviceError, ServiceException } from '@/lib/errors';
 import { POST } from './route';
 
 const browserUa =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
-function request(query = ''): Request {
+function request(query = '', headers: Record<string, string> = {}): Request {
   return new Request(`http://localhost/api/telemetry/landing-cta-clicked${query}`, {
     method: 'POST',
+    headers,
   });
 }
 
@@ -76,5 +88,40 @@ describe('POST /api/telemetry/landing-cta-clicked', () => {
       cta: 'start_signup',
       signals: { userAgent: browserUa, referer: null, dnt: true },
     });
+  });
+
+  it('meters per client IP from x-forwarded-for, falling back to a shared bucket', async () => {
+    currentHeaders = new Headers({ 'user-agent': browserUa });
+
+    await POST(request('', { 'x-forwarded-for': '203.0.113.9, 10.0.0.1' }));
+    expect(consumeRateLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      RateLimits.telemetryPerIp,
+      '203.0.113.9',
+    );
+
+    await POST(request());
+    expect(consumeRateLimit).toHaveBeenLastCalledWith(
+      expect.anything(),
+      RateLimits.telemetryPerIp,
+      'unknown',
+    );
+  });
+
+  it('returns 429 with Retry-After and records nothing when rate-limited', async () => {
+    currentHeaders = new Headers({ 'user-agent': browserUa });
+    vi.mocked(consumeRateLimit).mockRejectedValueOnce(
+      new ServiceException(
+        serviceError('rate_limited', 'too many requests', {
+          details: { retryAfterSeconds: 42, bucket: RateLimits.telemetryPerIp.bucket },
+        }),
+      ),
+    );
+
+    const res = await POST(request());
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('42');
+    expect(recordLandingCtaClicked).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/telemetry/landing-cta-clicked/route.ts
+++ b/src/app/api/telemetry/landing-cta-clicked/route.ts
@@ -1,7 +1,10 @@
 import { headers } from 'next/headers';
 import { z } from 'zod';
+import { getDb } from '@/db/client';
+import { extractClientIp } from '@/auth/request-context';
 import { handle } from '@/lib/api-response';
 import { LANDING_CTAS } from '@/lib/landing-cta';
+import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
 import { readRequestSignals, recordLandingCtaClicked } from '@/lib/view-tracker';
 
 export const runtime = 'nodejs';
@@ -11,6 +14,10 @@ const ctaSchema = z.enum(LANDING_CTAS).default('start_signup');
 
 export async function POST(request: Request) {
   return handle(async () => {
+    // Unauthenticated write into the activity log — meter it per IP so a
+    // script can't bloat the append-only table.
+    const clientIp = extractClientIp(new Headers(request.headers));
+    await consumeRateLimit(getDb(), RateLimits.telemetryPerIp, clientIp ?? 'unknown');
     const url = new URL(request.url);
     const cta = ctaSchema.parse(url.searchParams.get('cta') ?? undefined);
     const signals = readRequestSignals(await headers());

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -59,6 +59,12 @@ export const RateLimits = {
   magicLinkPerEmail: { bucket: 'auth.magic.email', max: 5, windowSeconds: 3600 },
   magicLinkPerIp: { bucket: 'auth.magic.ip', max: 20, windowSeconds: 3600 },
   commitmentPerIp: { bucket: 'commit.ip', max: 10, windowSeconds: 60 },
+  // Anonymous token-authenticated reads/edits on /api/commitments/[id]:
+  // generous for legitimate participants, hostile to edit-token brute force
+  // and unmetered DB hits.
+  commitmentTokenOpsPerIp: { bucket: 'commit.token.ip', max: 30, windowSeconds: 60 },
   signupCreatePerOrganizer: { bucket: 'signup.create', max: 60, windowSeconds: 3600 },
   magicComposePerOrganizer: { bucket: 'magic.compose', max: 10, windowSeconds: 3600 },
+  // Unauthenticated writes into the append-only activity log.
+  telemetryPerIp: { bucket: 'telemetry.ip', max: 30, windowSeconds: 3600 },
 } as const;

--- a/src/lib/worker-health.test.ts
+++ b/src/lib/worker-health.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { classifyWorkerStatus, WORKER_STALE_AFTER_MS } from './worker-health';
+
+const now = new Date('2026-06-09T12:00:00Z');
+
+describe('classifyWorkerStatus', () => {
+  it('reports ok when the dispatch cron completed recently', () => {
+    const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000);
+    expect(classifyWorkerStatus(fiveMinAgo, now)).toBe('ok');
+  });
+
+  it('reports ok right up to the staleness boundary', () => {
+    const atBoundary = new Date(now.getTime() - WORKER_STALE_AFTER_MS);
+    expect(classifyWorkerStatus(atBoundary, now)).toBe('ok');
+  });
+
+  it('reports stale when the last completion is older than the boundary', () => {
+    const justOver = new Date(now.getTime() - WORKER_STALE_AFTER_MS - 1);
+    expect(classifyWorkerStatus(justOver, now)).toBe('stale');
+  });
+
+  it('reports stale when the worker has never completed a dispatch', () => {
+    expect(classifyWorkerStatus(null, now)).toBe('stale');
+  });
+});

--- a/src/lib/worker-health.ts
+++ b/src/lib/worker-health.ts
@@ -1,0 +1,41 @@
+import { sql } from 'drizzle-orm';
+import type { Db } from '@/db/client';
+import { log } from './log';
+
+export type WorkerStatus = 'ok' | 'stale' | 'unknown';
+
+/**
+ * The reminder dispatch cron fires every 10 minutes (`src/jobs/worker.ts`);
+ * three missed beats means the worker process is down or wedged.
+ */
+export const WORKER_STALE_AFTER_MS = 30 * 60 * 1000;
+
+export function classifyWorkerStatus(
+  lastCompletedAt: Date | null,
+  now: Date,
+): Exclude<WorkerStatus, 'unknown'> {
+  if (!lastCompletedAt) return 'stale';
+  return now.getTime() - lastCompletedAt.getTime() <= WORKER_STALE_AFTER_MS ? 'ok' : 'stale';
+}
+
+/**
+ * Observes worker liveness from the web process with zero extra infra: the
+ * dispatch cron leaves completed jobs in `pgboss.job`, so a recent completion
+ * proves the worker is alive. Returns 'unknown' when the pgboss schema does
+ * not exist yet (worker never started against this database).
+ */
+export async function getWorkerStatus(db: Db): Promise<WorkerStatus> {
+  try {
+    const rows = await db.execute<{ last: Date | string | null }>(
+      sql`select max(completed_on) as last
+          from pgboss.job
+          where name = 'reminders.dispatch' and state = 'completed'`,
+    );
+    const raw = rows[0]?.last ?? null;
+    const last = raw === null ? null : new Date(raw);
+    return classifyWorkerStatus(last, new Date());
+  } catch (err) {
+    log.warn({ err }, 'health: pgboss schema unavailable, worker status unknown');
+    return 'unknown';
+  }
+}

--- a/src/lib/worker-health.ts
+++ b/src/lib/worker-health.ts
@@ -21,8 +21,9 @@ export function classifyWorkerStatus(
 /**
  * Observes worker liveness from the web process with zero extra infra: the
  * dispatch cron leaves completed jobs in `pgboss.job`, so a recent completion
- * proves the worker is alive. Returns 'unknown' when the pgboss schema does
- * not exist yet (worker never started against this database).
+ * proves the worker is alive. Returns 'unknown' when the query fails for any
+ * reason — most commonly the pgboss schema not existing yet (worker never
+ * started against this database), but also permissions or transient DB errors.
  */
 export async function getWorkerStatus(db: Db): Promise<WorkerStatus> {
   try {
@@ -35,7 +36,7 @@ export async function getWorkerStatus(db: Db): Promise<WorkerStatus> {
     const last = raw === null ? null : new Date(raw);
     return classifyWorkerStatus(last, new Date());
   } catch (err) {
-    log.warn({ err }, 'health: pgboss schema unavailable, worker status unknown');
+    log.warn({ err }, 'health: worker status query failed, reporting unknown');
     return 'unknown';
   }
 }


### PR DESCRIPTION
PR 5 of the engineering-integrity roadmap (independent of #155).

## Why

Audit findings: two unauthenticated endpoints accepted unmetered traffic, the health endpoint leaked raw driver error messages to anonymous callers, no platform health check was wired, and the worker process had no liveness signal at all.

## What

**Rate limiting** (reusing the existing Postgres-backed `consumeRateLimit` pattern):
- `POST /api/telemetry/landing-cta-clicked` — unauthenticated write into the append-only `activity` table; now metered per IP (30/hr, `telemetryPerIp`). Unit tests cover the IP keying, the `unknown` fallback bucket, and the 429 + `Retry-After` path.
- `GET/PATCH/DELETE /api/commitments/[id]` — anonymous token-authenticated ops; now metered per IP (30/min, `commitmentTokenOpsPerIp`), consumed **before** token verification or any DB lookup, so it also throttles edit-token brute force. New `route.db.test.ts` (7 tests) covers token-from-query, token-from-`x-edit-token`-header, missing/wrong token → 403, PATCH persistence, DELETE + returning-cookie rewrite, and the 429 ceiling.

**Health hardening:**
- `/api/public/health` stops returning `err.message` (driver errors can leak hosts/credentials) — generic `{ ok: false, status: 'db_unreachable' }`, details to the server log.
- New `src/lib/worker-health.ts`: the endpoint reports `worker: ok | stale | unknown` by checking `pgboss.job` for a `reminders.dispatch` completion within 30 minutes (cron fires every 10). Zero new infra; informational only — a stale worker never fails the HTTP check, so the platform won't restart a healthy web process to fix the worker. Pure classification logic is unit-tested (TDD).
- `fly.toml`: `[[http_service.checks]]` now points at the endpoint (30s interval).

CLAUDE.md updated: enumerates the rate-limited surfaces and states the rule that every unauthenticated write endpoint must consume a rate limit before doing any work.

## Verification

- `pnpm lint` ✓ · `pnpm typecheck` ✓ · `pnpm test` 522 ✓ · `pnpm test:db` 101 ✓
- Live against a production build:
  - 32 rapid telemetry POSTs from one IP → exactly 30×204 then 429 with `Retry-After`
  - `docker compose stop db` → `{"ok":false,"status":"db_unreachable"}` 503, no error detail
  - worker stopped → `worker:"stale"`; after `pnpm worker` processed a real dispatch → `worker:"ok"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)