### PR TITLE
Prevent calendar injection by escaping carriage returns in ICS

### DIFF
--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -44,6 +44,21 @@ describe('buildIcs', () => {
     expect(ics).toContain('DESCRIPTION:line1\\nline2');
   });
 
+  it('escapes carriage returns so they cannot forge ICS lines', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org',
+      title: 'Pickup\r\nSUMMARY:Injected',
+      description: 'old-mac\rline',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    // CRLF, lone CR, and lone LF all collapse to a single escaped newline,
+    // leaving no raw CR/LF inside a content line.
+    expect(ics).toContain('SUMMARY:Pickup\\nSUMMARY:Injected');
+    expect(ics).toContain('DESCRIPTION:old-mac\\nline');
+    expect(ics.split('\r\n')).not.toContain('SUMMARY:Injected');
+  });
+
   it('uses CRLF line endings', () => {
     const ics = buildIcs({
       uid: 'com_x@opensignup.org',

--- a/src/lib/ics.test.ts
+++ b/src/lib/ics.test.ts
@@ -52,11 +52,28 @@ describe('buildIcs', () => {
       start: new Date('2026-05-02T15:00:00Z'),
       now: new Date('2026-04-30T12:00:00Z'),
     });
-    // CRLF, lone CR, and lone LF all collapse to a single escaped newline,
-    // leaving no raw CR/LF inside a content line.
-    expect(ics).toContain('SUMMARY:Pickup\\nSUMMARY:Injected');
+    // CRLF, lone CR, and lone LF all collapse to a single escaped newline.
+    // Assert the structural invariant: exactly one physical SUMMARY line, equal
+    // to the escaped value — no forged SUMMARY line slips through.
+    const summaryLines = ics.split('\r\n').filter((l) => l.startsWith('SUMMARY:'));
+    expect(summaryLines).toEqual(['SUMMARY:Pickup\\nSUMMARY:Injected']);
     expect(ics).toContain('DESCRIPTION:old-mac\\nline');
-    expect(ics.split('\r\n')).not.toContain('SUMMARY:Injected');
+  });
+
+  it('strips line breaks from structural UID and URL fields', () => {
+    const ics = buildIcs({
+      uid: 'com_x@opensignup.org\r\nUID:forged',
+      url: 'https://opensignup.org/a\r\nATTENDEE:forged',
+      title: 'Pickup',
+      start: new Date('2026-05-02T15:00:00Z'),
+      now: new Date('2026-04-30T12:00:00Z'),
+    });
+    const lines = ics.split('\r\n');
+    expect(lines.filter((l) => l.startsWith('UID:'))).toEqual(['UID:com_x@opensignup.orgUID:forged']);
+    expect(lines.filter((l) => l.startsWith('URL:'))).toEqual([
+      'URL:https://opensignup.org/aATTENDEE:forged',
+    ]);
+    expect(lines).not.toContain('ATTENDEE:forged');
   });
 
   it('uses CRLF line endings', () => {

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -25,7 +25,10 @@ function formatUtc(d: Date): string {
 function escapeText(value: string): string {
   return value
     .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
+    // Collapse every line-break form (CRLF, lone CR, lone LF) into a single
+    // escaped newline. A raw CR left in a content line corrupts the file and
+    // lets attacker-controlled text forge ICS lines (calendar injection).
+    .replace(/\r\n|\r|\n/g, '\\n')
     .replace(/,/g, '\\,')
     .replace(/;/g, '\\;');
 }

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -34,6 +34,15 @@ function escapeText(value: string): string {
 }
 
 /**
+ * UID and URL are not TEXT values, so they aren't comma/semicolon-escaped
+ * (that would corrupt a URL). But a raw CR/LF would still break out of the
+ * content line, so strip line breaks to keep these fields from forging lines.
+ */
+function stripBreaks(value: string): string {
+  return value.replace(/[\r\n]/g, '');
+}
+
+/**
  * RFC 5545 §3.1: content lines longer than 75 octets must be folded by
  * inserting CRLF + a single space at each fold point. We fold by octet
  * length (UTF-8) so multi-byte characters split safely.
@@ -69,7 +78,7 @@ export function buildIcs(input: IcsEventInput): string {
     'CALSCALE:GREGORIAN',
     'METHOD:PUBLISH',
     'BEGIN:VEVENT',
-    `UID:${input.uid}`,
+    `UID:${stripBreaks(input.uid)}`,
     `DTSTAMP:${formatUtc(now)}`,
     `DTSTART:${formatUtc(start)}`,
     `DTEND:${formatUtc(end)}`,
@@ -77,7 +86,7 @@ export function buildIcs(input: IcsEventInput): string {
   ];
   if (input.description) rawLines.push(`DESCRIPTION:${escapeText(input.description)}`);
   if (input.location) rawLines.push(`LOCATION:${escapeText(input.location)}`);
-  if (input.url) rawLines.push(`URL:${input.url}`);
+  if (input.url) rawLines.push(`URL:${stripBreaks(input.url)}`);
   rawLines.push('END:VEVENT', 'END:VCALENDAR');
 
   return rawLines.map(foldLine).join(CRLF) + CRLF;


### PR DESCRIPTION
## Summary

Fixes a security vulnerability in ICS file generation where carriage returns (`\r`) in event properties could be exploited to forge additional ICS lines, allowing calendar injection attacks.

## Changes

- **`src/lib/ics.ts`**: Updated `escapeText()` to collapse all line-break forms (CRLF, lone CR, lone LF) into a single escaped newline (`\\n`). Previously only handled lone LF, leaving raw CR characters that could corrupt the ICS file structure.
  
- **`src/lib/ics.test.ts`**: Added test case verifying that carriage returns in title and description fields are properly escaped and cannot be used to inject forged ICS lines.

## Implementation Details

The fix uses a single regex replacement `/\r\n|\r|\n/g` to normalize all line-break variants before escaping. This ensures:
- CRLF sequences don't leave a stray CR
- Lone CR characters (old Mac line endings) are escaped
- Lone LF characters continue to work as before
- No raw CR/LF bytes remain in content lines that could allow an attacker to forge additional ICS properties

The test confirms that injected content like `SUMMARY:Injected` cannot appear as a separate ICS line when embedded in a title with carriage returns.

https://claude.ai/code/session_01UQ4iMq3dTNpZ39c8KK7ZsX