### PR TITLE
feat(commitments): email a confirmation when a participant signs up

### DIFF
--- a/scripts/render-email-templates.ts
+++ b/scripts/render-email-templates.ts
@@ -58,6 +58,7 @@ const cases: Array<[string, ReactElement]> = [
  */
 const expected: Record<string, string> = {
   'magic-link': 'https://example.test/login/confirm?token=abc',
+  'commitment-confirmation': 'https://example.test/s/snacks/c/com_1?token=abc',
   reminder: 'Saturday Snack Rotation',
 };
 

--- a/scripts/render-email-templates.ts
+++ b/scripts/render-email-templates.ts
@@ -11,6 +11,7 @@
  */
 import { createElement, type ReactElement } from 'react';
 import { renderEmail } from '@/email/render';
+import { CommitmentConfirmationEmail } from '@/email/templates/commitment-confirmation';
 import { MagicLinkEmail } from '@/email/templates/magic-link';
 import { ReminderEmail } from '@/email/templates/reminder';
 
@@ -21,6 +22,19 @@ const cases: Array<[string, ReactElement]> = [
       url: 'https://example.test/login/confirm?token=abc',
       email: 'organizer@example.test',
       expiresInMinutes: 60,
+    }),
+  ],
+  [
+    'commitment-confirmation',
+    createElement(CommitmentConfirmationEmail, {
+      participantName: 'Dana',
+      signupTitle: 'Saturday Snack Rotation',
+      manageUrl: 'https://example.test/s/snacks/c/com_1?token=abc',
+      slotLabel: 'Week 1',
+      slotDateLabel: 'Saturday, September 5 at 9:00 AM',
+      notes: 'Bringing grapes',
+      quantity: 2,
+      reminderLeadHours: 24,
     }),
   ],
   [

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -21,45 +21,44 @@ export default function PrivacyPage() {
     <>
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Privacy policy</h1>
-        <p className="text-ink-muted text-sm">Last updated: 29 August 2026</p>
+        <p className="text-sm text-ink-muted">Last updated: 31 August 2026</p>
       </header>
 
       <section className="space-y-3">
         <p>
-          This page describes what data {INSTANCE_NAME} collects and how it is used. It
-          is written in plain English and reflects what the code actually does — the
-          source is open and you can verify any claim here against the schema at{' '}
+          This page describes what data {INSTANCE_NAME} collects and how it is used. It is written
+          in plain English and reflects what the code actually does — the source is open and you can
+          verify any claim here against the schema at{' '}
           <a href={SOURCE_URL} className="text-brand underline">
             {SOURCE_DISPLAY}
           </a>
           .
         </p>
         <p>
-          The OpenSignup <em>project</em> is an open-source coordination tool released
-          under AGPL-3.0. This page applies to <em>this instance</em> — the deployment
-          you are currently using. The data controller for this instance is {operator}.
+          The OpenSignup <em>project</em> is an open-source coordination tool released under
+          AGPL-3.0. This page applies to <em>this instance</em> — the deployment you are currently
+          using. The data controller for this instance is {operator}.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">What we collect from organizers</h2>
         <p>
-          Organizers (people who create signups) sign in without a password — either
-          via a magic link sent to their email or, where the operator has enabled it,
-          an optional third-party sign-in such as Google. We store:
+          Organizers (people who create signups) sign in without a password — either via a magic
+          link sent to their email or, where the operator has enabled it, an optional third-party
+          sign-in such as Google. We store:
         </p>
         <ul className="list-disc space-y-1 pl-6">
           <li>Email address (used to send magic-link sign-in emails).</li>
           <li>Optional display name and organization name.</li>
           <li>The signups, slots, and settings you create.</li>
           <li>
-            An append-only activity log of organizer actions (sign-ins, creating
-            and editing signups, sending magic links), participant commitments on
-            your signups, and reminder dispatches. This exists so an organizer
-            can audit what happened in their own workspace and so the operator
-            can investigate abuse. The same log records anonymous view telemetry
-            on the marketing home page and on your public signup pages (see
-            &ldquo;Logs and rate-limiting&rdquo; below).
+            An append-only activity log of organizer actions (sign-ins, creating and editing
+            signups, sending magic links), participant commitments on your signups, and reminder
+            dispatches. This exists so an organizer can audit what happened in their own workspace
+            and so the operator can investigate abuse. The same log records anonymous view telemetry
+            on the marketing home page and on your public signup pages (see &ldquo;Logs and
+            rate-limiting&rdquo; below).
           </li>
         </ul>
         <p>No password is ever stored — sign-in is passwordless.</p>
@@ -68,20 +67,20 @@ export default function PrivacyPage() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">What we collect from participants</h2>
         <p>
-          Participants (people signing up for a slot) never create an account. When you
-          commit to a slot we store only what is needed to honour your commitment:
+          Participants (people signing up for a slot) never create an account. When you commit to a
+          slot we store only what is needed to honour your commitment:
         </p>
         <ul className="list-disc space-y-1 pl-6">
           <li>Display name.</li>
           <li>
-            Email address. This is required so we can send you a confirmation,
-            optional reminders, and a link to edit or cancel your commitment.
+            Email address. This is required so we can send you a confirmation, optional reminders,
+            and a link to edit or cancel your commitment.
           </li>
           <li>Your slot selection, quantity, and any optional notes.</li>
         </ul>
         <p>
-          A short-lived browser cookie lets you return and edit or cancel your own
-          commitment without re-entering your email. See the{' '}
+          A short-lived browser cookie lets you return and edit or cancel your own commitment
+          without re-entering your email. See the{' '}
           <Link href="/cookies" className="text-brand underline">
             cookies page
           </Link>{' '}
@@ -92,38 +91,35 @@ export default function PrivacyPage() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">Logs and rate-limiting</h2>
         <p>
-          To prevent abuse, the server records request IP addresses in short-lived
-          rate-limit records (e.g. to throttle magic-link sends). These rows are
-          scoped to individual buckets and are not joined to your account or
-          commitment for analytics. Server-side application logs are standard
-          request/error logs and do not include cookies, tokens, or magic-link URLs.
+          To prevent abuse, the server records request IP addresses in short-lived rate-limit
+          records (e.g. to throttle magic-link sends). These rows are scoped to individual buckets
+          and are not joined to your account or commitment for analytics. Server-side application
+          logs are standard request/error logs and do not include cookies, tokens, or magic-link
+          URLs.
         </p>
         <p>
-          For each view of a public signup page, the server writes a single
-          activity entry containing a user-agent class (browser, bot, or
-          unknown), the host of the referring page (not the full referer URL),
-          the signup&apos;s status, and whether the viewer is a returning
-          participant on that signup. We do not record your IP address on this
-          entry. Bot traffic and requests carrying a Do Not Track or Global
-          Privacy Control signal are skipped. The same applies when you follow
-          an &ldquo;edit your commitment&rdquo; link, when you load the
-          marketing home page, and when you click the &ldquo;Start a
-          signup&rdquo; button on it (where we record only the user-agent class
-          and the referring host).
+          For each view of a public signup page, the server writes a single activity entry
+          containing a user-agent class (browser, bot, or unknown), the host of the referring page
+          (not the full referer URL), the signup&apos;s status, and whether the viewer is a
+          returning participant on that signup. We do not record your IP address on this entry. Bot
+          traffic and requests carrying a Do Not Track or Global Privacy Control signal are skipped.
+          The same applies when you follow an &ldquo;edit your commitment&rdquo; link, when you load
+          the marketing home page, and when you click the &ldquo;Start a signup&rdquo; button on it
+          (where we record only the user-agent class and the referring host).
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">Email delivery</h2>
         <p>
-          {INSTANCE_NAME} sends three kinds of email: organizer magic-link sign-in
-          emails, a confirmation to a participant when they commit to a slot, and a
-          reminder before a dated slot. Confirmations and reminders each contain a
-          private link that lets you change or cancel that commitment without signing
-          in, so treat them as you would a password and don&apos;t forward them.
-          Organizers choose how far ahead reminders go out, and can turn them off for
-          a signup entirely. Delivery uses whichever transport the operator has
-          configured (SMTP, a transactional provider, or local console output in
+          {INSTANCE_NAME} sends three kinds of email: organizer magic-link sign-in emails, a
+          confirmation to a participant when they commit to a slot, and a reminder before a dated
+          slot. Moving to a different slot sends a fresh confirmation, because the private link in
+          the old one stops working. Confirmations and reminders each contain a private link that
+          lets you change or cancel that commitment without signing in, so treat them as you would a
+          password and don&apos;t forward them. Organizers choose how far ahead reminders go out,
+          and can turn them off for a signup entirely. Delivery uses whichever transport the
+          operator has configured (SMTP, a transactional provider, or local console output in
           development). No marketing email is ever sent.
         </p>
       </section>
@@ -131,45 +127,42 @@ export default function PrivacyPage() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">Third parties</h2>
         <p>
-          OpenSignup is designed to have no required external dependencies beyond a
-          Postgres database. Optional integrations (email provider, error reporting,
-          product analytics, AI draft generation, and third-party sign-in) are off by
-          default and only enabled if the operator has configured them via environment
-          variables. Where this instance has enabled any such integration, the operator
-          will list it on request.
+          OpenSignup is designed to have no required external dependencies beyond a Postgres
+          database. Optional integrations (email provider, error reporting, product analytics, AI
+          draft generation, and third-party sign-in) are off by default and only enabled if the
+          operator has configured them via environment variables. Where this instance has enabled
+          any such integration, the operator will list it on request.
         </p>
         <p>
           If third-party sign-in (for example, Google) is enabled and you choose it, you
-          authenticate on the provider&apos;s own site and they return your email, name,
-          avatar, and a unique account identifier. We store the link between that provider
-          account and your organizer record — along with the standard sign-in tokens the
-          provider issues — so we can recognise you on future sign-ins. We do not use those
-          tokens to access anything on the provider beyond the basic profile needed to sign
-          you in.
+          authenticate on the provider&apos;s own site and they return your email, name, avatar, and
+          a unique account identifier. We store the link between that provider account and your
+          organizer record — along with the standard sign-in tokens the provider issues — so we can
+          recognise you on future sign-ins. We do not use those tokens to access anything on the
+          provider beyond the basic profile needed to sign you in.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">Your rights</h2>
         <p>
-          You can request a copy of the data we hold about you, or ask us to delete it,
-          by emailing{' '}
+          You can request a copy of the data we hold about you, or ask us to delete it, by emailing{' '}
           <a href={SUPPORT_MAILTO} className="text-brand underline">
             {SUPPORT_EMAIL}
           </a>
-          . Today this is a manual process — self-service export and deletion endpoints
-          are on the roadmap. Organizers can already delete individual signups from
-          their workspace settings, which removes the associated commitments.
+          . Today this is a manual process — self-service export and deletion endpoints are on the
+          roadmap. Organizers can already delete individual signups from their workspace settings,
+          which removes the associated commitments.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">Self-hosting note</h2>
         <p>
-          If you are reading this on a self-hosted copy of OpenSignup, the operator of
-          that instance — not the OpenSignup project — is responsible for how your data
-          is handled. The OpenSignup project publishes source code only; it does not
-          operate or have access to data on other people&apos;s deployments.
+          If you are reading this on a self-hosted copy of OpenSignup, the operator of that instance
+          — not the OpenSignup project — is responsible for how your data is handled. The OpenSignup
+          project publishes source code only; it does not operate or have access to data on other
+          people&apos;s deployments.
         </p>
       </section>
 

--- a/src/app/(legal)/privacy/page.tsx
+++ b/src/app/(legal)/privacy/page.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
     <>
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight">Privacy policy</h1>
-        <p className="text-ink-muted text-sm">Last updated: 2 June 2026</p>
+        <p className="text-ink-muted text-sm">Last updated: 29 August 2026</p>
       </header>
 
       <section className="space-y-3">
@@ -116,11 +116,15 @@ export default function PrivacyPage() {
       <section className="space-y-3">
         <h2 className="text-xl font-semibold tracking-tight">Email delivery</h2>
         <p>
-          {INSTANCE_NAME} sends two kinds of email: organizer magic-link sign-in
-          emails, and slot reminders to participants who provided an email address.
-          Delivery uses whichever transport the operator has configured (SMTP, a
-          transactional provider, or local console output in development). No marketing
-          email is ever sent.
+          {INSTANCE_NAME} sends three kinds of email: organizer magic-link sign-in
+          emails, a confirmation to a participant when they commit to a slot, and a
+          reminder before a dated slot. Confirmations and reminders each contain a
+          private link that lets you change or cancel that commitment without signing
+          in, so treat them as you would a password and don&apos;t forward them.
+          Organizers choose how far ahead reminders go out, and can turn them off for
+          a signup entirely. Delivery uses whichever transport the operator has
+          configured (SMTP, a transactional provider, or local console output in
+          development). No marketing email is ever sent.
         </p>
       </section>
 

--- a/src/app/api/commitments/[id]/route.ts
+++ b/src/app/api/commitments/[id]/route.ts
@@ -1,9 +1,11 @@
-import type { NextRequest } from 'next/server';
+import { after, type NextRequest } from 'next/server';
 import { getDb } from '@/db/client';
 import type { Db } from '@/db/client';
 import { extractClientIp } from '@/auth/request-context';
 import { fail, handle, respond } from '@/lib/api-response';
 import { serviceError } from '@/lib/errors';
+import { editTokenFor } from '@/lib/token';
+import { notifyCommitmentCreated } from '@/email/notify';
 import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
 import {
   COMMIT_COOKIE_NAME,
@@ -48,6 +50,16 @@ export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: strin
     if (!token) return fail(serviceError('forbidden', 'edit token required', { field: 'token' }));
     const body = await req.json().catch(() => ({}));
     const result = await updateOwnCommitment(db, id, token, body);
+    // A swap cancels this commitment and creates a new one with a new id and a
+    // new edit token, so the confirmation already in the participant's inbox
+    // now points at a cancelled row — while telling them to keep it because it
+    // is how they change their slot. Send a receipt for the replacement. Edit
+    // tokens are HMAC(secret, commitment_id), so the new one is re-derivable
+    // without threading it back out of the service.
+    if (result.ok && result.value.id !== id) {
+      const swapped = result.value;
+      after(() => notifyCommitmentCreated(db, swapped.id, editTokenFor(swapped.id)));
+    }
     return respond(result);
   });
 }

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -12,26 +12,39 @@ import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
 import { commitToSlot } from '@/services/commitments';
 import { extractClientIp } from '@/auth/request-context';
 
-export async function POST(
-  req: NextRequest,
-  ctx: { params: Promise<{ id: string }> },
-) {
+export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   return handle(async () => {
     const { id: slotId } = await ctx.params;
     const db = getDb();
     const clientIp = extractClientIp(req.headers);
     await consumeRateLimit(db, RateLimits.commitmentPerIp, clientIp ?? 'unknown');
     const body = await req.json().catch(() => ({}));
+    // Per-address limit as well as per-IP, consumed before commitToSlot so a
+    // rejected request never reaches the send. The address is unverified and
+    // this endpoint now produces outbound mail, so the IP bucket alone would
+    // let one caller spray a stranger's inbox across a signup's slots. Shape is
+    // only checked here; commitToSlot's Zod parse remains the authority.
+    const claimedEmail =
+      typeof body === 'object' && body !== null ? (body as { email?: unknown }).email : undefined;
+    if (typeof claimedEmail === 'string' && claimedEmail.includes('@')) {
+      await consumeRateLimit(db, RateLimits.commitmentPerEmail, claimedEmail.trim().toLowerCase());
+    }
     const result = await commitToSlot(db, slotId, body);
     if (!result.ok) return fail(result.error);
 
     const { signupSlug, ...responseValue } = result.value;
-    const editUrl = commitmentEditUrl(signupSlug, responseValue.commitment.id, responseValue.editToken);
+    const editUrl = commitmentEditUrl(
+      signupSlug,
+      responseValue.commitment.id,
+      responseValue.editToken,
+    );
     const response = respond(
       { ok: true, value: { ...responseValue, editUrl } },
       {
         edit: link(editUrl),
-        self: link(`/api/commitments/${responseValue.commitment.id}?token=${responseValue.editToken}`),
+        self: link(
+          `/api/commitments/${responseValue.commitment.id}?token=${responseValue.editToken}`,
+        ),
         cancel: link(
           `/api/commitments/${responseValue.commitment.id}?token=${responseValue.editToken}`,
           'DELETE',
@@ -48,9 +61,7 @@ export async function POST(
 
     // After the response, so a slow mail server never holds up a participant
     // who has already got their slot. Failures are logged, never surfaced.
-    after(() =>
-      notifyCommitmentCreated(db, responseValue.commitment.id, responseValue.editToken),
-    );
+    after(() => notifyCommitmentCreated(db, responseValue.commitment.id, responseValue.editToken));
 
     return response;
   });

--- a/src/app/api/slots/[id]/commitments/route.ts
+++ b/src/app/api/slots/[id]/commitments/route.ts
@@ -1,4 +1,4 @@
-import type { NextRequest } from 'next/server';
+import { after, type NextRequest } from 'next/server';
 import { getDb } from '@/db/client';
 import { fail, handle, respond } from '@/lib/api-response';
 import {
@@ -7,6 +7,7 @@ import {
   setReturningCommitCookie,
 } from '@/lib/returning-participant';
 import { commitmentEditUrl, link } from '@/lib/links';
+import { notifyCommitmentCreated } from '@/email/notify';
 import { consumeRateLimit, RateLimits } from '@/lib/rate-limit';
 import { commitToSlot } from '@/services/commitments';
 import { extractClientIp } from '@/auth/request-context';
@@ -44,6 +45,13 @@ export async function POST(
       responseValue.commitment.signupId,
     );
     setReturningCommitCookie(response, nextCookie);
+
+    // After the response, so a slow mail server never holds up a participant
+    // who has already got their slot. Failures are logged, never surfaced.
+    after(() =>
+      notifyCommitmentCreated(db, responseValue.commitment.id, responseValue.editToken),
+    );
+
     return response;
   });
 }

--- a/src/db/schema/activity.ts
+++ b/src/db/schema/activity.ts
@@ -50,6 +50,7 @@ export const ACTIVITY_EVENTS = [
   'field.deleted',
   'participant.created',
   'commitment.created',
+  'commitment.confirmation_sent',
   'commitment.updated',
   'commitment.cancelled',
   'commitment.swapped',

--- a/src/email/notify.db.test.ts
+++ b/src/email/notify.db.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { and, eq, sql } from 'drizzle-orm';
+import { getDb, type Db } from '@/db/client';
+import { activity } from '@/db/schema/activity';
+import { workspaceMembers } from '@/db/schema/members';
+import { organizers } from '@/db/schema/organizers';
+import { workspaces } from '@/db/schema/workspaces';
+import { makeId } from '@/lib/ids';
+import type { Actor } from '@/lib/policy';
+import { commitToSlot } from '@/services/commitments';
+import { createSignup, publishSignup } from '@/services/signups';
+import { addSlot } from '@/services/slots';
+import { notifyCommitmentCreated } from './notify';
+
+interface Fixture {
+  db: Db;
+  workspaceId: string;
+  organizerId: string;
+  actor: Actor;
+}
+
+async function setupWorkspace(): Promise<Fixture> {
+  const db = getDb();
+  const organizerId = makeId('org');
+  const workspaceId = makeId('ws');
+  const slug = `conf-${workspaceId.slice(-8).toLowerCase()}`;
+  const email = `${slug}@example.test`;
+
+  await db.transaction(async (tx) => {
+    await tx.insert(organizers).values({ id: organizerId, email, name: 'Confirm Org' });
+    await tx.insert(workspaces).values({
+      id: workspaceId,
+      slug,
+      name: 'Confirm Workspace',
+      type: 'personal',
+      plan: 'free',
+    });
+    await tx.insert(workspaceMembers).values({
+      id: makeId('mem'),
+      workspaceId,
+      organizerId,
+      role: 'owner',
+      status: 'active',
+    });
+  });
+
+  return {
+    db,
+    workspaceId,
+    organizerId,
+    actor: {
+      kind: 'organizer',
+      id: organizerId,
+      email,
+      workspaceIds: [workspaceId],
+      workspaceRoles: { [workspaceId]: 'owner' },
+    },
+  };
+}
+
+async function commitOnce(fx: Fixture, title: string) {
+  const created = await createSignup(fx.db, fx.actor, fx.workspaceId, {
+    title,
+    description: '',
+    tags: [],
+    visibility: 'unlisted' as const,
+    settings: {},
+  });
+  if (!created.ok) throw new Error(created.error.message);
+  const slot = await addSlot(fx.db, fx.actor, created.value.id, { values: {}, capacity: 4 });
+  if (!slot.ok) throw new Error(slot.error.message);
+  const pub = await publishSignup(fx.db, fx.actor, created.value.id);
+  if (!pub.ok) throw new Error(pub.error.message);
+  const commit = await commitToSlot(fx.db, slot.value.id, {
+    name: 'Dana Participant',
+    email: `${slot.value.id.slice(-10).toLowerCase()}@example.test`,
+    quantity: 1,
+  });
+  if (!commit.ok) throw new Error(commit.error.message);
+  return { commitmentId: commit.value.commitment.id, editToken: commit.value.editToken };
+}
+
+async function confirmationRows(db: Db, commitmentId: string): Promise<number> {
+  const rows = await db
+    .select({ id: activity.id })
+    .from(activity)
+    .where(
+      and(
+        eq(activity.eventType, 'commitment.confirmation_sent'),
+        sql`(${activity.payload}->>'commitmentId') = ${commitmentId}`,
+      ),
+    );
+  return rows.length;
+}
+
+describe('notifyCommitmentCreated (db)', () => {
+  let fx: Fixture;
+
+  beforeAll(async () => {
+    fx = await setupWorkspace();
+  });
+
+  afterAll(async () => {
+    await fx.db.delete(workspaces).where(eq(workspaces.id, fx.workspaceId));
+    await fx.db.delete(organizers).where(eq(organizers.id, fx.organizerId));
+  });
+
+  it('records a confirmation_sent activity row', async () => {
+    const { commitmentId, editToken } = await commitOnce(fx, 'Confirm me');
+    await notifyCommitmentCreated(fx.db, commitmentId, editToken);
+    expect(await confirmationRows(fx.db, commitmentId)).toBe(1);
+  });
+
+  it('does not send twice for the same commitment', async () => {
+    const { commitmentId, editToken } = await commitOnce(fx, 'Confirm once');
+    await notifyCommitmentCreated(fx.db, commitmentId, editToken);
+    await notifyCommitmentCreated(fx.db, commitmentId, editToken);
+    expect(await confirmationRows(fx.db, commitmentId)).toBe(1);
+  });
+
+  it('swallows an unknown commitment instead of throwing', async () => {
+    await expect(
+      notifyCommitmentCreated(fx.db, makeId('com'), 'irrelevant'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/email/notify.db.test.ts
+++ b/src/email/notify.db.test.ts
@@ -10,6 +10,10 @@ import type { Actor } from '@/lib/policy';
 import { commitToSlot } from '@/services/commitments';
 import { createSignup, publishSignup } from '@/services/signups';
 import { addSlot } from '@/services/slots';
+import { commitments } from '@/db/schema/commitments';
+import { slots } from '@/db/schema/slots';
+import { willSendReminder } from '@/lib/reminder-eligibility';
+import { selectDueReminders } from '@/jobs/reminders';
 import { notifyCommitmentCreated } from './notify';
 
 interface Fixture {
@@ -122,5 +126,58 @@ describe('notifyCommitmentCreated (db)', () => {
     await expect(
       notifyCommitmentCreated(fx.db, makeId('com'), 'irrelevant'),
     ).resolves.toBeUndefined();
+  });
+
+  describe('the reminder it promises', () => {
+    /**
+     * Places a commitment at a known offset from its own creation, then winds
+     * both timestamps back so `now` sits where the first eligible scan would
+     * be. That is the only way to ask the real question: not "is it due at
+     * commit time" — it never is — but "will any later scan ever select it".
+     */
+    async function agreesWithDispatcher(
+      title: string,
+      slotMinutesAfterSignup: number,
+      hoursSinceSignup: number,
+    ): Promise<{ promised: boolean; dispatched: boolean }> {
+      const { commitmentId } = await commitOnce(fx, title);
+      const [row] = await fx.db
+        .select({ slotId: commitments.slotId })
+        .from(commitments)
+        .where(eq(commitments.id, commitmentId));
+      if (!row) throw new Error('commitment vanished');
+
+      const createdAt = new Date(Date.now() - hoursSinceSignup * 3_600_000);
+      const slotAt = new Date(createdAt.getTime() + slotMinutesAfterSignup * 60_000);
+      await fx.db.update(commitments).set({ createdAt }).where(eq(commitments.id, commitmentId));
+      await fx.db.update(slots).set({ slotAt }).where(eq(slots.id, row.slotId));
+
+      const due = await selectDueReminders(fx.db);
+      return {
+        promised: willSendReminder({ sendReminders: true, slotAt, createdAt }),
+        dispatched: due.some((d) => d.commitmentId === commitmentId),
+      };
+    }
+
+    it('does not promise one for a slot too soon after signing up', async () => {
+      // Sign up at 09:00 for a 09:40 slot. By the time the created_at guard
+      // lets the scan reach it, the slot has already happened — so the receipt
+      // must not say a reminder is coming.
+      const { promised, dispatched } = await agreesWithDispatcher('Slot 40m out', 40, 1.5);
+      expect(promised).toBe(false);
+      expect(dispatched).toBe(false);
+    });
+
+    it('does not promise one for a slot already in the past', async () => {
+      const { promised, dispatched } = await agreesWithDispatcher('Slot already gone', -120, 3);
+      expect(promised).toBe(false);
+      expect(dispatched).toBe(false);
+    });
+
+    it('promises one when the dispatcher will in fact send it', async () => {
+      const { promised, dispatched } = await agreesWithDispatcher('Slot 20h out', 20 * 60, 2);
+      expect(promised).toBe(true);
+      expect(dispatched).toBe(true);
+    });
   });
 });

--- a/src/email/notify.ts
+++ b/src/email/notify.ts
@@ -1,0 +1,109 @@
+/**
+ * Post-mutation email side effects.
+ *
+ * Kept out of `src/services/*` because services are pure(-ish) `(db, actor,
+ * input) => Result` functions that run inside DB tests, and out of route
+ * handlers because those stay thin. Call these from `after()` so a slow or
+ * failing mail server never delays or fails the participant's request.
+ *
+ * Every function here swallows its own errors: a confirmation email is a
+ * courtesy, and losing one must never look like a failed sign-up.
+ */
+import { and, eq, sql } from 'drizzle-orm';
+import type { Db } from '@/db/client';
+import { activity } from '@/db/schema/activity';
+import { commitments } from '@/db/schema/commitments';
+import { participants } from '@/db/schema/participants';
+import { signups } from '@/db/schema/signups';
+import { slots } from '@/db/schema/slots';
+import { recordActivity } from '@/lib/activity';
+import { commitmentEditUrl } from '@/lib/links';
+import { log } from '@/lib/log';
+import { formatSlotWhen } from '@/lib/slot-time';
+import { SignupSettingsSchema } from '@/schemas/signups';
+import { sendCommitmentConfirmation } from './send';
+
+/**
+ * Emails a participant the receipt for a commitment they just made, including
+ * the token-bearing link they need to change or cancel it later.
+ *
+ * Unlike reminders this is transactional — it acknowledges an action the
+ * participant took seconds ago — so it is not gated on the signup's reminder
+ * settings.
+ */
+export async function notifyCommitmentCreated(
+  db: Db,
+  commitmentId: string,
+  editToken: string,
+): Promise<void> {
+  try {
+    const [row] = await db
+      .select({
+        commitment: commitments,
+        slot: slots,
+        signup: signups,
+        participant: participants,
+      })
+      .from(commitments)
+      .innerJoin(slots, eq(slots.id, commitments.slotId))
+      .innerJoin(signups, eq(signups.id, commitments.signupId))
+      .innerJoin(participants, eq(participants.id, commitments.participantId))
+      .where(eq(commitments.id, commitmentId))
+      .limit(1);
+
+    if (!row) {
+      log.warn({ commitmentId }, 'commitment not found for confirmation email');
+      return;
+    }
+
+    // Guards a pathological double-POST: one commitment, one receipt.
+    const [alreadySent] = await db
+      .select({ id: activity.id })
+      .from(activity)
+      .where(
+        and(
+          eq(activity.eventType, 'commitment.confirmation_sent'),
+          sql`(${activity.payload}->>'commitmentId') = ${commitmentId}`,
+        ),
+      )
+      .limit(1);
+    if (alreadySent) return;
+
+    const settings = SignupSettingsSchema.safeParse(row.signup.settings ?? {});
+    // Only promise a reminder the dispatcher would actually send: it needs
+    // reminders enabled and a slot date to count back from.
+    const remindersOn = settings.success ? settings.data.sendReminders : true;
+    const reminderLeadHours =
+      remindersOn && row.slot.slotAt
+        ? (settings.success ? settings.data.reminderLeadHours : null)
+        : null;
+
+    await sendCommitmentConfirmation(row.participant.email, {
+      participantName: row.participant.name,
+      signupTitle: row.signup.title,
+      manageUrl: commitmentEditUrl(row.signup.slug, row.commitment.id, editToken),
+      slotLabel: row.slot.ref,
+      slotDateLabel: formatSlotWhen(row.slot.slotAt),
+      notes: row.commitment.notes,
+      quantity: row.commitment.quantity,
+      reminderLeadHours,
+    });
+
+    await recordActivity(db, {
+      signupId: row.signup.id,
+      workspaceId: row.signup.workspaceId,
+      actor: { actorId: row.participant.id, actorType: 'participant' },
+      eventType: 'commitment.confirmation_sent',
+      payload: {
+        commitmentId: row.commitment.id,
+        participantId: row.participant.id,
+        channel: 'email',
+      },
+    });
+  } catch (err) {
+    // A missed confirmation is a courtesy lost, not a failed sign-up. The
+    // commitment is already committed; the participant has their link on
+    // screen and in the returning-participant cookie.
+    log.error({ err, commitmentId }, 'confirmation email failed');
+  }
+}

--- a/src/email/notify.ts
+++ b/src/email/notify.ts
@@ -56,7 +56,16 @@ export async function notifyCommitmentCreated(
       return;
     }
 
-    // Guards a pathological double-POST: one commitment, one receipt.
+    // Belt and braces, not the primary defence. This is a read-then-write with
+    // no lock, so it would not survive two concurrent calls for the same
+    // commitment — but there is no path that produces them. This runs once per
+    // successful POST (from `after()`), each successful POST inserts exactly
+    // one commitment with a fresh UUIDv7 id, and a racing duplicate commit by
+    // the same participant is rejected as `conflict` under the slot's
+    // SELECT ... FOR UPDATE (src/services/commitments.ts). The check earns its
+    // place only against a future caller that retries; if one is ever added,
+    // the claim has to move before the send, not after it — an atomic guard
+    // here would still leave the email already sent.
     const [alreadySent] = await db
       .select({ id: activity.id })
       .from(activity)

--- a/src/email/notify.ts
+++ b/src/email/notify.ts
@@ -19,6 +19,7 @@ import { slots } from '@/db/schema/slots';
 import { recordActivity } from '@/lib/activity';
 import { commitmentEditUrl } from '@/lib/links';
 import { log } from '@/lib/log';
+import { willSendReminder } from '@/lib/reminder-eligibility';
 import { formatSlotWhen } from '@/lib/slot-time';
 import { SignupSettingsSchema } from '@/schemas/signups';
 import { slotDisplayLabel } from '@/lib/slot-label';
@@ -74,6 +75,10 @@ export async function notifyCommitmentCreated(
       .where(
         and(
           eq(activity.eventType, 'commitment.confirmation_sent'),
+          // Scoped to the signup as well as the commitment: the row carries
+          // signup_id anyway, and it keeps this off a full scan of every
+          // confirmation ever sent even where the expression index is absent.
+          eq(activity.signupId, row.signup.id),
           sql`(${activity.payload}->>'commitmentId') = ${commitmentId}`,
         ),
       )
@@ -81,13 +86,20 @@ export async function notifyCommitmentCreated(
     if (alreadySent) return;
 
     const settings = SignupSettingsSchema.safeParse(row.signup.settings ?? {});
-    // Only promise a reminder the dispatcher would actually send: it needs
-    // reminders enabled and a slot date to count back from.
+    // Only promise a reminder the dispatcher would actually send. The gate is
+    // the dispatcher's own rule (src/lib/reminder-eligibility.ts), not a
+    // paraphrase of it: reminders on and a slot date are not enough, because a
+    // slot less than an hour out is one the created_at guard can never reach.
     const remindersOn = settings.success ? settings.data.sendReminders : true;
-    const reminderLeadHours =
-      remindersOn && row.slot.slotAt
-        ? (settings.success ? settings.data.reminderLeadHours : null)
-        : null;
+    const reminderLeadHours = willSendReminder({
+      sendReminders: remindersOn,
+      slotAt: row.slot.slotAt,
+      createdAt: row.commitment.createdAt,
+    })
+      ? settings.success
+        ? settings.data.reminderLeadHours
+        : null
+      : null;
 
     // `slots.ref` is a slug, not a display name — use the label the
     // participant page shows, so the receipt names what they picked.

--- a/src/email/notify.ts
+++ b/src/email/notify.ts
@@ -21,6 +21,8 @@ import { commitmentEditUrl } from '@/lib/links';
 import { log } from '@/lib/log';
 import { formatSlotWhen } from '@/lib/slot-time';
 import { SignupSettingsSchema } from '@/schemas/signups';
+import { slotDisplayLabel } from '@/lib/slot-label';
+import { listFieldsForSignup } from '@/services/slot-fields';
 import { sendCommitmentConfirmation } from './send';
 
 /**
@@ -87,11 +89,21 @@ export async function notifyCommitmentCreated(
         ? (settings.success ? settings.data.reminderLeadHours : null)
         : null;
 
+    // `slots.ref` is a slug, not a display name — use the label the
+    // participant page shows, so the receipt names what they picked.
+    const fields = await listFieldsForSignup(db, row.signup.id);
+    const slotLabel = slotDisplayLabel(
+      fields,
+      (row.slot.values as Record<string, unknown>) ?? {},
+      row.slot.ref,
+      settings.success ? settings.data.groupByFieldRefs[0] : undefined,
+    );
+
     await sendCommitmentConfirmation(row.participant.email, {
       participantName: row.participant.name,
       signupTitle: row.signup.title,
       manageUrl: commitmentEditUrl(row.signup.slug, row.commitment.id, editToken),
-      slotLabel: row.slot.ref,
+      slotLabel,
       slotDateLabel: formatSlotWhen(row.slot.slotAt),
       notes: row.commitment.notes,
       quantity: row.commitment.quantity,

--- a/src/email/send.ts
+++ b/src/email/send.ts
@@ -1,7 +1,24 @@
 import { createElement } from 'react';
 import { getEmailTransport } from './index';
+import {
+  CommitmentConfirmationEmail,
+  type CommitmentConfirmationEmailProps,
+} from './templates/commitment-confirmation';
 import { ReminderEmail, type ReminderEmailProps } from './templates/reminder';
 import { renderEmail } from './render';
+
+export async function sendCommitmentConfirmation(
+  to: string,
+  props: CommitmentConfirmationEmailProps,
+) {
+  const { html, text } = await renderEmail(createElement(CommitmentConfirmationEmail, props));
+  return getEmailTransport().send({
+    to,
+    subject: `You're signed up: ${props.slotLabel} · ${props.signupTitle}`,
+    html,
+    text,
+  });
+}
 
 export async function sendReminder(to: string, props: ReminderEmailProps) {
   const { html, text } = await renderEmail(createElement(ReminderEmail, props));

--- a/src/email/templates/commitment-confirmation.tsx
+++ b/src/email/templates/commitment-confirmation.tsx
@@ -1,0 +1,82 @@
+import { Button, Heading, Text } from '@react-email/components';
+import { EmailLayout } from './layout';
+
+export interface CommitmentConfirmationEmailProps {
+  participantName: string;
+  signupTitle: string;
+  /** The participant's own token-bearing link to view, change, or cancel. */
+  manageUrl: string;
+  slotLabel: string;
+  /** Rendered slot date, or null for an undated slot. */
+  slotDateLabel?: string | null;
+  notes?: string | null;
+  quantity?: number;
+  /** Set when this signup will also send a reminder before the slot. */
+  reminderLeadHours?: number | null;
+}
+
+function reminderSentence(hours: number): string {
+  if (hours % 24 === 0) {
+    const days = hours / 24;
+    return days === 1 ? 'the day before' : `${days} days before`;
+  }
+  return hours === 1 ? 'an hour before' : `${hours} hours before`;
+}
+
+export function CommitmentConfirmationEmail({
+  participantName,
+  signupTitle,
+  manageUrl,
+  slotLabel,
+  slotDateLabel,
+  notes,
+  quantity,
+  reminderLeadHours,
+}: CommitmentConfirmationEmailProps) {
+  const preview = `You're signed up: ${slotLabel} · ${signupTitle}`;
+  return (
+    <EmailLayout preview={preview}>
+      <Heading as="h1" className="m-0 text-xl font-semibold">
+        You&apos;re signed up
+      </Heading>
+      <Text className="mt-2 text-[#5b6474]">
+        Thanks {participantName} — you&apos;re down for <strong>{signupTitle}</strong>.
+      </Text>
+      <Text className="mt-4 text-[#0b1220]">
+        <strong>What:</strong> {slotLabel}
+        {slotDateLabel ? (
+          <>
+            <br />
+            <strong>When:</strong> {slotDateLabel}
+          </>
+        ) : null}
+        {quantity && quantity > 1 ? (
+          <>
+            <br />
+            <strong>Spots:</strong> {quantity}
+          </>
+        ) : null}
+      </Text>
+      {notes ? (
+        <Text className="mt-4 rounded-lg bg-[#f7f8fa] p-3 text-[#0b1220]">
+          <strong>Your notes:</strong> {notes}
+        </Text>
+      ) : null}
+      <Button
+        href={manageUrl}
+        className="mt-6 inline-block rounded-lg bg-[#1f6feb] px-5 py-3 text-sm font-medium text-white no-underline"
+      >
+        View or change your slot
+      </Button>
+      <Text className="mt-6 text-xs text-[#8a93a4]">
+        Keep this email — the button above is how you change or cancel later, with no password to
+        remember. Anyone with that link can change your slot, so don&apos;t forward it.
+        {reminderLeadHours ? (
+          <> We&apos;ll also send you a reminder {reminderSentence(reminderLeadHours)}.</>
+        ) : null}
+      </Text>
+    </EmailLayout>
+  );
+}
+
+export default CommitmentConfirmationEmail;

--- a/src/email/templates/worker-render.test.ts
+++ b/src/email/templates/worker-render.test.ts
@@ -49,6 +49,7 @@ describe('email templates under the worker toolchain', () => {
       { cwd: repoRoot },
     );
     expect(stdout).toContain('ok magic-link');
+    expect(stdout).toContain('ok commitment-confirmation');
     expect(stdout).toContain('ok reminder');
   }, 60_000);
 

--- a/src/jobs/reminders.ts
+++ b/src/jobs/reminders.ts
@@ -8,6 +8,7 @@ import { slots } from '@/db/schema/slots';
 import { recordActivity } from '@/lib/activity';
 import { log } from '@/lib/log';
 import { commitmentEditUrl, publicSignupUrl } from '@/lib/links';
+import { REMINDER_SETTLE_HOURS } from '@/lib/reminder-eligibility';
 import { formatSlotWhen } from '@/lib/slot-time';
 import { editTokenFor } from '@/lib/token';
 import { DEFAULT_REMINDER_LEAD_HOURS, SignupSettingsSchema } from '@/schemas/signups';
@@ -79,7 +80,7 @@ export async function selectDueReminders(db: Db): Promise<DueReminder[]> {
         sql`${slots.slotAt} > now()`,
         sql`${slots.slotAt} <= now() + ${leadInterval}`,
         // Not still in the afterglow of their own confirmation (see doc comment).
-        sql`${commitments.createdAt} < now() - interval '1 hour'`,
+        sql`${commitments.createdAt} < now() - make_interval(hours => ${REMINDER_SETTLE_HOURS})`,
         sql`COALESCE((${signups.settings}->>'sendReminders')::boolean, true) = true`,
         // skip if a reminder was already recorded for this commitment
         sql`NOT EXISTS (

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -59,6 +59,13 @@ export const RateLimits = {
   magicLinkPerEmail: { bucket: 'auth.magic.email', max: 5, windowSeconds: 3600 },
   magicLinkPerIp: { bucket: 'auth.magic.ip', max: 20, windowSeconds: 3600 },
   commitmentPerIp: { bucket: 'commit.ip', max: 10, windowSeconds: 60 },
+  // Per-address, mirroring magicLinkPerEmail. A commit now sends a confirmation
+  // to an address nobody has verified, so without this one IP can put a
+  // stranger's address on every slot of a signup and turn each into an
+  // unsolicited token-bearing email. Well above what a real participant needs:
+  // one address committing to more than this many slots an hour is not a person
+  // signing up for a rota.
+  commitmentPerEmail: { bucket: 'commit.email', max: 10, windowSeconds: 3600 },
   // Anonymous token-authenticated reads/edits on /api/commitments/[id]:
   // generous for legitimate participants, hostile to edit-token brute force
   // and unmetered DB hits.

--- a/src/lib/reminder-eligibility.test.ts
+++ b/src/lib/reminder-eligibility.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { REMINDER_SETTLE_HOURS, willSendReminder } from './reminder-eligibility';
+
+const createdAt = new Date('2026-09-05T09:00:00.000Z');
+const hoursOut = (h: number) => new Date(createdAt.getTime() + h * 3_600_000);
+
+describe('willSendReminder', () => {
+  it('is true for a dated slot comfortably ahead', () => {
+    expect(willSendReminder({ sendReminders: true, slotAt: hoursOut(20), createdAt })).toBe(true);
+  });
+
+  it('is false when the signup has reminders switched off', () => {
+    expect(willSendReminder({ sendReminders: false, slotAt: hoursOut(20), createdAt })).toBe(false);
+  });
+
+  it('is false for a slot with no date to count back from', () => {
+    expect(willSendReminder({ sendReminders: true, slotAt: null, createdAt })).toBe(false);
+    expect(willSendReminder({ sendReminders: true, slotAt: undefined, createdAt })).toBe(false);
+  });
+
+  it('is false for a slot sooner than the settle window', () => {
+    // Sign up at 09:00 for a 09:40 slot: the dispatcher's created_at guard means
+    // no scan can ever select this, so the receipt must not promise a reminder.
+    expect(willSendReminder({ sendReminders: true, slotAt: hoursOut(0.66), createdAt })).toBe(
+      false,
+    );
+  });
+
+  it('is false for a slot in the past', () => {
+    expect(willSendReminder({ sendReminders: true, slotAt: hoursOut(-2), createdAt })).toBe(false);
+  });
+
+  it('turns over exactly at the settle window', () => {
+    expect(
+      willSendReminder({ sendReminders: true, slotAt: hoursOut(REMINDER_SETTLE_HOURS), createdAt }),
+    ).toBe(false);
+    expect(
+      willSendReminder({
+        sendReminders: true,
+        slotAt: new Date(hoursOut(REMINDER_SETTLE_HOURS).getTime() + 1),
+        createdAt,
+      }),
+    ).toBe(true);
+  });
+
+  it('defaults createdAt to now', () => {
+    expect(
+      willSendReminder({ sendReminders: true, slotAt: new Date(Date.now() + 20 * 3_600_000) }),
+    ).toBe(true);
+    expect(willSendReminder({ sendReminders: true, slotAt: new Date(Date.now() + 60_000) })).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/reminder-eligibility.ts
+++ b/src/lib/reminder-eligibility.ts
@@ -1,0 +1,45 @@
+/**
+ * The one rule deciding whether a commitment will get a reminder, shared by the
+ * dispatcher that sends them and the confirmation email that promises them.
+ *
+ * These two had drifted: the confirmation promised a reminder whenever the
+ * signup had reminders on and the slot had a date, while the dispatcher also
+ * requires the slot to still be ahead and the commitment to have settled for an
+ * hour. Sign up at 09:00 for a 09:40 slot and the receipt promised a reminder
+ * that could never arrive. Keeping the threshold and the predicate here means a
+ * change to one is a change to both.
+ */
+
+/**
+ * How long a commitment must exist before its reminder is eligible.
+ *
+ * Someone who signed up minutes ago does not need a "coming up soon" email on
+ * the heels of their confirmation. The dispatcher applies this as
+ * `created_at < now() - interval`, so a slot inside this window of the signup
+ * never has a scan that can select it.
+ */
+export const REMINDER_SETTLE_HOURS = 1;
+
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * Whether a reminder will actually be sent for a commitment created now.
+ *
+ * Deliberately not the dispatcher's full predicate: signup status, opt-outs and
+ * `slot_at <= now() + lead` are all either true at commit time or can only
+ * change later, and a receipt cannot see the future. This covers what is
+ * knowable and wrong to promise — reminders switched off, a slot with no date,
+ * and a slot too close to the sign-up for any scan to reach it.
+ */
+export function willSendReminder(input: {
+  sendReminders: boolean;
+  slotAt: Date | null | undefined;
+  /** Commitment creation time; defaults to now. */
+  createdAt?: Date;
+}): boolean {
+  if (!input.sendReminders) return false;
+  const { slotAt } = input;
+  if (!slotAt || Number.isNaN(slotAt.getTime())) return false;
+  const createdAt = input.createdAt ?? new Date();
+  return slotAt.getTime() > createdAt.getTime() + REMINDER_SETTLE_HOURS * MS_PER_HOUR;
+}


### PR DESCRIPTION
**Stack for #165 — 4 of 5.** Base: `claude/opensignup-issue-165-360oav` (#184).

Addresses item 2 from the issue thread — the confirmation email @csmcolo asked for, templated, no customization UI (they said a template is fine).

## Problem

Participants get nothing after committing. The only record of their sign-up is the edit link on screen and a cookie that doesn't survive a different device. As the reporter put it:

> An email with the link to the user sign-up, I think, would work better than asking them to bookmark it.

## Change

Sends a receipt on commit: what they signed up for, when, their notes, quantity, and the token-bearing link to change or cancel.

When the signup will also send a reminder, the email says so — phrased from the signup's own lead time rather than a hardcoded "24 hours", and only when the dispatcher would really send one (reminders enabled, and a slot date to count back from). No promising mail we won't deliver.

## Where the code lives

Dispatched from `after()` in the commit route, so a slow or unreachable mail server can't delay a participant who already has their slot.

The work itself is in `src/email/notify.ts` rather than in the service (services are pure(-ish) `Result` functions that run inside DB tests) or in the route (which stays thin per CLAUDE.md). It swallows its own errors: a lost confirmation is a courtesy missed, never a failed sign-up.

A `commitment.confirmation_sent` activity row records the send. It's belt-and-braces rather than the primary defence against a double send — review raised that it's a read-then-write with no lock, which is true of the pattern. What actually prevents duplicates is upstream: this runs once per successful POST, each successful POST inserts one commitment with a fresh UUIDv7 id, and a racing duplicate commit by the same participant is rejected as `conflict` under the slot's `SELECT ... FOR UPDATE`. The reasoning is recorded in the code, including the part that matters if a retrying caller is ever added — the claim would have to move *before* the send, since a lock after it still leaves the email delivered.

Unlike reminders this is **transactional** — it acknowledges an action taken seconds earlier — so it is not gated on the reminder settings, and (in PR 5) not on the reminder opt-out either.

`organizerDisplayName` is deliberately not used: it exists in the Zod schema but is never persisted or read anywhere, so referencing it would imply a feature that doesn't work.

## Legal

`privacy` said we send two kinds of email; there are now three. It also never mentioned that participant emails carry a link granting edit and cancel without signing in, which is the part a reader most needs to know. Updated, with the date bumped, per CLAUDE.md.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` (548), `pnpm test:db` (118) green. Exercised end to end against a running dev server: a real `POST /api/slots/{id}/commitments` produced HTTP 200, the confirmation email hit the console transport with the correct manage link, and a `commitment.confirmation_sent` activity row landed in Postgres.