### PR TITLE
fix(worker): compile email templates with the automatic JSX runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,10 @@ COPY --from=builder --chown=signup:signup /app/.next/static ./.next/static
 COPY --from=builder --chown=signup:signup /app/src ./src
 COPY --from=builder --chown=signup:signup /app/drizzle.config.ts ./drizzle.config.ts
 COPY --from=builder --chown=signup:signup /app/tsconfig.json ./tsconfig.json
+# The reminder worker runs `tsx --tsconfig tsconfig.worker.json`, and tsx
+# hard-errors on a missing tsconfig rather than falling back to a default —
+# omit this and the worker crash-loops under `restart: unless-stopped`.
+COPY --from=builder --chown=signup:signup /app/tsconfig.worker.json ./tsconfig.worker.json
 COPY --from=builder --chown=signup:signup /app/node_modules ./node_modules
 COPY --from=builder --chown=signup:signup /app/package.json ./package.json
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,7 +59,9 @@ services:
       migrate:
         condition: service_completed_successfully
     env_file: .env
-    command: ['pnpm', 'exec', 'tsx', 'src/jobs/worker.ts']
+    # Go through the `worker` script rather than invoking tsx directly, so the
+    # worker's JSX tsconfig stays defined in exactly one place.
+    command: ['pnpm', 'worker']
     restart: unless-stopped
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "email:dev": "email dev --dir src/email/templates --port 3001",
-    "worker": "tsx src/jobs/worker.ts",
+    "worker": "tsx --tsconfig tsconfig.worker.json src/jobs/worker.ts",
     "eval:magic-compose": "tsx scripts/eval-magic-compose.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/scripts/render-email-templates.ts
+++ b/scripts/render-email-templates.ts
@@ -36,11 +36,34 @@ const cases: Array<[string, ReactElement]> = [
   ],
 ];
 
+/**
+ * A distinctive string each template must put in its output. Asserting on real
+ * rendered content rather than "not empty" is what makes the guard notice a
+ * template that renders but drops a section — e.g. after gaining a prop the
+ * fixture above does not supply.
+ */
+const expected: Record<string, string> = {
+  'magic-link': 'https://example.test/login/confirm?token=abc',
+  reminder: 'Saturday Snack Rotation',
+};
+
 async function main(): Promise<void> {
   for (const [name, node] of cases) {
     const { html, text } = await renderEmail(node);
     if (!html.trim() || !text.trim()) {
       throw new Error(`${name} rendered empty output`);
+    }
+    const needle = expected[name];
+    if (needle === undefined) {
+      throw new Error(`${name} has no expected-content entry; add one`);
+    }
+    for (const [format, body] of [
+      ['html', html],
+      ['text', text],
+    ] as const) {
+      if (!body.includes(needle)) {
+        throw new Error(`${name} ${format} output is missing ${JSON.stringify(needle)}`);
+      }
     }
     console.log(`ok ${name}`);
   }

--- a/scripts/render-email-templates.ts
+++ b/scripts/render-email-templates.ts
@@ -1,0 +1,49 @@
+/**
+ * Renders every email template and exits non-zero if any of them throws.
+ *
+ * Exists to be run under the *worker's* toolchain (`tsx --tsconfig
+ * tsconfig.worker.json`), which is the only place templates are compiled
+ * outside Next.js. See src/email/templates/worker-render.test.ts for why that
+ * distinction matters.
+ */
+import { createElement, type ReactElement } from 'react';
+import { renderEmail } from '@/email/render';
+import { MagicLinkEmail } from '@/email/templates/magic-link';
+import { ReminderEmail } from '@/email/templates/reminder';
+
+const cases: Array<[string, ReactElement]> = [
+  [
+    'magic-link',
+    createElement(MagicLinkEmail, {
+      url: 'https://example.test/login/confirm?token=abc',
+      email: 'organizer@example.test',
+      expiresInMinutes: 60,
+    }),
+  ],
+  [
+    'reminder',
+    createElement(ReminderEmail, {
+      participantName: 'Dana',
+      signupTitle: 'Saturday Snack Rotation',
+      signupUrl: 'https://example.test/s/snacks',
+      slotLabel: 'Week 1',
+      slotDateLabel: 'Saturday, September 5',
+      notes: 'Bringing grapes',
+    }),
+  ],
+];
+
+async function main(): Promise<void> {
+  for (const [name, node] of cases) {
+    const { html, text } = await renderEmail(node);
+    if (!html.trim() || !text.trim()) {
+      throw new Error(`${name} rendered empty output`);
+    }
+    console.log(`ok ${name}`);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/render-email-templates.ts
+++ b/scripts/render-email-templates.ts
@@ -1,5 +1,8 @@
 /**
- * Renders every email template and exits non-zero if any of them throws.
+ * Renders each sendable email template and exits non-zero if any of them
+ * throws. Shared pieces under src/email/templates (layout.tsx) are covered
+ * transitively, since every sendable template composes them; add a case here
+ * whenever a new template gains a `send*` function.
  *
  * Exists to be run under the *worker's* toolchain (`tsx --tsconfig
  * tsconfig.worker.json`), which is the only place templates are compiled

--- a/src/email/templates/worker-render.test.ts
+++ b/src/email/templates/worker-render.test.ts
@@ -17,11 +17,13 @@ const run = promisify(execFile);
  * in the test suite to notice.
  *
  * So this test shells out to the worker's real toolchain rather than importing
- * the templates directly. If it fails, reminder emails are broken in
+ * the templates directly. The set it covers is whatever
+ * scripts/render-email-templates.ts lists — the sendable templates, plus the
+ * shared layout they all compose. If it fails, reminder emails are broken in
  * production even though every other email test is green.
  */
 describe('email templates under the worker toolchain', () => {
-  it('renders every template with tsx + tsconfig.worker.json', async () => {
+  it('renders each sendable template with tsx + tsconfig.worker.json', async () => {
     const { stdout } = await run(
       'pnpm',
       ['exec', 'tsx', '--tsconfig', 'tsconfig.worker.json', 'scripts/render-email-templates.ts'],

--- a/src/email/templates/worker-render.test.ts
+++ b/src/email/templates/worker-render.test.ts
@@ -1,8 +1,21 @@
 import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 
 const run = promisify(execFile);
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+
+function workerScript(): string {
+  const pkg = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as {
+    scripts?: Record<string, string>;
+  };
+  const script = pkg.scripts?.worker;
+  if (!script) throw new Error('package.json has no "worker" script');
+  return script;
+}
 
 /**
  * Guards the reminder worker's JSX transform.
@@ -23,13 +36,34 @@ const run = promisify(execFile);
  * production even though every other email test is green.
  */
 describe('email templates under the worker toolchain', () => {
-  it('renders each sendable template with tsx + tsconfig.worker.json', async () => {
+  it('renders each sendable template under the flags the worker script uses', async () => {
+    // Derived from package.json rather than hardcoded, so reverting the
+    // `worker` script — or a deployment invoking tsx directly, which
+    // docker-compose.prod.yml did before this change — fails here instead of
+    // staying green while reminder emails break again.
+    const script = workerScript();
+    const flags = script.split(/\s+/).slice(1, -1);
     const { stdout } = await run(
       'pnpm',
-      ['exec', 'tsx', '--tsconfig', 'tsconfig.worker.json', 'scripts/render-email-templates.ts'],
-      { cwd: process.cwd() },
+      ['exec', 'tsx', ...flags, 'scripts/render-email-templates.ts'],
+      { cwd: repoRoot },
     );
     expect(stdout).toContain('ok magic-link');
     expect(stdout).toContain('ok reminder');
   }, 60_000);
+
+  it('ships every tsconfig the worker script needs in the runner image', async () => {
+    // CI has no docker build step, so nothing else catches a tsconfig that the
+    // worker command references but the image never receives. tsx hard-errors
+    // on a missing tsconfig, so the worker would crash-loop on deploy.
+    const referenced = [...workerScript().matchAll(/--tsconfig\s+(\S+)/g)].map(
+      (m) => m[1] as string,
+    );
+    expect(referenced.length).toBeGreaterThan(0);
+
+    const dockerfile = readFileSync(resolve(repoRoot, 'Dockerfile'), 'utf8');
+    for (const path of referenced) {
+      expect(dockerfile).toMatch(new RegExp(`COPY .*/${path}\\b`));
+    }
+  });
 });

--- a/src/email/templates/worker-render.test.ts
+++ b/src/email/templates/worker-render.test.ts
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const run = promisify(execFile);
+
+/**
+ * Guards the reminder worker's JSX transform.
+ *
+ * Email templates are compiled twice by two different toolchains: by Next.js
+ * for the web process, and by `tsx` for `pnpm worker`. Vitest applies its own
+ * transform, so a normal render test passes even when the worker cannot render
+ * the same template at all — which is exactly what happened: with
+ * `"jsx": "preserve"` in tsconfig.json, tsx emitted classic
+ * `React.createElement` calls against templates written for the automatic
+ * runtime, and every reminder job died on `React is not defined` with nothing
+ * in the test suite to notice.
+ *
+ * So this test shells out to the worker's real toolchain rather than importing
+ * the templates directly. If it fails, reminder emails are broken in
+ * production even though every other email test is green.
+ */
+describe('email templates under the worker toolchain', () => {
+  it('renders every template with tsx + tsconfig.worker.json', async () => {
+    const { stdout } = await run(
+      'pnpm',
+      ['exec', 'tsx', '--tsconfig', 'tsconfig.worker.json', 'scripts/render-email-templates.ts'],
+      { cwd: process.cwd() },
+    );
+    expect(stdout).toContain('ok magic-link');
+    expect(stdout).toContain('ok reminder');
+  }, 60_000);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,13 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", "tests/**/*.ts", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts",
+    "scripts/**/*.ts",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules", ".next", "dist", "playwright-report"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/vitest.db.config.ts
+++ b/vitest.db.config.ts
@@ -6,6 +6,12 @@ loadEnv({ path: '.env.local' });
 loadEnv({ path: '.env' });
 
 export default defineConfig({
+  // The unit config gets the automatic JSX runtime from @vitejs/plugin-react;
+  // this one has no plugins, so without this any test that reaches an email
+  // template fails with `React is not defined` — tsconfig.json sets
+  // `jsx: "preserve"` for Next.js, under which esbuild emits classic
+  // React.createElement calls. Same root cause as tsconfig.worker.json.
+  esbuild: { jsx: 'automatic' },
   test: {
     environment: 'node',
     include: ['src/**/*.db.test.ts'],


### PR DESCRIPTION
**Stack for #165 — 2 of 5.** Base: `claude/opensignup-issue-165-env-fix` (#182).

## Reminder emails have never sent

Every `reminders.send` job fails and retries until it is dead-lettered:

```
ReferenceError: React is not defined
    at ReminderEmail (src/email/templates/reminder.tsx)
```

Confirmed against a live worker and Postgres — the `pgboss.job` row ends in `state=failed` with that error, and no `reminder.sent` activity row is ever written. So the reminder feature is present in the code but has never delivered an email.

## Cause

Email templates are compiled by two toolchains: Next.js for the web process, and bare `tsx` for `pnpm worker`. `tsconfig.json` sets `"jsx": "preserve"` (as Next.js requires), under which esbuild falls back to the **classic** runtime and emits `React.createElement` — but the templates are written for the **automatic** runtime and import no React.

The web process is fine because Next applies its own transform. The worker is the only place that isn't, and reminders are the only email it sends.

## Change

- `tsconfig.worker.json` extends the base config with `"jsx": "react-jsx"`; the `worker` script points at it.
- `docker-compose.prod.yml` invoked `tsx` directly, bypassing the script, so it would have stayed broken — it now goes through `pnpm worker`. One definition, not three. (`fly.example.toml` already used `pnpm worker`.)
- `vitest.db.config.ts` had the same latent gap: it has no plugins, so it inherited `jsx: "preserve"` too. No test imported a template yet, so nothing was failing — the first one to try would have hit a confusing error far from its cause.

## Why no test caught this

Vitest applies its own JSX transform, so importing a template in a test proves nothing about whether the worker can render it. The new guard shells out to the worker's **actual** toolchain instead. I verified it fails correctly by reverting the tsconfig: `ReferenceError: React is not defined`.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` (532) green. End-to-end: with this fix a reminder renders and reaches the console transport for the first time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KttMJN7n8KTNn63qVpPCcy)_