### PR TITLE
fix: prevent email security scanners from consuming magic link tokens

### DIFF
--- a/src/app/login/confirm/page.tsx
+++ b/src/app/login/confirm/page.tsx
@@ -1,0 +1,55 @@
+import { redirect } from 'next/navigation';
+import { getEnv } from '@/lib/env';
+
+export const metadata = { title: 'Sign in', robots: { index: false } };
+export const dynamic = 'force-dynamic';
+
+function isValidCallbackNext(next: string, authUrl: string): boolean {
+  try {
+    const u = new URL(next);
+    const base = new URL(authUrl);
+    return u.origin === base.origin && u.pathname === '/api/auth/callback/nodemailer';
+  } catch {
+    return false;
+  }
+}
+
+export default async function ConfirmLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const { next } = await searchParams;
+
+  if (!next || !isValidCallbackNext(next, getEnv().AUTH_URL)) {
+    redirect('/login?error=Configuration');
+  }
+
+  const email = new URL(next).searchParams.get('email') ?? '';
+
+  return (
+    <main className="container-tight flex min-h-[100svh] flex-col justify-center gap-6 py-16">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold tracking-tight">Sign in to OpenSignup</h1>
+        <p className="text-ink-muted">
+          {email ? (
+            <>
+              Click the button below to sign in as <strong>{email}</strong>.
+            </>
+          ) : (
+            'Click the button below to sign in.'
+          )}
+        </p>
+      </div>
+      <a
+        href={next}
+        className="w-full rounded-lg bg-[#1f6feb] px-5 py-3 text-center font-medium text-white no-underline transition-colors hover:bg-[#1658c4]"
+      >
+        Sign in →
+      </a>
+      <a href="/login" className="text-center text-sm text-ink-muted hover:underline">
+        Use a different email
+      </a>
+    </main>
+  );
+}

--- a/src/app/login/confirm/page.tsx
+++ b/src/app/login/confirm/page.tsx
@@ -43,6 +43,7 @@ export default async function ConfirmLoginPage({
       </div>
       <a
         href={next}
+        referrerPolicy="no-referrer"
         className="w-full rounded-lg bg-[#1f6feb] px-5 py-3 text-center font-medium text-white no-underline transition-colors hover:bg-[#1658c4]"
       >
         Sign in →

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -12,7 +12,7 @@ import { RateLimits, consumeRateLimit } from '@/lib/rate-limit';
 import { ServiceException } from '@/lib/errors';
 import { SignupAdapter } from './adapter';
 import { buildOAuthProviders } from './oauth-providers';
-import { canonicalizeMagicLinkUrl } from './magic-link-url';
+import { canonicalizeMagicLinkUrl, buildConfirmationUrl } from './magic-link-url';
 import { extractEmailDomain } from './email-domain';
 import { getMagicLinkMaxAgeSeconds } from './magic-link-expiry';
 import { getCurrentRequestIp } from './request-context';
@@ -59,8 +59,9 @@ function buildConfig(): NextAuthConfig {
             Math.round((expires.getTime() - Date.now()) / 60_000),
           );
           const safeUrl = canonicalizeMagicLinkUrl(url, getEnv().AUTH_URL);
+          const confirmUrl = buildConfirmationUrl(safeUrl, getEnv().AUTH_URL);
           const node = createElement(MagicLinkEmail, {
-            url: safeUrl,
+            url: confirmUrl,
             email: identifier,
             expiresInMinutes,
           });

--- a/src/auth/magic-link-url.test.ts
+++ b/src/auth/magic-link-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canonicalizeMagicLinkUrl } from './magic-link-url';
+import { canonicalizeMagicLinkUrl, buildConfirmationUrl } from './magic-link-url';
 
 describe('canonicalizeMagicLinkUrl', () => {
   it('rewrites a fly.dev origin to the AUTH_URL origin', () => {
@@ -29,5 +29,34 @@ describe('canonicalizeMagicLinkUrl', () => {
     const raw = 'http://signups.fly.dev/api/auth/callback/nodemailer?token=t';
     const result = canonicalizeMagicLinkUrl(raw, 'https://opensignup.org');
     expect(result.startsWith('https://opensignup.org/')).toBe(true);
+  });
+});
+
+describe('buildConfirmationUrl', () => {
+  it('wraps the callback URL in a /login/confirm page', () => {
+    const callback =
+      'https://opensignup.org/api/auth/callback/nodemailer?token=abc&email=user%40example.com';
+    const result = buildConfirmationUrl(callback, 'https://opensignup.org');
+    const url = new URL(result);
+    expect(url.pathname).toBe('/login/confirm');
+    expect(url.searchParams.get('next')).toBe(callback);
+  });
+
+  it('uses the authUrl origin for the confirmation page', () => {
+    const callback =
+      'https://opensignup.org/api/auth/callback/nodemailer?token=t&email=a%40b.com';
+    const result = buildConfirmationUrl(callback, 'https://opensignup.org');
+    expect(result.startsWith('https://opensignup.org/login/confirm')).toBe(true);
+  });
+
+  it('preserves token and email in the nested next param', () => {
+    const callback =
+      'https://opensignup.org/api/auth/callback/nodemailer?token=xyz&email=foo%40bar.com&callbackUrl=%2Fapp';
+    const result = buildConfirmationUrl(callback, 'https://opensignup.org');
+    const next = new URL(result).searchParams.get('next')!;
+    const inner = new URL(next);
+    expect(inner.searchParams.get('token')).toBe('xyz');
+    expect(inner.searchParams.get('email')).toBe('foo@bar.com');
+    expect(inner.searchParams.get('callbackUrl')).toBe('/app');
   });
 });

--- a/src/auth/magic-link-url.ts
+++ b/src/auth/magic-link-url.ts
@@ -9,3 +9,14 @@ export function canonicalizeMagicLinkUrl(rawUrl: string, authUrl: string): strin
   link.host = canonical.host;
   return link.toString();
 }
+
+// Wrap the Auth.js callback URL in a /login/confirm page so that corporate
+// email security scanners (Mimecast, Proofpoint, etc.) that pre-click links
+// don't consume the token. The actual callback URL is passed as `next` and
+// only visited when the user clicks the "Sign in" button on that page.
+export function buildConfirmationUrl(callbackUrl: string, authUrl: string): string {
+  const base = new URL(authUrl);
+  const confirm = new URL('/login/confirm', base);
+  confirm.searchParams.set('next', callbackUrl);
+  return confirm.toString();
+}


### PR DESCRIPTION
## Problem

Corporate email security gateways (Mimecast, Proofpoint, Barracuda) pre-fetch URLs in emails at delivery time to scan for malware. Because Auth.js v5 immediately deletes the single-use token on the first GET to `/api/auth/callback/nodemailer`, the scanner consumes the token before the user ever sees the email.

Reported by Gabe Coale (Strategos International) — first real user — who couldn't log in at all. Their email footer confirms Mimecast is active on their domain.

## Fix

Add `/login/confirm` as an intermediate page. The magic link in the email now points to:

```
https://opensignup.org/login/confirm?next=<encoded-callback-url>
```

Mimecast pre-fetches this URL and sees a static HTML page with a "Sign in →" button. It does not interact further. The actual Auth.js callback URL is only visited when the user clicks the button, at which point the token is consumed and the session is created.

The `next` param is validated against `AUTH_URL` origin **and** exact pathname (`/api/auth/callback/nodemailer`) before being rendered as an `href`, preventing open-redirect abuse.

## Changes

- `src/auth/magic-link-url.ts` — adds `buildConfirmationUrl`
- `src/auth/config.ts` — wraps the magic link in confirmation URL before sending email
- `src/app/login/confirm/page.tsx` — new confirmation page
- `src/auth/magic-link-url.test.ts` — 3 new tests for `buildConfirmationUrl`

## Test plan

- [x] Request a magic link, verify the email button href points to `/login/confirm?next=...` not directly to the callback
- [ ] Visit the confirmation URL directly (simulating scanner) — token should remain unconsumed in `verification_tokens`
- [x] Click "Sign in →" — session should be created and user redirected to `/app`
- [x] Visit `/login/confirm?next=https://evil.com/api/auth/callback/nodemailer` — should redirect to `/login?error=Configuration`
- [x] `pnpm test src/auth/magic-link-url.test.ts` — 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)