### PR TITLE
Bump shell-quote to ^1.8.4 to fix critical Dependabot alert (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
   },
   "pnpm": {
     "overrides": {
-      "next": "15.5.18"
+      "next": "15.5.18",
+      "shell-quote": "^1.8.4"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "pnpm": {
     "overrides": {
       "next": "15.5.18",
-      "shell-quote": "^1.8.4"
+      "shell-quote": "1.8.4"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   next: 15.5.18
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -3997,8 +3998,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -6994,7 +6995,7 @@ snapshots:
       debug: 4.4.3
       env-paths: 3.0.0
       semver: 7.8.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8122,7 +8123,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   next: 15.5.18
-  shell-quote: ^1.8.4
+  shell-quote: 1.8.4
 
 importers:
 


### PR DESCRIPTION
## What

Adds a `pnpm.overrides` entry pinning `shell-quote` to `^1.8.4`, resolving the critical Dependabot alert (#72).

```jsonc
"pnpm": {
  "overrides": {
    "next": "15.5.18",
    "shell-quote": "^1.8.4"   // GHSA-w7jw-789q-3m8p
  }
}
```

## Why

- **Advisory:** [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — `shell-quote`'s `quote()` does not escape newlines in object `.op` values (command-injection class). **Severity: critical.**
- **Vulnerable:** `>=1.1.0 <=1.8.3` · **Patched:** `>=1.8.4` · was resolving to `1.8.3`.
- **Path:** `. > drizzle-kit > gel > shell-quote` (single copy in the lockfile).

**Reachability:** `shell-quote` is only pulled in transitively through `drizzle-kit` (a dev/CLI migration tool, `devDependency`) via its `gel` driver. It is **not** in the Next.js server runtime, the production build output, or any participant/organizer request path — so real-world exposure in the deployed app is low. The fix is still worth doing to clear the critical alert, and the `1.8.3 → 1.8.4` patch has a stable API.

## Verification

- `pnpm install` → lockfile now resolves `shell-quote@1.8.4`, no `1.8.3` remaining.
- `pnpm audit` → critical `shell-quote` / GHSA-w7jw-789q-3m8p finding cleared (0 critical).
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (523 tests) all pass.
- `pnpm build` passes (with `NEXT_PUBLIC_*` supplied); `drizzle-kit --version` (the only `shell-quote` consumer) runs.

## Scope

This addresses only alert #72 (the critical one). The repo still has 8 lower-severity advisories, all likewise in transitive dev/build tooling (`esbuild`, `glob`, `postcss`, `prismjs`, `ws`, `brace-expansion`) — happy to follow up with those in a separate PR if wanted.

https://claude.ai/code/session_01EqcFLZ37DpA8e9jdfpsjxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqcFLZ37DpA8e9jdfpsjxV)_