### PR TITLE
Replace custom anySignal with native AbortSignal.any()

### DIFF
--- a/src/lib/magic-compose/llm-client.ts
+++ b/src/lib/magic-compose/llm-client.ts
@@ -44,7 +44,12 @@ export function defaultLlmClient(): LlmClient {
       const timeoutController = new AbortController();
       const timeout = setTimeout(() => timeoutController.abort(), env.LLM_TIMEOUT_MS);
 
-      const combinedSignal = anySignal([signal, timeoutController.signal]);
+      // Native since Node 20.3 — settles listener lifecycle for us (the old
+      // hand-rolled combiner leaked an abort listener on a caller-supplied
+      // signal on the success path).
+      const combinedSignal = signal
+        ? AbortSignal.any([signal, timeoutController.signal])
+        : timeoutController.signal;
 
       try {
         const res = await fetch(url, {
@@ -275,17 +280,4 @@ function extractChoiceContent(body: unknown): string | null {
   if (!message || typeof message !== 'object') return null;
   const content = (message as { content?: unknown }).content;
   return typeof content === 'string' ? content : null;
-}
-
-function anySignal(signals: Array<AbortSignal | undefined>): AbortSignal {
-  const controller = new AbortController();
-  for (const s of signals) {
-    if (!s) continue;
-    if (s.aborted) {
-      controller.abort();
-      return controller.signal;
-    }
-    s.addEventListener('abort', () => controller.abort(), { once: true });
-  }
-  return controller.signal;
 }

--- a/src/lib/magic-compose/llm-client.ts
+++ b/src/lib/magic-compose/llm-client.ts
@@ -44,9 +44,7 @@ export function defaultLlmClient(): LlmClient {
       const timeoutController = new AbortController();
       const timeout = setTimeout(() => timeoutController.abort(), env.LLM_TIMEOUT_MS);
 
-      // Native since Node 20.3 — settles listener lifecycle for us (the old
-      // hand-rolled combiner leaked an abort listener on a caller-supplied
-      // signal on the success path).
+      // Native since Node 20.3 (floor is 20.19 via package.json engines).
       const combinedSignal = signal
         ? AbortSignal.any([signal, timeoutController.signal])
         : timeoutController.signal;


### PR DESCRIPTION
## Summary

Replaces the custom `anySignal()` helper function with the native `AbortSignal.any()` API available since Node 20.3, eliminating a memory leak in the LLM client's timeout handling.

## Key Changes

- **Removed custom `anySignal()` function** — The hand-rolled implementation leaked abort listeners on caller-supplied signals in the success path
- **Adopted native `AbortSignal.any()`** — Available since Node 20.3, properly manages listener lifecycle
- **Updated timeout logic in `defaultLlmClient()`** — Now uses `AbortSignal.any([signal, timeoutController.signal])` when a signal is provided, falling back to `timeoutController.signal` alone when none is supplied

## Implementation Details

The custom implementation registered abort listeners that were never cleaned up on the success path. The native `AbortSignal.any()` handles this correctly, settling the listener lifecycle automatically. This is particularly important for the LLM client's timeout handling, which combines a caller-supplied abort signal with an internal timeout controller.

https://claude.ai/code/session_01LwXSamkQUyxX2wnz4B47cz