### PR TITLE
Potential fix for code scanning alert no. 2: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,13 +1,11 @@
-import { randomBytes } from 'node:crypto';
+import { randomInt } from 'node:crypto';
 
 const CROCKFORD = '0123456789abcdefghjkmnpqrstvwxyz';
 
 export function randomSuffix(length = 5): string {
-  const bytes = randomBytes(length);
   let out = '';
   for (let i = 0; i < length; i++) {
-    const byte = bytes[i] ?? 0;
-    out += CROCKFORD[byte % CROCKFORD.length];
+    out += CROCKFORD[randomInt(CROCKFORD.length)];
   }
   return out;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/richshaw/OpenSignup/security/code-scanning/2](https://github.com/richshaw/OpenSignup/security/code-scanning/2)

Best fix: use Node’s built-in `crypto.randomInt(max)` to generate unbiased indices directly in `[0, CROCKFORD.length)`, avoiding manual modulo arithmetic entirely.

In `src/lib/slug.ts`, update `randomSuffix`:

- Change import from only `randomBytes` to `randomInt`.
- Replace byte-buffer generation and `%` indexing loop with repeated `randomInt(CROCKFORD.length)` index generation.
- Keep function signature and behavior the same (same output alphabet and requested length).

This avoids bias now and in future if `CROCKFORD` size changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
