### PR TITLE
fix: bump nodemailer to 9.0.3 to patch high-severity SSRF/file-read advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lucide-react": "^0.468.0",
     "next": "15.5.18",
     "next-auth": "5.0.0-beta.31",
-    "nodemailer": "^8.0.9",
+    "nodemailer": "^9.0.3",
     "pg-boss": "^10.1.5",
     "pino": "^9.5.0",
     "postgres": "^3.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     dependencies:
       '@auth/drizzle-adapter':
         specifier: ^1.7.4
-        version: 1.11.2(nodemailer@8.0.9)
+        version: 1.11.2(nodemailer@9.0.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.4
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -50,10 +50,10 @@ importers:
         version: 15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-auth:
         specifier: 5.0.0-beta.31
-        version: 5.0.0-beta.31(next@15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@8.0.9)(react@19.0.0)
+        version: 5.0.0-beta.31(next@15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@9.0.3)(react@19.0.0)
       nodemailer:
-        specifier: ^8.0.9
-        version: 8.0.9
+        specifier: ^9.0.3
+        version: 9.0.3
       pg-boss:
         specifier: ^10.1.5
         version: 10.4.2
@@ -3411,8 +3411,8 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
-  nodemailer@8.0.9:
-    resolution: {integrity: sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==}
+  nodemailer@9.0.3:
+    resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -4517,7 +4517,7 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@auth/core@0.41.2(nodemailer@8.0.9)':
+  '@auth/core@0.41.2(nodemailer@9.0.3)':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.3
@@ -4525,11 +4525,11 @@ snapshots:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
     optionalDependencies:
-      nodemailer: 8.0.9
+      nodemailer: 9.0.3
 
-  '@auth/drizzle-adapter@1.11.2(nodemailer@8.0.9)':
+  '@auth/drizzle-adapter@1.11.2(nodemailer@9.0.3)':
     dependencies:
-      '@auth/core': 0.41.2(nodemailer@8.0.9)
+      '@auth/core': 0.41.2(nodemailer@9.0.3)
     transitivePeerDependencies:
       - '@simplewebauthn/browser'
       - '@simplewebauthn/server'
@@ -7461,13 +7461,13 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next-auth@5.0.0-beta.31(next@15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@8.0.9)(react@19.0.0):
+  next-auth@5.0.0-beta.31(next@15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@9.0.3)(react@19.0.0):
     dependencies:
-      '@auth/core': 0.41.2(nodemailer@8.0.9)
+      '@auth/core': 0.41.2(nodemailer@9.0.3)
       next: 15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
-      nodemailer: 8.0.9
+      nodemailer: 9.0.3
 
   next@15.5.18(@babel/core@7.24.5)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -7502,7 +7502,7 @@ snapshots:
 
   node-releases@2.0.38: {}
 
-  nodemailer@8.0.9: {}
+  nodemailer@9.0.3: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
nodemailer <=9.0.0 has a high-severity advisory (GHSA-p6gq-j5cr-w38f):
message-level raw option bypasses disableFileAccess/disableUrlAccess,
enabling arbitrary file read and SSRF. Our SmtpTransport doesn't use
the raw option, but there's no reason to stay on the vulnerable line.

Verified the only 8->9 breaking change (stricter TLS validation for
remote-content fetching: attachment URLs, OAuth2, proxies) doesn't
affect this codebase's usage. next-auth's Nodemailer provider peer
dependency (^7.0.7) shows a pnpm warning but is inert here —
sendVerificationRequest is fully overridden to use our own
EmailTransport and never constructs next-auth's own transport.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q8fW6wB3ktEbGjkbkA65ib