### PR TITLE
fix(seo): correct crawler-facing metadata defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,10 @@ All notable changes to OpenSignup are documented here. Format follows [Keep a Ch
 - 48-hour reminder emails via pg-boss.
 - Pluggable email transport: console, SMTP, Resend.
 - AGPL-3.0 license.
+
+### Fixed
+- Landing-page JSON-LD no longer declares a `SoftwareApplication`, which Google's rich result requires to carry `aggregateRating` or `review`; it now describes the site and its publisher with `WebSite` + `Organization`.
+- The landing page rendered two `<h1>` elements — the hero headline plus the example signup card. `SignupViewBody` now emits an `h2` in `showcase` mode.
+- Meta descriptions on the landing page, root layout, and the three legal pages are within the 110–160 character range crawlers expect.
+- The privacy, terms, and cookies pages now declare a self-referencing canonical URL.
+- `/login` and `/login/check` now render the site footer, so both link to the privacy policy and terms.

--- a/src/app/(legal)/cookies/page.tsx
+++ b/src/app/(legal)/cookies/page.tsx
@@ -4,7 +4,8 @@ import { INSTANCE_NAME } from '@/lib/site-config';
 
 export const metadata: Metadata = {
   title: 'Cookies',
-  description: `Cookies set by ${INSTANCE_NAME}.`,
+  description: `Every cookie ${INSTANCE_NAME} sets, what each one is for, and how long it lasts — plus why there are no advertising or cross-site tracking cookies here.`,
+  alternates: { canonical: '/cookies' },
 };
 
 export default function CookiesPage() {

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -11,7 +11,8 @@ import {
 
 export const metadata: Metadata = {
   title: 'Privacy policy',
-  description: `How ${INSTANCE_NAME} collects and uses your data.`,
+  description: `How ${INSTANCE_NAME} collects, uses, and stores your data — what we keep for organizers and participants, the cookies we set, and how long we retain it.`,
+  alternates: { canonical: '/privacy' },
 };
 
 export default function PrivacyPage() {

--- a/src/app/(legal)/terms/page.tsx
+++ b/src/app/(legal)/terms/page.tsx
@@ -11,7 +11,8 @@ import {
 
 export const metadata: Metadata = {
   title: 'Terms of service',
-  description: `Terms for using ${INSTANCE_NAME}.`,
+  description: `The terms for using ${INSTANCE_NAME}: acceptable use, what organizers and participants are responsible for, availability, liability, and the AGPL-3.0 licence.`,
+  alternates: { canonical: '/terms' },
 };
 
 export default function TermsPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,10 @@ import { APP_ORIGIN, INSTANCE_NAME } from '@/lib/site-config';
 import { inter } from './fonts';
 import './globals.css';
 
+// Kept under 160 characters so search engines don't truncate it, and over 110
+// so crawlers (Ahrefs, Screaming Frog) don't flag it as too thin.
 const DESCRIPTION =
-  'Ad-free, open-source sign-up coordination. Organize potlucks, volunteer shifts, snack rotations, and carpools — share a link and let people commit to slots, no accounts required.';
+  'Ad-free, open-source sign-up coordination for potlucks, volunteer shifts, snack rotations, and carpools. Share a link — participants need no account.';
 
 export const metadata: Metadata = {
   metadataBase: new URL(APP_ORIGIN),

--- a/src/app/login/check/page.tsx
+++ b/src/app/login/check/page.tsx
@@ -1,4 +1,5 @@
 import { getMagicLinkMaxAgeMinutes } from '@/auth/magic-link-expiry';
+import { SiteFooter } from '@/components/site-footer';
 import { formatDuration } from '@/lib/format-duration';
 
 export const metadata = { title: 'Check your email', robots: { index: false } };
@@ -9,14 +10,17 @@ export const dynamic = 'force-dynamic';
 
 export default function CheckEmailPage() {
   return (
-    <main className="container-tight flex min-h-[100svh] flex-col justify-center gap-6 py-16">
-      <div className="space-y-3">
-        <h1 className="text-3xl font-semibold tracking-tight">Check your email</h1>
-        <p className="text-ink-muted">
-          We sent a sign-in link to your inbox. Click it to continue. The link expires in{' '}
-          {formatDuration(getMagicLinkMaxAgeMinutes())}.
-        </p>
-      </div>
-    </main>
+    <div className="flex min-h-[100svh] flex-col">
+      <main className="container-tight flex flex-1 flex-col justify-center gap-6 py-16">
+        <div className="space-y-3">
+          <h1 className="text-3xl font-semibold tracking-tight">Check your email</h1>
+          <p className="text-ink-muted">
+            We sent a sign-in link to your inbox. Click it to continue. The link expires in{' '}
+            {formatDuration(getMagicLinkMaxAgeMinutes())}.
+          </p>
+        </div>
+      </main>
+      <SiteFooter />
+    </div>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { signIn } from '@/auth/config';
 import { getOrganizerSession } from '@/auth/session';
 import { getEnabledOAuthProviders } from '@/auth/oauth-providers';
+import { SiteFooter } from '@/components/site-footer';
 import { log } from '@/lib/log';
 import { EmailSchema } from '@/schemas/common';
 import { LoginForm, type LoginActionResult } from './login-form';
@@ -43,7 +44,8 @@ export default async function LoginPage({
   }
 
   return (
-    <main className="container-tight flex min-h-[100svh] flex-col justify-center gap-8 py-16">
+    <div className="flex min-h-[100svh] flex-col">
+      <main className="container-tight flex flex-1 flex-col justify-center gap-8 py-16">
       <div className="space-y-3">
         <h1 className="text-3xl font-semibold tracking-tight">Sign in to OpenSignup</h1>
         <p className="text-ink-muted">
@@ -59,6 +61,10 @@ export default async function LoginPage({
       ) : null}
       <OAuthButtons providers={oauthProviders} callbackUrl={callbackUrl} />
       <LoginForm action={handle} />
-    </main>
+      </main>
+      {/* Also gives this page outgoing links — a page that collects an email
+          address should link to the privacy policy and terms. */}
+      <SiteFooter />
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,8 +11,9 @@ import { HomeExampleCard } from './_components/HomeExampleCard';
 import { StartSignupCta } from './_components/StartSignupCta';
 
 const PAGE_TITLE = `${INSTANCE_NAME} — free, ad-free sign-up sheets`;
+// Under 160 characters — see the note on DESCRIPTION in src/app/layout.tsx.
 const PAGE_DESCRIPTION =
-  'Coordinate snack rotations, potlucks, volunteer shifts, and carpools. Ad-free, open-source, and no accounts for participants — share a link and people commit to slots.';
+  'Coordinate snack rotations, potlucks, volunteer shifts, and carpools. Ad-free, open-source, and no accounts for participants — just share a link.';
 
 export const metadata: Metadata = {
   // Absolute title so the homepage isn't suffixed with the instance name twice.

--- a/src/app/s/[slug]/signup-view.test.tsx
+++ b/src/app/s/[slug]/signup-view.test.tsx
@@ -84,4 +84,41 @@ describe('<SignupViewBody mode="showcase" />', () => {
     expect(button).toBeDisabled();
     expect(button).toHaveClass('opacity-60');
   });
+
+  it('demotes the title to h2 so an embedding page keeps a single h1', () => {
+    // Showcase mode is embedded in a page that already has its own h1 (the
+    // landing hero). Two h1s on one page is an SEO defect.
+    render(
+      <SignupViewBody
+        signup={SIGNUP}
+        fields={FIELDS}
+        groupByRef={null}
+        slots={SLOTS}
+        slug="example"
+        mode="showcase"
+      />,
+    );
+    expect(screen.getByRole('heading', { level: 2, name: 'Snack duty' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+  });
+});
+
+describe('<SignupViewBody /> heading level', () => {
+  // Only 'preview' is exercised here: 'live' mounts CommitDialog, which calls
+  // useRouter() and needs an App Router context jsdom doesn't provide. Both
+  // take the same non-showcase branch, so preview is a faithful stand-in.
+  it('keeps the title as the h1 outside showcase mode, where it is the page heading', () => {
+    render(
+      <SignupViewBody
+        signup={SIGNUP}
+        fields={FIELDS}
+        groupByRef={null}
+        slots={SLOTS}
+        slug="example"
+        mode="preview"
+        showStateBanner={false}
+      />,
+    );
+    expect(screen.getByRole('heading', { level: 1, name: 'Snack duty' })).toBeInTheDocument();
+  });
 });

--- a/src/app/s/[slug]/signup-view.tsx
+++ b/src/app/s/[slug]/signup-view.tsx
@@ -146,6 +146,7 @@ export function SignupViewBody({
   const ownCount = ownCommitments?.length ?? 0;
   const firstOwnSlot = firstOwn ? slots.find((s) => s.id === firstOwn.slotId) ?? null : null;
   const firstOwnTitle = firstOwnSlot ? titleFor(firstOwnSlot, primary) : '';
+  const Title = mode === 'showcase' ? 'h2' : 'h1';
 
   const previewCopy =
     signup.status === 'draft'
@@ -190,7 +191,11 @@ export function SignupViewBody({
       ) : null}
 
       <header className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight">{signup.title}</h1>
+        {/* On /s/[slug] this title *is* the page heading, so it's an h1. In
+            'showcase' mode the card is embedded in a page that already has its
+            own h1 (the marketing headline), and a second h1 is an SEO defect —
+            demote to h2 there. Styling is identical either way. */}
+        <Title className="text-3xl font-semibold tracking-tight">{signup.title}</Title>
         {signup.description ? (
           <p className="text-ink-muted whitespace-pre-line">{signup.description}</p>
         ) : null}

--- a/src/lib/seo.test.ts
+++ b/src/lib/seo.test.ts
@@ -62,17 +62,27 @@ describe('buildRobots', () => {
 });
 
 describe('buildLandingJsonLd', () => {
-  it('describes the WebSite and a free, web-based SoftwareApplication', () => {
-    const graph = buildLandingJsonLd(ORIGIN, 'Acme Signups', 'Coordinate anything.')[
-      '@graph'
-    ] as Array<Record<string, unknown>>;
-    const types = graph.map((node) => node['@type']);
-    expect(types).toContain('WebSite');
-    expect(types).toContain('SoftwareApplication');
+  const graphOf = (): Array<Record<string, unknown>> =>
+    buildLandingJsonLd(ORIGIN, 'Acme Signups', 'Coordinate anything.')['@graph'] as Array<
+      Record<string, unknown>
+    >;
 
-    const app = graph.find((node) => node['@type'] === 'SoftwareApplication');
-    expect(app?.name).toBe('Acme Signups');
-    expect(app?.offers).toMatchObject({ price: '0', priceCurrency: 'USD' });
+  it('describes the WebSite and the Organization that publishes it', () => {
+    const graph = graphOf();
+    expect(graph.map((node) => node['@type'])).toEqual(['WebSite', 'Organization']);
+
+    const site = graph.find((node) => node['@type'] === 'WebSite');
+    const org = graph.find((node) => node['@type'] === 'Organization');
+    expect(site?.name).toBe('Acme Signups');
+    // The publisher reference must resolve to the Organization node in-graph.
+    expect(site?.publisher).toEqual({ '@id': org?.['@id'] });
+    expect(org?.['@id']).toBe(`${ORIGIN}/#organization`);
+  });
+
+  it('emits no SoftwareApplication, which Google would reject without a rating', () => {
+    // Google's software-app rich result requires aggregateRating or review; we
+    // have neither, so the type must stay out of the graph entirely.
+    expect(graphOf().map((node) => node['@type'])).not.toContain('SoftwareApplication');
   });
 });
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -50,8 +50,15 @@ export function buildRobots(origin: string): MetadataRoute.Robots {
 type JsonLd = Record<string, unknown>;
 
 /**
- * Structured data for the landing page: a `WebSite` node plus a free,
- * web-based `SoftwareApplication` node, combined in an `@graph`.
+ * Structured data for the landing page: a `WebSite` node plus the `Organization`
+ * that publishes it, combined in an `@graph`.
+ *
+ * Deliberately NOT a `SoftwareApplication`. Google's software-app rich result
+ * requires `aggregateRating` or `review` in addition to `name` and `offers`, and
+ * emitting the type without one is a hard validation error in the Rich Results
+ * Test (Ahrefs reports it as "structured data has Google rich results
+ * validation error"). We have no review data and won't invent any, so we
+ * describe the site and its publisher instead — both are rating-free types.
  */
 export function buildLandingJsonLd(origin: string, name: string, description: string): JsonLd {
   return {
@@ -63,15 +70,14 @@ export function buildLandingJsonLd(origin: string, name: string, description: st
         name,
         url: origin,
         description,
+        publisher: { '@id': `${origin}/#organization` },
       },
       {
-        '@type': 'SoftwareApplication',
+        '@type': 'Organization',
+        '@id': `${origin}/#organization`,
         name,
-        applicationCategory: 'BusinessApplication',
-        operatingSystem: 'Web',
         url: origin,
         description,
-        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
       },
     ],
   };


### PR DESCRIPTION
Found by an Ahrefs crawl of a deployed instance. Every fix here is generic to the app rather than specific to any one deployment, so it belongs upstream.

## What was wrong

**Structured data was invalid.** The landing page declared a `SoftwareApplication` in its JSON-LD. Google's software-app rich result requires that type to carry `aggregateRating` or `review`, and emitting it without one is a hard validation error in the Rich Results Test — so the markup was not just failing to earn a rich result, it was actively reporting an error.

**The landing page had two `<h1>` elements.** The hero headline, plus the signup title inside `HomeExampleCard`, which reuses `SignupViewBody`.

**Meta descriptions sat outside the 110–160 character band.** The root layout description (178 chars, inherited by `/login` and `/login/check`) and the landing description (167) were long enough to be truncated in results. The three legal pages were 26–43 characters — thin enough that crawlers flag them as effectively missing.

**The legal pages emitted no canonical link at all.** Any duplicate host — `www` vs apex, a staging domain — produced uncanonicalised duplicate pages.

**`/login` and `/login/check` had zero outgoing links.**

## Decision worth reviewing

The JSON-LD change is the only judgment call in here. I replaced `SoftwareApplication` with `WebSite` + `Organization` rather than keeping the type and adding a rating.

The alternative is to keep `SoftwareApplication` and supply a genuine `review` or `aggregateRating`. That's the better outcome *if* real review data exists — it's what makes the rich result eligible at all. There is none today, and inventing it would be both dishonest and a Google policy violation, so the markup describes what we can actually attest to. `WebSite` and `Organization` carry no rating requirement.

If review data shows up later, reintroducing `SoftwareApplication` alongside it is a clean follow-up.

## Notes

The `SignupViewBody` heading change keeps the `h1` on `/s/[slug]`, where the signup title genuinely *is* the page heading, and demotes to `h2` only in `showcase` mode. Styling is identical either way.

The login-page footer is worth having independently of SEO — a page that collects an email address should link to the privacy policy and terms.

New tests guard both directions of the heading change. `live` mode is deliberately not exercised: it mounts `CommitDialog`, which calls `useRouter()` and needs an App Router context jsdom doesn't provide. `preview` takes the same non-showcase branch and stands in for it — this is why the existing tests in that file only use `showcase` and `preview`.

## Verification

`pnpm lint`, `pnpm typecheck`, and `pnpm test` (44 files, 526 tests) all pass, and `pnpm build` succeeds. Rendered HTML was checked against a local production server: one `<h1>` on the landing page, all descriptions 145–152 chars, canonicals present on every indexable page, and the login pages returning 200 with footer links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
