### PR TITLE
chore: make fly.toml a self-host template, deploy real config privately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ evals/**/snapshots/
 
 # Internal planning docs — kept local, not published
 docs/plans/
+
+# Your instance's real Fly config — copy fly.example.toml to fly.toml.
+# Keeps instance branding/app name out of the public repo.
+fly.toml

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The footer, privacy policy, terms, and cookies pages are instance-agnostic — t
 
 - **Docker Compose** (`docker-compose.prod.yml`) — set them in the same `.env` file at the project root that Compose already reads for variable substitution. Compose passes them through as `build.args` and fails fast if any required value is missing.
 - **`docker build`** — pass each as `--build-arg NEXT_PUBLIC_INSTANCE_NAME=…`.
-- **Fly.io** — set under `[build.args]` in `fly.toml` (the included file is the upstream's deployment; replace with your own values). `fly secrets` are runtime-only and won't work here.
+- **Fly.io** — copy the template (`cp fly.example.toml fly.toml`) and set your values under `[build.args]` in `fly.toml`. `fly.toml` is gitignored, so your instance's config stays out of git. `fly secrets` are runtime-only and won't work here.
 - **Local dev** (`pnpm dev`) — set them in `.env.local`; Next.js reads it on each build/restart.
 
 ## Status

--- a/fly.example.toml
+++ b/fly.example.toml
@@ -1,5 +1,10 @@
-# Fly.io configuration for OpenSignup.
-# First time: `fly launch --no-deploy --copy-config` (or `fly apps create signups`),
+# Fly.io configuration template for OpenSignup.
+#
+# Copy this to `fly.toml` and fill in your own values before deploying:
+#   cp fly.example.toml fly.toml
+# `fly.toml` is gitignored so your instance's config never lands in git.
+#
+# First time: `fly launch --no-deploy --copy-config` (or `fly apps create your-app-name`),
 # then `fly postgres create` + `fly postgres attach`, then set secrets (see below),
 # then `fly deploy`.
 #
@@ -13,21 +18,21 @@
 #   EMAIL_FROM    — e.g. "OpenSignup <hello@signup.example.com>"
 #   EMAIL_TRANSPORT + RESEND_API_KEY (or SMTP_* vars) — see .env.example
 
-app = "signups"
+app = "your-app-name"
 primary_region = "iad"
 
 # Build args for NEXT_PUBLIC_* values. These must be available during
 # `pnpm build` (Next.js inlines them into the prerendered legal pages),
 # so fly secrets — which are runtime-only — are not sufficient. Values
 # here are public (they ship in the client bundle) and represent this
-# instance's branding. Self-hosters override in their own fly.toml.
+# instance's branding. Replace them all with your own.
 [build]
   [build.args]
-    NEXT_PUBLIC_INSTANCE_NAME = "OpenSignup"
-    NEXT_PUBLIC_SUPPORT_EMAIL = "hello@opensignup.org"
-    NEXT_PUBLIC_SOURCE_URL = "https://github.com/richshaw/OpenSignup"
-    NEXT_PUBLIC_GOVERNING_LAW = "the State of Washington, United States"
-    NEXT_PUBLIC_APP_URL = "https://opensignup.org"
+    NEXT_PUBLIC_INSTANCE_NAME = "Your Instance"
+    NEXT_PUBLIC_SUPPORT_EMAIL = "hello@example.com"
+    NEXT_PUBLIC_SOURCE_URL = "https://github.com/you/your-fork"
+    NEXT_PUBLIC_GOVERNING_LAW = "your jurisdiction"
+    NEXT_PUBLIC_APP_URL = "https://your-domain.example"
 
 [deploy]
   release_command = "pnpm db:migrate"
@@ -40,7 +45,8 @@ primary_region = "iad"
   NODE_ENV = "production"
   PORT = "3000"
   NEXT_TELEMETRY_DISABLED = "1"
-  NEXT_PUBLIC_DEMO_VIDEO_URL = "https://opensignup-public.t3.tigrisfiles.io/demo.mp4"
+  # Optional: URL of the demo video shown on the landing page.
+  # NEXT_PUBLIC_DEMO_VIDEO_URL = "https://cdn.example.com/demo.mp4"
 
 [http_service]
   internal_port = 3000


### PR DESCRIPTION
## What

Stop shipping this instance's real Fly config in the public repo. This is Phase 1 (foundation) of separating the opensignup.org deployment from the public OSS repo.

- **`fly.toml` → `fly.example.toml`** — a self-host template with placeholder values (app name, branding build args, app URL). Structural config (processes, vm, http_service, health check, release command) is unchanged.
- **`.gitignore`** — ignore `fly.toml` so a real instance config never lands in git.
- **`README.md`** — Fly self-host step now copies the template (`cp fly.example.toml fly.toml`).

## Why

The public repo is the OSS collaboration hub; the real production config (and, later, private SEO content / analytics / workstreams) lives in a separate private deploy repo that tracks this repo as `upstream` and is the only thing that deploys to Fly. Self-hosters get a clean template instead of the upstream's live values.

Note: the previous values were non-secret branding already in git history; this change prevents *future* config from leaking and gives the private overlay a clean seam.

## Verification

- `pnpm typecheck` ✅
- `pnpm test` — 525 passed ✅
- No `.ts/.tsx/.js` files touched; nothing in CI/Dockerfile/compose references `fly.toml`.
- Self-host path: `cp fly.example.toml fly.toml`, fill values, `fly deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)