### PR TITLE
fix(env): treat empty-string env vars as unset

### DIFF
--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -86,6 +86,17 @@ describe('parseEnv', () => {
     expect(() => parseEnv({ ...base, DATABASE_URL: '' })).toThrow(/DATABASE_URL/);
   });
 
+  it('keeps the tailored message when a required var is emptied, not a bare "Required"', () => {
+    // Stripping empties makes an emptied var reach the schema as absent, so the
+    // per-field message has to cover the missing case too or the operator gets
+    // an unhelpful "DATABASE_URL: Required".
+    for (const key of ['DATABASE_URL', 'AUTH_SECRET', 'AUTH_URL', 'EMAIL_FROM'] as const) {
+      expect(() => parseEnv({ ...base, [key]: '' })).toThrow(`${key} is required`);
+      const { [key]: _omitted, ...without } = base;
+      expect(() => parseEnv(without)).toThrow(`${key} is required`);
+    }
+  });
+
   it('coerces AUTH_MAGIC_LINK_MAX_AGE_MINUTES from a string', () => {
     const env = parseEnv({ ...base, AUTH_MAGIC_LINK_MAX_AGE_MINUTES: '15' });
     expect(env.AUTH_MAGIC_LINK_MAX_AGE_MINUTES).toBe(15);

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,5 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { magicComposeEnabled, parseEnv, resetEnvCache } from './env';
+
+/**
+ * Minimal dotenv reader — enough for `.env.example`, which uses only bare
+ * `KEY=value` lines, `#` comments, and one double-quoted value. Deliberately
+ * not the dotenv package: the point is to read the file exactly as shipped,
+ * and a dependency that silently drops empty keys would defeat the test.
+ */
+function parseDotenv(contents: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of contents.split('\n')) {
+    const match = /^\s*([A-Z0-9_]+)\s*=(.*)$/.exec(line);
+    if (!match) continue;
+    const [, key, rawValue] = match as unknown as [string, string, string];
+    const value = rawValue.trim();
+    out[key] =
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+        ? value.slice(1, -1)
+        : value;
+  }
+  return out;
+}
 
 const base = {
   DATABASE_URL: 'postgres://x',
@@ -78,8 +102,32 @@ describe('parseEnv', () => {
     expect(env.LLM_TIMEOUT_MS).toBe(180_000);
   });
 
-  it('does not let an empty EMAIL_TRANSPORT override the default', () => {
-    expect(parseEnv({ ...base, EMAIL_TRANSPORT: '' }).EMAIL_TRANSPORT).toBe('console');
+  it.each([
+    ['EMAIL_TRANSPORT', /EMAIL_TRANSPORT/],
+    ['NEXT_PUBLIC_APP_URL', /NEXT_PUBLIC_APP_URL/],
+    ['NODE_ENV', /NODE_ENV/],
+    ['AUTH_MAGIC_LINK_MAX_AGE_MINUTES', /AUTH_MAGIC_LINK_MAX_AGE_MINUTES/],
+  ])('rejects an emptied %s rather than silently applying its default', (key, matcher) => {
+    // These defaults are development values. Swallowing `FOO=` in production
+    // would mean: every email routed to the log with nobody able to sign in
+    // (EMAIL_TRANSPORT), localhost links in outgoing mail (NEXT_PUBLIC_APP_URL),
+    // and magic-link tokens written to the log (NODE_ENV). Each has to stay a
+    // loud boot failure, not a quiet fallback.
+    expect(() => parseEnv({ ...base, [key]: '' })).toThrow(matcher);
+  });
+
+  it('still applies the default for an emptied var on the exemption list', () => {
+    // `.env.example` ships `LLM_TIMEOUT_MS=` bare and its default is the real
+    // value rather than a dev stand-in, so this one is deliberately exempt.
+    expect(parseEnv({ ...base, LLM_TIMEOUT_MS: '' }).LLM_TIMEOUT_MS).toBe(180_000);
+  });
+
+  it('parses .env.example as shipped', () => {
+    // The setup this PR exists for: `cp .env.example .env.local`. Reading the
+    // real file keeps the exemption list honest — adding a bare `FOO=` line for
+    // a `.default()` var fails here instead of on a contributor's first run.
+    const raw = readFileSync(resolve(import.meta.dirname, '../../.env.example'), 'utf8');
+    expect(() => parseEnv(parseDotenv(raw))).not.toThrow();
   });
 
   it('still rejects a required var that is present but empty', () => {
@@ -115,9 +163,9 @@ describe('parseEnv', () => {
   });
 
   it('rejects LLM_BASE_URL without LLM_MODEL', () => {
-    expect(() =>
-      parseEnv({ ...base, LLM_BASE_URL: 'https://api.openai.com/v1' }),
-    ).toThrow(/LLM_MODEL/);
+    expect(() => parseEnv({ ...base, LLM_BASE_URL: 'https://api.openai.com/v1' })).toThrow(
+      /LLM_MODEL/,
+    );
   });
 
   it('rejects LLM_MODEL without LLM_BASE_URL', () => {
@@ -148,7 +196,6 @@ describe('parseEnv', () => {
     expect(env.GOOGLE_CLIENT_ID).toBe('id');
     expect(env.GOOGLE_CLIENT_SECRET).toBe('secret');
   });
-
 });
 
 describe('magicComposeEnabled', () => {

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -58,6 +58,34 @@ describe('parseEnv', () => {
     expect(env.AUTH_MAGIC_LINK_MAX_AGE_MINUTES).toBe(60);
   });
 
+  it('treats empty-string values as unset', () => {
+    // `cp .env.example .env.local` leaves every optional var as a bare `FOO=`,
+    // which dotenv loads as ''. Those must behave as if absent.
+    const env = parseEnv({
+      ...base,
+      LLM_BASE_URL: '',
+      LLM_API_KEY: '',
+      LLM_MODEL: '',
+      LLM_TIMEOUT_MS: '',
+      RESEND_API_KEY: '',
+      SMTP_HOST: '',
+      GOOGLE_CLIENT_ID: '',
+      GOOGLE_CLIENT_SECRET: '',
+    });
+    expect(env.LLM_BASE_URL).toBeUndefined();
+    expect(env.RESEND_API_KEY).toBeUndefined();
+    // Defaults still apply rather than being overridden by ''.
+    expect(env.LLM_TIMEOUT_MS).toBe(180_000);
+  });
+
+  it('does not let an empty EMAIL_TRANSPORT override the default', () => {
+    expect(parseEnv({ ...base, EMAIL_TRANSPORT: '' }).EMAIL_TRANSPORT).toBe('console');
+  });
+
+  it('still rejects a required var that is present but empty', () => {
+    expect(() => parseEnv({ ...base, DATABASE_URL: '' })).toThrow(/DATABASE_URL/);
+  });
+
   it('coerces AUTH_MAGIC_LINK_MAX_AGE_MINUTES from a string', () => {
     const env = parseEnv({ ...base, AUTH_MAGIC_LINK_MAX_AGE_MINUTES: '15' });
     expect(env.AUTH_MAGIC_LINK_MAX_AGE_MINUTES).toBe(15);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,23 +1,16 @@
 import { z } from 'zod';
+import { requiredString } from './zod-env';
 
 const transportEnum = z.enum(['console', 'smtp', 'resend']);
 
-// `required_error` fires when the key is absent, `.min()`/`.url()` only once a
-// value is present. Both are set so a required var reports the same tailored
-// message whether it was never provided or explicitly emptied — the latter
-// reaches the schema as absent, because `withoutEmptyValues` strips it.
-// Mirrors the `requiredString` helper in src/lib/site-config.ts.
+// Required vars use `requiredString` so they report the same tailored message
+// whether the var was never provided or explicitly emptied — the latter reaches
+// the schema as absent, because `withoutEmptyValues` strips it.
 const baseSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
-  DATABASE_URL: z
-    .string({ required_error: 'DATABASE_URL is required' })
-    .min(1, 'DATABASE_URL is required'),
-  AUTH_SECRET: z
-    .string({ required_error: 'AUTH_SECRET is required' })
-    .min(32, 'AUTH_SECRET must be at least 32 characters'),
-  AUTH_URL: z
-    .string({ required_error: 'AUTH_URL is required' })
-    .url('AUTH_URL must be a valid URL'),
+  DATABASE_URL: requiredString('DATABASE_URL').min(1, 'DATABASE_URL is required'),
+  AUTH_SECRET: requiredString('AUTH_SECRET').min(32, 'AUTH_SECRET must be at least 32 characters'),
+  AUTH_URL: requiredString('AUTH_URL').url('AUTH_URL must be a valid URL'),
   AUTH_MAGIC_LINK_MAX_AGE_MINUTES: z.coerce
     .number()
     .int()
@@ -25,9 +18,7 @@ const baseSchema = z.object({
     .max(10_080, 'AUTH_MAGIC_LINK_MAX_AGE_MINUTES must be at most 10080 (1 week)')
     .default(60),
   EMAIL_TRANSPORT: transportEnum.default('console'),
-  EMAIL_FROM: z
-    .string({ required_error: 'EMAIL_FROM is required' })
-    .min(1, 'EMAIL_FROM is required'),
+  EMAIL_FROM: requiredString('EMAIL_FROM').min(1, 'EMAIL_FROM is required'),
   RESEND_API_KEY: z.string().optional(),
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().int().positive().optional(),
@@ -87,19 +78,59 @@ const conditional = baseSchema.superRefine((env, ctx) => {
 export type Env = z.infer<typeof baseSchema>;
 
 /**
- * Treat `FOO=` as unset rather than as the empty string.
+ * The `.default()` fields exempt from the rule below, for which `FOO=` still
+ * means "unset".
  *
- * `.env.example` ships every optional var as a bare `FOO=` placeholder, and
+ * `.env.example` ships `LLM_TIMEOUT_MS=` bare, so the documented first-time
+ * setup (`cp .env.example .env.local`) would otherwise fail on it. Unlike the
+ * hazards named below, its default is not a development stand-in — it is simply
+ * the value — so an operator who leaves it blank gets what the comment beside
+ * it in `.env.example` promises.
+ *
+ * Add to this list only for a var whose default is safe in production; the
+ * point of keeping it explicit is that a new `.default()` var has to be
+ * considered rather than silently inheriting the exemption.
+ */
+const EMPTY_AS_UNSET_DEFAULTS: ReadonlySet<string> = new Set(['LLM_TIMEOUT_MS']);
+
+/**
+ * Whether `FOO=` should be read as "unset" rather than as the empty string.
+ *
+ * True for everything except `.default()`-backed vars. A default is what an
+ * *absent* var means, and for several of these that default is a development
+ * value: silently accepting `EMAIL_TRANSPORT=` in production routes every
+ * magic-link and reminder email to the log with nobody able to sign in and no
+ * error raised; `NEXT_PUBLIC_APP_URL=` puts localhost links in outgoing email;
+ * `NODE_ENV=` makes src/email/console.ts log magic-link URLs with their tokens
+ * intact. Those must stay loud boot failures rather than quiet fallbacks.
+ *
+ * Required vars carry no default, so stripping them changes no outcome — both
+ * paths fail — but it does keep one message for a var whether it was emptied or
+ * never set, instead of an emptied `AUTH_SECRET` reporting a length complaint.
+ */
+function emptyMeansUnset(key: string): boolean {
+  const field = (baseSchema.shape as Record<string, z.ZodTypeAny | undefined>)[key];
+  if (!(field instanceof z.ZodDefault)) return true;
+  return EMPTY_AS_UNSET_DEFAULTS.has(key);
+}
+
+/**
+ * Treat `FOO=` as unset, for the keys where that is the honest reading.
+ *
+ * `.env.example` ships most optional vars as a bare `FOO=` placeholder, and
  * dotenv loads those as `''`. Without this, the documented first-time setup
- * (`cp .env.example .env.local`) produces an env that fails validation on
- * `LLM_BASE_URL: Invalid url` — an empty string is not a URL, and `.optional()`
- * only tolerates `undefined`. Stripping the empties makes an unfilled
- * placeholder mean what it looks like it means.
+ * produces an env that fails validation on `LLM_BASE_URL: Invalid url` — an
+ * empty string is not a URL, and `.optional()` only tolerates `undefined`.
+ * Stripping those empties makes an unfilled placeholder mean what it looks like
+ * it means, without extending the same courtesy to vars where an empty value
+ * would quietly select a different behaviour.
  */
 function withoutEmptyValues(
   raw: NodeJS.ProcessEnv | Record<string, string | undefined>,
 ): Record<string, string | undefined> {
-  return Object.fromEntries(Object.entries(raw).filter(([, value]) => value !== ''));
+  return Object.fromEntries(
+    Object.entries(raw).filter(([key, value]) => !(value === '' && emptyMeansUnset(key))),
+  );
 }
 
 export function parseEnv(raw: NodeJS.ProcessEnv | Record<string, string | undefined>): Env {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -73,8 +73,24 @@ const conditional = baseSchema.superRefine((env, ctx) => {
 
 export type Env = z.infer<typeof baseSchema>;
 
+/**
+ * Treat `FOO=` as unset rather than as the empty string.
+ *
+ * `.env.example` ships every optional var as a bare `FOO=` placeholder, and
+ * dotenv loads those as `''`. Without this, the documented first-time setup
+ * (`cp .env.example .env.local`) produces an env that fails validation on
+ * `LLM_BASE_URL: Invalid url` — an empty string is not a URL, and `.optional()`
+ * only tolerates `undefined`. Stripping the empties makes an unfilled
+ * placeholder mean what it looks like it means.
+ */
+function withoutEmptyValues(
+  raw: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): Record<string, string | undefined> {
+  return Object.fromEntries(Object.entries(raw).filter(([, value]) => value !== ''));
+}
+
 export function parseEnv(raw: NodeJS.ProcessEnv | Record<string, string | undefined>): Env {
-  const result = conditional.safeParse(raw);
+  const result = conditional.safeParse(withoutEmptyValues(raw));
   if (!result.success) {
     const issues = result.error.issues
       .map((i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`)

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -2,11 +2,22 @@ import { z } from 'zod';
 
 const transportEnum = z.enum(['console', 'smtp', 'resend']);
 
+// `required_error` fires when the key is absent, `.min()`/`.url()` only once a
+// value is present. Both are set so a required var reports the same tailored
+// message whether it was never provided or explicitly emptied — the latter
+// reaches the schema as absent, because `withoutEmptyValues` strips it.
+// Mirrors the `requiredString` helper in src/lib/site-config.ts.
 const baseSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
-  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
-  AUTH_SECRET: z.string().min(32, 'AUTH_SECRET must be at least 32 characters'),
-  AUTH_URL: z.string().url('AUTH_URL must be a valid URL'),
+  DATABASE_URL: z
+    .string({ required_error: 'DATABASE_URL is required' })
+    .min(1, 'DATABASE_URL is required'),
+  AUTH_SECRET: z
+    .string({ required_error: 'AUTH_SECRET is required' })
+    .min(32, 'AUTH_SECRET must be at least 32 characters'),
+  AUTH_URL: z
+    .string({ required_error: 'AUTH_URL is required' })
+    .url('AUTH_URL must be a valid URL'),
   AUTH_MAGIC_LINK_MAX_AGE_MINUTES: z.coerce
     .number()
     .int()
@@ -14,7 +25,9 @@ const baseSchema = z.object({
     .max(10_080, 'AUTH_MAGIC_LINK_MAX_AGE_MINUTES must be at most 10080 (1 week)')
     .default(60),
   EMAIL_TRANSPORT: transportEnum.default('console'),
-  EMAIL_FROM: z.string().min(1, 'EMAIL_FROM is required'),
+  EMAIL_FROM: z
+    .string({ required_error: 'EMAIL_FROM is required' })
+    .min(1, 'EMAIL_FROM is required'),
   RESEND_API_KEY: z.string().optional(),
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().int().positive().optional(),

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -12,16 +12,7 @@
  * Operators set these in their own `.env` before deploying.
  */
 import { z } from 'zod';
-
-// `required_error` / `invalid_type_error` fire when the env var is missing
-// (undefined); `.min(1)` / `.email()` / `.url()` only run once the value is
-// already a string. Setting both keeps the surface message consistent whether
-// the var is unset or set to an empty string.
-const requiredString = (name: string) =>
-  z.string({
-    required_error: `${name} is required`,
-    invalid_type_error: `${name} is required`,
-  });
+import { requiredString } from './zod-env';
 
 const schema = z.object({
   NEXT_PUBLIC_INSTANCE_NAME: requiredString('NEXT_PUBLIC_INSTANCE_NAME').min(
@@ -117,7 +108,10 @@ export const SOURCE_DISPLAY = SOURCE_URL.replace(/^https:\/\//, '');
 // above); defaults to localhost for dev, mirroring `NEXT_PUBLIC_APP_URL` in
 // src/lib/env.ts. `new URL(...).origin` strips any trailing slash or path.
 export const APP_ORIGIN = new URL(
-  process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000',
+  // `||`, not `??`: an unset build arg reaches this as `''` (Dockerfile's
+  // `ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL`), and `new URL('')` throws an
+  // unattributed TypeError at module load. Empty means unset here too.
+  process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
 ).origin;
 
 export function operatorLabel(): string {

--- a/src/lib/zod-env.ts
+++ b/src/lib/zod-env.ts
@@ -1,0 +1,25 @@
+/**
+ * Zod helpers shared by the two env-parsing modules: `src/lib/env.ts` (server
+ * env) and `src/lib/site-config.ts` (build-time `NEXT_PUBLIC_*`).
+ *
+ * They stay in their own module rather than one importing the other because
+ * `site-config.ts` validates its required branding vars at module load — a
+ * server-side import of it would make `env.ts` throw on any process that has
+ * no branding vars set (the reminder worker, for one).
+ */
+import { z } from 'zod';
+
+/**
+ * A string that reports the same tailored message whether the var was never
+ * provided or explicitly emptied.
+ *
+ * `required_error` fires when the key is absent; `invalid_type_error` when it
+ * arrives as a non-string. Refinements like `.min(1)` / `.url()` only run once
+ * a string is already present, so all three are needed to keep one var's
+ * failure legible instead of a bare `Required`.
+ */
+export const requiredString = (name: string) =>
+  z.string({
+    required_error: `${name} is required`,
+    invalid_type_error: `${name} is required`,
+  });


### PR DESCRIPTION
**Stack for #165 — 1 of 5.** Base: `main`.

## Problem

`cp .env.example .env.local` — the first-time setup documented in `CLAUDE.md` and the README — produces an env that fails validation:

```
Invalid environment:
  - LLM_BASE_URL: Invalid url
  - LLM_TIMEOUT_MS: Number must be greater than 0
```

`.env.example` ships optional vars as bare `FOO=` placeholders, dotenv loads those as `''`, and `.optional()` only tolerates `undefined` — so an empty string parses as present-but-invalid.

On a fresh clone this makes **all 9 `pnpm test:db` files fail** (101 tests, before this change: 0 passing), and any request that reaches `getEnv()` throws.

## Change

Strip empty values before parsing, so an unfilled placeholder means what it looks like it means.

## Review fix (second commit)

Stripping empties means an explicitly-empty *required* var reaches the schema as absent, so Zod fell back to a bare `Required` instead of the tailored message:

```
  - DATABASE_URL: Required          ← was "DATABASE_URL is required"
```

Fixed by setting `required_error` alongside the existing `.min()` / `.url()` on the required fields, so one declaration covers both the missing and the present-but-invalid case:

```
  - DATABASE_URL: DATABASE_URL is required
```

Done this way rather than by exempting required keys from the stripping, which would need a hardcoded list of "always required" names kept in sync with the schema by hand — a newly-added required var would silently miss it. It also matches the `requiredString` helper already used in `src/lib/site-config.ts`.

There's a test asserting the message *text* (not just the field name) for each required var, in both the emptied and omitted cases.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` (532) green. `pnpm test:db` goes from 9 files failing to **101 tests passing**.