### PR TITLE
Remove unused MagicComposeRefusal type export

### DIFF
--- a/src/lib/magic-compose/prompt.ts
+++ b/src/lib/magic-compose/prompt.ts
@@ -58,7 +58,6 @@ export const RefusalSchema = z.object({
 export const MagicComposeDraftSchema = z.union([RefusalSchema, FullDraftSchema]);
 
 export type MagicComposeDraft = z.infer<typeof FullDraftSchema>;
-export type MagicComposeRefusal = z.infer<typeof RefusalSchema>;
 export type MagicComposeParsed = z.infer<typeof MagicComposeDraftSchema>;
 
 const SYSTEM_PROMPT = `You are OpenSignup's signup drafter. OpenSignup is a coordination tool where organizers create signups containing slots, and participants commit to slots without ever creating an account.


### PR DESCRIPTION
## Summary
Removes an unused type export from the Magic Compose prompt module that was inferred from the `RefusalSchema` but never referenced elsewhere in the codebase.

## Changes
- Removed `export type MagicComposeRefusal = z.infer<typeof RefusalSchema>;` from `src/lib/magic-compose/prompt.ts`

## Details
The `MagicComposeRefusal` type was defined but not imported or used anywhere in the codebase. The `RefusalSchema` itself remains in place and is still used as part of the `MagicComposeDraftSchema` union, so the validation logic is unaffected. This is a straightforward cleanup to reduce unused exports.

https://claude.ai/code/session_01M1uLmoBcyBiTeq9qGAmdBV