### PR TITLE
Remove unused fieldTypeMeta helper function

### DIFF
--- a/src/components/build-grid/fieldTypes.ts
+++ b/src/components/build-grid/fieldTypes.ts
@@ -29,8 +29,3 @@ export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
     label: 'List',
   },
 };
-
-/** Returns metadata for a field type; falls back to `text` for unknown types. */
-export function fieldTypeMeta(type: FieldType): FieldTypeMeta {
-  return FIELD_TYPE_META[type] ?? FIELD_TYPE_META.text;
-}


### PR DESCRIPTION
## Summary
Removes the `fieldTypeMeta` helper function from `src/components/build-grid/fieldTypes.ts` as it is no longer used in the codebase.

## Changes
- Deleted the `fieldTypeMeta` function that provided a fallback to the `text` field type for unknown types
- The `FIELD_TYPE_META` constant remains as the source of truth for field type metadata

## Notes
This appears to be cleanup of dead code. Callers should reference `FIELD_TYPE_META` directly or implement their own fallback logic if needed.

https://claude.ai/code/session_012HBE7uq7QDTNonUMRQVQk7