### PR TITLE
fix(deps): restore nodemailer ^9.0.3 spec to match lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lucide-react": "^0.468.0",
     "next": "15.5.22",
     "next-auth": "5.0.0-beta.32",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.3",
     "pg-boss": "^10.1.5",
     "pino": "^9.5.0",
     "postgres": "^3.4.5",


### PR DESCRIPTION
## Problem

`main` cannot install. `pnpm install --frozen-lockfile` fails on a clean checkout:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
because pnpm-lock.yaml is not up to date with <ROOT>/package.json
```

The single mismatch is `nodemailer` — `package.json` says `^8.0.5`, `pnpm-lock.yaml` says `^9.0.3`.

Because the install step runs before every other check, both CI jobs die in ~20s on `main` and on every open PR against it. #179 (postcss bump) is red for exactly this reason and not for anything to do with postcss.

## Cause

#170 bumped nodemailer to `^9.0.3` to patch a high-severity SSRF / arbitrary-file-read advisory in 8.x.

#178 reshuffled the `dependencies` block and reverted that one line back to `^8.0.5` — the pre-#170 value — while its regenerated lockfile kept 9.0.3. So the merged state is both internally inconsistent and silently un-does the security bump at the spec level.

## Fix

Restore `"nodemailer": "^9.0.3"` in `package.json`. One line, no lockfile change — 9.0.3 is already what the lockfile resolves, so the installed dependency tree is byte-identical to what CI would otherwise have produced.

## Verification

Run locally against the CI step list:

| Check | Result |
| --- | --- |
| `pnpm install --frozen-lockfile` | passes, `pnpm-lock.yaml` untouched |
| `pnpm lint` | clean |
| `pnpm typecheck` | clean |
| `pnpm test` | 526 passed / 44 files |
| `pnpm build` | succeeds |
| installed nodemailer | 9.0.3 |

`pnpm test:db` and `pnpm test:e2e` were not run locally — no Docker available in that environment, so no Postgres. The change alters no resolved dependency, so neither is expected to move, but CI is the actual check.

## Follow-up (not addressed here)

`next-auth@5.0.0-beta.32` and `@auth/core@0.41.3` both declare `nodemailer: ^7.0.7 || ^8.0.5`, so nodemailer 9 sits outside their peer range. It is an optional peer and pnpm only warns, so nothing breaks today — but the repo is caught between an Auth.js version that wants nodemailer 8 and an advisory that wants 9. That tension predates this PR and likely explains why #178 "corrected" the spec downward. Worth resolving deliberately rather than by accident.

## Effect on #179

Once this lands, dependabot should auto-rebase #179 onto the fixed base and it should go green on its own. If it does not rebase, `·@·d·ependabot r·ebase` on that PR will force it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcCCKULuSLPUDd63sni4wX)_